### PR TITLE
fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Models are at the heart of `mobx-state-tree`. They simply store your data.
 Example:
 
 ```javascript
-import {createFactory, action, arrayOf, refenceTo} from "mobx-state-tree"
+import {createFactory, action, mapOf, refenceTo} from "mobx-state-tree"
 
 const Box = createFactory({
     // props


### PR DESCRIPTION
It was importing arrayOf(), but it was using mapOf()!
Great work on mobx-state-tree, keep working on it! ;)
