### PR TITLE
feat: add default type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,10 @@ export {
     createUnionFactory as unionOf
 } from "./types/union"
 
+export {
+    createDefaultValueFactory as withDefault
+} from "./types/with-default"
+
 /**
  * Registers middleware on a model instance that is invoked whenever one of it's actions is called, or an action on one of it's children.
  * Will only be invoked on 'root' actions, not on actions called from existing actions.

--- a/src/types/with-default.ts
+++ b/src/types/with-default.ts
@@ -1,0 +1,35 @@
+import {isFactory, IFactory} from "../core/factories"
+import {hasNode, getNode} from "../core/node"
+import {invariant, fail} from "../utils"
+import {Type} from "../core/types"
+
+
+export class DefaultValue extends Type {
+    readonly type: IFactory<any, any>
+    readonly defaultValue: any
+
+    constructor(type: IFactory<any, any>, defaultValue: any) {
+        super(type.type.name)
+        this.type = type
+        this.defaultValue = defaultValue
+    }
+
+    describe(){
+        return "(" + this.type.type.describe() + " = " + JSON.stringify(this.defaultValue) + ")"
+    }
+
+    create(value, environment?) {
+        return typeof value === "undefined" ? this.type(this.defaultValue) : this.type(value)
+    }
+
+    is(value) {
+        return this.type.is(value)
+    }
+
+}
+
+export function createDefaultValueFactory(type: IFactory<any, any>, defaultValueOrNode: any): IFactory<any, any> {
+    const defaultValue = hasNode(defaultValueOrNode) ? getNode(defaultValueOrNode).snapshot : defaultValueOrNode
+    invariant(type.is(defaultValue), `Default value ${JSON.stringify(defaultValue)} is not assignable to type ${type.factoryName}. Expected ${JSON.stringify(type.type.describe())}`)
+    return new DefaultValue(type, defaultValue).factory
+}

--- a/test/with-default.ts
+++ b/test/with-default.ts
@@ -1,0 +1,50 @@
+import {test} from "ava"
+import {withDefault, createFactory, arrayOf, getSnapshot} from "../"
+
+test("it should provide a default value, if no snapshot is provided", t => {
+    const Row = createFactory({
+        name: '',
+        quantity: 0
+    })
+
+    const Factory = createFactory({
+        // TODO: as any due to #19
+        rows: withDefault(arrayOf(Row) as any, [{name: 'test'}])
+    })
+
+    const doc = Factory()
+    t.deepEqual<any>(getSnapshot(doc), {rows: [{name: 'test', quantity: 0}]})
+})
+
+
+test("it should use the snapshot if provided", t => {
+    const Row = createFactory({
+        name: '',
+        quantity: 0
+    })
+
+    const Factory = createFactory({
+        // TODO: as any due to #19
+        rows: withDefault(arrayOf(Row) as any, [{name: 'test'}])
+    })
+
+    const doc = Factory({rows: [{name: 'snapshot', quantity: 0}]})
+    t.deepEqual<any>(getSnapshot(doc), {rows: [{name: 'snapshot', quantity: 0}]})
+})
+
+
+test("it should throw if default value is invalid snapshot", t => {
+    const Row = createFactory({
+        name: '',
+        quantity: 0
+    })
+
+    const error = t.throws(() => {
+        const Factory = createFactory({
+            // TODO: as any due to #19
+            rows: withDefault(arrayOf(Row) as any, [{wrongProp: true}])
+        })
+    })
+
+    t.is(error.message, '[mobx-state-tree] Default value [{"wrongProp":true}] is not assignable to type unnamed-object-factory[]. Expected "{ name: primitive; quantity: primitive }[]"')
+})


### PR DESCRIPTION
As of #16 

`withDefault(arrayOf(Row) as any, [{name: 'test'}])`

Notice that as any is required due to #19