### PR TITLE
First class support for identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,36 +178,6 @@ Useful methods:
 -   `onPatch(model, listener)` attaches a patch listener  to the provided model, which will be invoked whenever the model or any of it's descendants is mutated
 -   `applyPatch(model, patch)` applies a patch to the provided model
 
-## Dependency Injection
-
-The actual signature of all _factory_ functions is `(snapshot, environment) => model`.
-This makes it possible to associate an environment with a factory created object.
-The environment is intended to be an inmutable object context information about the environment, for example which data fetch library should be used etc.
-This makes it easy to mock these kind of dependencies, as alternative to requiring singletons that might be needed inside actions.
-
-It is recommended to only provide an environment to the root of your state tree; environments of non-roots might be lost when using functions like `applySnapshot`, `applyPatch`, or `applyAction`.
-
-Useful methods:
-
-`getEnvironment(model, key)` Returns a value from the environment. Environments are stacked; the resolve the environment value the tree is walked up, until a model provides an environment value for the specified key.
-
-Example:
-
-```javascript
-const Store = createFactory({
-    users: [],
-    requestData: action(function() {
-        const fetchImpl = getEnvironment(this, "fetch")
-        fetchImpl("http://localhost/users").then(this.receiveData)
-    }),
-    receiveData: action(function(users) {
-        // etc...
-    })
-})
-```
-
-const myStore = Store({ users: \[]}, { fetch: window.fetch })
-
 ## Working with references
 
 ## Be careful with direct references to items in the tree
@@ -235,7 +205,7 @@ escape slashes and backslashes
 
 **Parameters**
 
--   `str`  
+-   `str`
 
 ## unescapeJsonPath
 
@@ -245,7 +215,7 @@ unescape slashes and backslashes
 
 **Parameters**
 
--   `str`  
+-   `str`
 
 ## map
 
@@ -302,7 +272,7 @@ Example of a logging middleware:
 **Parameters**
 
 -   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** model to intercept actions on
--   `callback`  
+-   `callback`
 
 Returns **IDisposer** function to remove the middleware
 
@@ -317,7 +287,7 @@ Patches can be used to deep observe a model tree.
 **Parameters**
 
 -   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** the model instance from which to receive patches
--   `callback`  
+-   `callback`
 
 Returns **IDisposer** function to remove the listener
 
@@ -330,10 +300,10 @@ The listener will only be fire at the and a MobX (trans)action
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `callback`  
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `callback`
 
-Returns **IDisposer** 
+Returns **IDisposer**
 
 ## applyPatch
 
@@ -343,8 +313,8 @@ Applies a JSON-patch to the given model instance or bails out if the patch could
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `patch` **IJsonPatch** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `patch` **IJsonPatch**
 
 ## applyPatches
 
@@ -354,8 +324,8 @@ Applies a number of JSON patches in a single MobX transaction
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `patches` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;IJsonPatch>** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `patches` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;IJsonPatch>**
 
 ## applyAction
 
@@ -366,9 +336,9 @@ Returns the value of the last actoin
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `action` **IActionCall** 
--   `options` **\[IActionCallOptions]** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `action` **IActionCall**
+-   `options` **\[IActionCallOptions]**
 
 ## applyActions
 
@@ -380,9 +350,9 @@ Does not return any value
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `actions` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;IActionCall>** 
--   `options` **\[IActionCallOptions]** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `actions` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;IActionCall>**
+-   `options` **\[IActionCallOptions]**
 
 ## applySnapshot
 
@@ -392,8 +362,8 @@ Applies a snapshot to a given model instances. Patch and snapshot listeners will
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `snapshot` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `snapshot` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
 ## getSnapshot
 
@@ -404,9 +374,9 @@ structural sharing where possible. Doesn't require MobX transactions to be compl
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
-Returns **Any** 
+Returns **Any**
 
 ## hasParent
 
@@ -416,10 +386,10 @@ Given a model instance, returns `true` if the object has a parent, that is, is p
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 -   `strict` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]**  (optional, default `false`)
 
-Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**
 
 ## getParent
 
@@ -431,10 +401,10 @@ map or array.
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `strict`  
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `strict`
 
-Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**
 
 ## getParent
 
@@ -445,10 +415,10 @@ TODO:? strict mode?
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 -   `strict` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]**  (optional, default `false`)
 
-Returns **Any** 
+Returns **Any**
 
 ## getRoot
 
@@ -459,9 +429,9 @@ Returns the closest parent that is a model instance, but which isn't an array or
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
-Returns **Any** 
+Returns **Any**
 
 ## getRoot
 
@@ -471,9 +441,9 @@ Given an object in a model tree, returns the root object of that tree
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
-Returns **Any** 
+Returns **Any**
 
 ## getPath
 
@@ -483,9 +453,9 @@ Returns the path of the given object in the model tree
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
-Returns **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+Returns **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)**
 
 ## getPathParts
 
@@ -495,9 +465,9 @@ Returns the path of the given object as unescaped string array
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
-Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** 
+Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>**
 
 ## isRoot
 
@@ -507,9 +477,9 @@ Returns true if the given object is the root of a model tree
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
-Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**
 
 ## resolve
 
@@ -519,10 +489,10 @@ Resolves a path relatively to a given object.
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 -   `path` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** escaped json path
 
-Returns **Any** 
+Returns **Any**
 
 ## tryResolve
 
@@ -530,10 +500,10 @@ Returns **Any**
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `path` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `path` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)**
 
-Returns **Any** 
+Returns **Any**
 
 ## getFromEnvironment
 
@@ -541,10 +511,10 @@ Returns **Any**
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `key`  
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `key`
 
-Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
 ## clone
 
@@ -552,10 +522,10 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 **Parameters**
 
--   `source` **T** 
--   `customEnvironment` **\[Any]** 
+-   `source` **T**
+-   `customEnvironment` **\[Any]**
 
-Returns **T** 
+Returns **T**
 
 ## \_getNode
 
@@ -565,7 +535,7 @@ Internal function, use with care!
 
 **Parameters**
 
--   `thing`  
+-   `thing`
 
 ## \_getNode
 
@@ -573,9 +543,9 @@ Internal function, use with care!
 
 **Parameters**
 
--   `thing` **any** 
+-   `thing` **any**
 
-Returns **Any** 
+Returns **Any**
 
 ## get
 
@@ -593,9 +563,9 @@ The result of this function is the return value of the callbacks
 
 **Parameters**
 
--   `value`  
--   `asNodeCb`  
--   `asPrimitiveCb`  
+-   `value`
+-   `asNodeCb`
+-   `asPrimitiveCb`
 
 # FAQ
 

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -1,7 +1,7 @@
 import { action as mobxAction, isObservable } from "mobx"
 import {isModel} from "./factories"
 import {resolve} from "../top-level-api"
-import {invariant, isPlainObject, isPrimitive, argsToArray} from "../utils"
+import {invariant, isPlainObject, isPrimitive, argsToArray, createNamedFunction} from "../utils"
 import {Node, getNode, getRelativePath} from "./node"
 
 export type IActionCall = {
@@ -43,7 +43,7 @@ export function createActionInvoker(name: string, fn: Function) {
 
     // This construction helps producing a better function name in the stack trace, but could be optimized
     // away in prod builds, and `invoker` be returned directly
-    return new Function("f", `return function ${name}() { return f.apply(this, arguments)}`)(actionInvoker)
+    return createNamedFunction(name, actionInvoker)
 }
 
 

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -15,7 +15,7 @@ export type IActionHandler  = (actionCall: IActionCall, next: () => void) => voi
 export function createActionInvoker(name: string, fn: Function) {
     const action = mobxAction(name, fn)
 
-    return function() {
+    const actionInvoker = function () {
         const adm = getNode(this)
         if (adm.isRunningAction()) {
             // an action is already running in this tree, invoking this action does not emit a new action
@@ -40,6 +40,10 @@ export function createActionInvoker(name: string, fn: Function) {
             }
         }
     }
+
+    // This construction helps producing a better function name in the stack trace, but could be optimized
+    // away in prod builds, and `invoker` be returned directly
+    return new Function("f", `return function ${name}() { return f.apply(this, arguments)}`)(actionInvoker)
 }
 
 

--- a/src/core/factories.ts
+++ b/src/core/factories.ts
@@ -9,7 +9,7 @@ export interface IFactory<S, T> {
     (snapshot?: S, env?: Object): T & IModel
     factoryName: string,
     is: ITypeChecker
-    isFactory: boolean // TODO: rename to isFactory
+    isFactory: boolean
     type: IType
 }
 

--- a/src/core/json-patch.ts
+++ b/src/core/json-patch.ts
@@ -11,8 +11,6 @@ export interface IJsonPatch {
 }
 
 
-// TODO: use https://www.npmjs.com/package/json-pointer
-
 /**
  * escape slashes and backslashes
  * http://tools.ietf.org/html/rfc6901
@@ -32,13 +30,12 @@ export function joinJsonPath(path: string[]): string {
     // `/` refers to property with an empty name, while `` refers to root itself!
     if (path.length === 0)
         return ""
-    return "/" + path.map(escapeJsonPath).join("/")
+    return path.map(escapeJsonPath).join("/")
 }
 
 export function splitJsonPath(path: string): string[] {
     // `/` refers to property with an empty name, while `` refers to root itself!
     if (path === "")
         return []
-    invariant(path[0] === "/", `Expected path to start with '/', got: '${path}'`)
-    return path.substr(1).split("/").map(unescapeJsonPath)
+    return path.split("/").map(unescapeJsonPath)
 }

--- a/src/core/json-patch.ts
+++ b/src/core/json-patch.ts
@@ -37,5 +37,5 @@ export function splitJsonPath(path: string): string[] {
     // `/` refers to property with an empty name, while `` refers to root itself!
     if (path === "")
         return []
-    return path.split("/").map(unescapeJsonPath)
+    return path.replace(/\/$/, "").split("/").map(unescapeJsonPath)
 }

--- a/src/core/node.ts
+++ b/src/core/node.ts
@@ -64,7 +64,7 @@ export class Node {
      * Returnes (escaped) path representation as string
      */
     @computed public get path(): string {
-        return joinJsonPath(this.pathParts)
+        return "/" + joinJsonPath(this.pathParts)
     }
 
     @computed public get subpath(): string {
@@ -208,7 +208,9 @@ export class Node {
     resolvePath(pathParts: string[], failIfResolveFails: boolean = true): Node | undefined {
         let current: Node | null = this
         for (let i = 0; i < pathParts.length; i++) {
-            if (pathParts[i] === "..")
+            if (pathParts[i] === "") // '/bla' or 'a//b' splits to empty strings
+                current = current.root
+            else if (pathParts[i] === "..")
                 current = current!.parent
             else if (pathParts[i] === ".")
                 continue

--- a/src/core/node.ts
+++ b/src/core/node.ts
@@ -32,8 +32,6 @@ export class Node {
         this.factory = factory
         this.target = initialState
 
-        intercept(this.target, ((c) => this.type.willChange(this, c)) as any)
-        observe(this.target, (c) => this.type.didChange(this, c))
         reaction(() => this.snapshot, snapshot => {
             this.snapshotSubscribers.forEach(f => f(snapshot))
         })
@@ -302,7 +300,7 @@ export function maybeNode<T, R>(value: T & IModel, asNodeCb: (node: Node, value:
     }
 }
 
-export function getNode(value: IModel): Node {
+export function getNode(value: any): Node {
     if (hasNode(value))
         return value.$treenode
     else

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -6,7 +6,7 @@ import {IFactory, IModel} from "./factories"
 export interface IType {
     name: string
     is(thing: IModel | any): boolean
-    create(snapshot, environment?): any
+    create(snapshot): any
     factory: IFactory<any, any> // TODO type
     describe(): string
 }
@@ -22,7 +22,7 @@ export abstract class Type implements IType { // TODO: generic for config and st
         this.factory = this.initializeFactory()
     }
 
-    abstract create(snapshot, environment?): any
+    abstract create(snapshot): any
     abstract is(thing): boolean
     abstract describe(): string
 
@@ -40,9 +40,9 @@ export abstract class Type implements IType { // TODO: generic for config and st
 }
 
 export abstract class ComplexType extends Type {
-    create(snapshot, environment?) {
+    create(snapshot) {
         const instance = this.createNewInstance()
-        const node = new Node(instance, environment, this.factory)
+        const node = new Node(instance, this.factory)
         this.finalizeNewInstance(instance)
         if (arguments.length > 0)
             node.applySnapshot(snapshot)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -55,8 +55,6 @@ export abstract class ComplexType extends Type {
     abstract applySnapshot(node: Node, target, snapshot)
     abstract getChildNodes(node: Node, target): [string, Node][]
     abstract getChildNode(node: Node, target, key): Node | null
-    abstract willChange(node: Node, change): Object | null
-    abstract didChange(node: Node, change): void
     abstract serialize(node: Node, target): any
     abstract applyPatchLocally(node: Node, target, subpath: string, patch: IJsonPatch): void
     abstract getChildFactory(key: string): IFactory<any, any>

--- a/src/top-level-api.ts
+++ b/src/top-level-api.ts
@@ -330,25 +330,13 @@ export function tryResolve(target: IModel, path: string): IModel | any {
  *
  *
  * @export
- * @param {Object} target
- * @returns {Object}
- */
-export function getFromEnvironment(target: IModel, key: string): any {
-    return getNode(target).getFromEnvironment(key)
-}
-
-/**
- *
- *
- * @export
  * @template T
  * @param {T} source
- * @param {*} [customEnvironment]
  * @returns {T}
  */
-export function clone<T extends IModel>(source: T, customEnvironment?: any): T {
+export function clone<T extends IModel>(source: T): T {
     const node = getNode(source)
-    return node.factory(node.snapshot, customEnvironment || node.environment) as T
+    return node.factory(node.snapshot) as T
 }
 
 /**
@@ -382,9 +370,9 @@ export function resetAppState() {
     appState.set(undefined)
 }
 
-export function initializeAppState<S, T>(factory: IFactory<S, T>, initialSnapshot?: S, environment?: Object) {
+export function initializeAppState<S, T>(factory: IFactory<S, T>, initialSnapshot?: S) {
     invariant(!appState, `Global app state was already initialized, use 'resetAppState' to reset it`)
-    appState.set(factory(initialSnapshot, environment))
+    appState.set(factory(initialSnapshot))
 }
 
 export function getAppState<T>(): T {

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -1,5 +1,5 @@
-import { applySnapshot } from '../../lib/top-level-api';
 import {observable, IObservableArray, IArrayWillChange, IArrayWillSplice, IArrayChange, IArraySplice, action, intercept, observe} from "mobx"
+import { applySnapshot } from "../top-level-api"
 import {Node, maybeNode, valueToSnapshot, getNode} from "../core/node"
 import {IJsonPatch} from "../core/json-patch"
 import {IFactory, isFactory, getFactory} from "../core/factories"

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -43,6 +43,8 @@ export class ArrayType extends ComplexType {
 
     willChange = (change: IArrayWillChange<any> | IArrayWillSplice<any>): Object | null => {
         // TODO: verify type
+                // TODO check type
+        // TODO: check if tree is editable
         const node = getNode(change.object)
         switch (change.type) {
             case "update":

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -48,6 +48,7 @@ export class ArrayType extends ComplexType {
         // TODO: verify type
                 // TODO check type
         // TODO: check if tree is editable
+        // TODO: check for key duplication
         const node = getNode(change.object)
         switch (change.type) {
             case "update":

--- a/src/types/frozen.ts
+++ b/src/types/frozen.ts
@@ -26,7 +26,7 @@ export class Frozen extends Type {
         return "frozen"
     }
 
-    create(value, environment?) {
+    create(value) {
         invariant(isSerializable(value), "Given value should be serializable")
         // deep freeze the object/array
         return isMutable(value) ? freeze(value) : value

--- a/src/types/identifier.ts
+++ b/src/types/identifier.ts
@@ -1,0 +1,13 @@
+export interface IIdentifierDescriptor {
+    isIdentifier: true
+}
+
+export function identifier(): string {
+    return {
+        isIdentifier: true
+    } as IIdentifierDescriptor as any
+}
+
+export function isIdentifierFactory(thing: any): thing is IIdentifierDescriptor {
+    return typeof thing === "object" && thing && thing.isIdentifier === true
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,7 +24,7 @@ import {recursive} from "./recursive"
  * @param {ModelFactory} [subFactory=primitiveFactory]
  * @returns
  */
-export function map<S, T>(subFactory: IFactory<S, T> = primitiveFactory as any): IFactory<{[key: string]: S}, ObservableMap<T>> {
+export function map<S, T>(subFactory: IFactory<S, T> = primitiveFactory as any): IFactory<{[key: string]: S}, ObservableMap<T> & { put(value: T): void }> {
     return createMapFactory(subFactory) as any
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 // tslint:disable-next-line:no_unused-variable
 import {IObservableArray, ObservableMap, IAction} from "mobx"
 import {IFactory} from "../core/factories"
-import {createMapFactory} from "./map"
+import {createMapFactory, IExtendedObservableMap} from "./map"
 import {createArrayFactory} from "./array"
 import {primitiveFactory} from "./primitive"
 import {primitiveFactory as primitive} from "./primitive"
@@ -24,7 +24,7 @@ import {recursive} from "./recursive"
  * @param {ModelFactory} [subFactory=primitiveFactory]
  * @returns
  */
-export function map<S, T>(subFactory: IFactory<S, T> = primitiveFactory as any): IFactory<{[key: string]: S}, ObservableMap<T> & { put(value: T): void }> {
+export function map<S, T>(subFactory: IFactory<S, T> = primitiveFactory as any): IFactory<{[key: string]: S}, IExtendedObservableMap<T>> {
     return createMapFactory(subFactory) as any
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ import {createMapFactory} from "./map"
 import {createArrayFactory} from "./array"
 import {primitiveFactory} from "./primitive"
 import {primitiveFactory as primitive} from "./primitive"
+import {identifier} from "./identifier"
 import {createModelFactory as struct, composeFactory as extend} from "./object"
 import {reference} from "./reference"
 import {createUnionFactory as union} from "./union"
@@ -54,5 +55,6 @@ export const types = {
     map,
     array,
     frozen,
-    recursive
+    recursive,
+    identifier
 }

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -1,7 +1,8 @@
+import { getIdentifierAttribute } from './object';
 import {observable, ObservableMap, IMapChange, IMapWillChange, action, intercept, observe} from "mobx"
-import {Node, maybeNode, valueToSnapshot, getNode} from "../core/node"
+import { getNode, hasNode, maybeNode, Node, valueToSnapshot } from '../core/node';
 import {isFactory, IFactory} from "../core/factories"
-import {identity, isPlainObject, nothing, isPrimitive} from "../utils"
+import {identity, isPlainObject, nothing, isPrimitive, invariant, fail} from "../utils"
 import {escapeJsonPath, IJsonPatch} from "../core/json-patch"
 import {ComplexType} from "../core/types"
 
@@ -23,7 +24,16 @@ export class MapType extends ComplexType {
     }
 
     createNewInstance() {
-        return observable.shallowMap()
+        const identifierAttr = getIdentifierAttribute(this.subType)
+        const map = observable.shallowMap()
+
+        // map.put(x) is a shorthand for map.set(x[identifier], x)
+        ; (map as any).put = function(value: any) {
+            invariant(!!identifierAttr, `Map.put is only supported if the subtype has an idenfier attribute`)
+            invariant(!!value, `Map.put cannot be used to set empty values`)
+            this.set(value[identifierAttr!], value)
+        }
+        return map
     }
 
     finalizeNewInstance(instance: ObservableMap<any>) {
@@ -46,10 +56,11 @@ export class MapType extends ComplexType {
     }
 
     willChange(change: IMapWillChange<any>): IMapWillChange<any> | null {
-        // TODO: check type
-        // TODO: check if editable
-
         const node = getNode(change.object)
+        const identifierAttr = getIdentifierAttribute(node)
+        if (identifierAttr && change.newValue && typeof change.newValue === "object" && change.newValue[identifierAttr] !== change.name)
+            fail(`A map of objects containing an identifier should always store the object under their own identifier. Trying to store key '${change.name}', but expected: '${change.newValue[identifierAttr!]}'`)
+
         switch (change.type) {
             case "update":
                 {
@@ -115,25 +126,29 @@ export class MapType extends ComplexType {
     }
 
     @action applySnapshot(node: Node, target: ObservableMap<any>, snapshot: any): void {
+        const identifierAttr = getIdentifierAttribute(this.subType)
         // Try to update snapshot smartly, by reusing instances under the same key as much as possible
         const currentKeys: { [key: string]: boolean } = {}
         target.keys().forEach(key => { currentKeys[key] = false })
         Object.keys(snapshot).forEach(key => {
+            const item = snapshot[key]
+            if (identifierAttr && item && typeof item === "object" && key !== item[identifierAttr])
+                fail(`A map of objects containing an identifier should always store the object under their own identifier. Trying to store key '${key}', but expected: '${item[identifierAttr]}'`)
             // if snapshot[key] is non-primitive, and this.get(key) has a Node, update it, instead of replace
-            if (key in currentKeys && !isPrimitive(snapshot[key])) {
+            if (key in currentKeys && !isPrimitive(item)) {
                 currentKeys[key] = true
                 maybeNode(
                     target.get(key),
                     propertyNode => {
                         // update existing instance
-                        propertyNode.applySnapshot(snapshot[key])
+                        propertyNode.applySnapshot(item)
                     },
                     () => {
-                        target.set(key, snapshot[key])
+                        target.set(key, item)
                     }
                 )
             } else {
-                target.set(key, snapshot[key])
+                target.set(key, item)
             }
         })
         Object.keys(currentKeys).forEach(key => {
@@ -151,7 +166,7 @@ export class MapType extends ComplexType {
     }
 }
 
-export function createMapFactory<S, T>(subtype: IFactory<S, T>): IFactory<{[key: string]: S}, ObservableMap<T>> {
+export function createMapFactory<S, T>(subtype: IFactory<S, T>): IFactory<{[key: string]: S}, ObservableMap<T> & { put(value: T): void }> {
     return new MapType(`map<string, ${subtype.factoryName}>`, subtype).factory
 }
 

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -10,6 +10,10 @@ interface IMapFactoryConfig {
     isMapFactory: true
 }
 
+export interface IExtendedObservableMap<T> extends ObservableMap<T> {
+    put(value: T): this
+}
+
 export class MapType extends ComplexType {
     isMapFactory = true
     subType: IFactory<any, any>
@@ -32,6 +36,7 @@ export class MapType extends ComplexType {
             invariant(!!identifierAttr, `Map.put is only supported if the subtype has an idenfier attribute`)
             invariant(!!value, `Map.put cannot be used to set empty values`)
             this.set(value[identifierAttr!], value)
+            return this
         }
         return map
     }
@@ -166,7 +171,7 @@ export class MapType extends ComplexType {
     }
 }
 
-export function createMapFactory<S, T>(subtype: IFactory<S, T>): IFactory<{[key: string]: S}, ObservableMap<T> & { put(value: T): void }> {
+export function createMapFactory<S, T>(subtype: IFactory<S, T>): IFactory<{[key: string]: S}, IExtendedObservableMap<T>> {
     return new MapType(`map<string, ${subtype.factoryName}>`, subtype).factory
 }
 

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -47,6 +47,8 @@ export class MapType extends ComplexType {
 
     willChange(change: IMapWillChange<any>): IMapWillChange<any> | null {
         // TODO: check type
+        // TODO: check if editable
+
         const node = getNode(change.object)
         switch (change.type) {
             case "update":

--- a/src/types/object.ts
+++ b/src/types/object.ts
@@ -1,8 +1,9 @@
+import { TransformedProperty } from './property-types/transformed-property';
 import { action, isAction, extendShallowObservable, observable, IObjectChange, IObjectWillChange, IAction, intercept, observe, computed } from "mobx"
 import { nothing, invariant, isSerializable, fail, identity, extend, isPrimitive, hasOwnProperty, isPlainObject } from "../utils"
 import { Node, maybeNode, valueToSnapshot, getNode } from "../core/node"
 import { IFactory, isFactory, getFactory } from "../core/factories"
-import { isReferenceFactory, createReferenceProps } from "./reference"
+import { isReferenceFactory } from "./reference"
 import { primitiveFactory } from "./primitive"
 import { ComplexType } from "../core/types"
 import { createDefaultValueFactory } from "./with-default"
@@ -91,7 +92,7 @@ export class ObjectType extends ComplexType {
             } else if (isFactory(value)) {
                 this.props[key] = new ValueProperty(key, value)
             } else if (isReferenceFactory(value)) {
-                // TODO:               addInitializer(t => extendShallowObservable(t, createReferenceProps(key, value)))
+                this.props[key] =  new TransformedProperty(key, value.setter, value.getter)
             } else if (isAction(value)) {
                 this.props[key] = new ActionProperty(key, value)
             } else if (typeof value === "function") {

--- a/src/types/object.ts
+++ b/src/types/object.ts
@@ -178,7 +178,9 @@ export class ObjectType extends ComplexType {
             const prop = this.props[key]
             return prop instanceof ValueProperty
                 ? key + ": " + prop.factory.type.describe()
-                : ""
+                : prop instanceof IdentifierProperty
+                    ? key + ": identifier()"
+                    : ""
         }).filter(Boolean).join("; ") + " }"
     }
 }

--- a/src/types/object.ts
+++ b/src/types/object.ts
@@ -1,3 +1,4 @@
+import { IdentifierProperty } from './property-types/identifier-property';
 import { action, isAction, extendShallowObservable, IObjectChange, IObjectWillChange, IAction, intercept, observe } from "mobx"
 import { nothing, invariant, fail, identity, extend, isPrimitive, hasOwnProperty, isPlainObject } from "../utils"
 import { Node, maybeNode } from "../core/node"
@@ -92,7 +93,7 @@ export class ObjectType extends ComplexType {
             if (isIdentifierFactory(value)) {
                 invariant(!this.identifierAttribute, `Cannot define property '${key}' as object identifier, property '${this.identifierAttribute}' is already defined as identifier property`)
                 this.identifierAttribute = key
-                this.props[key] = new ValueProperty(key, createDefaultValueFactory(primitiveFactory, "")) // TODO: create string non-empty subtype value!
+                this.props[key] = new IdentifierProperty(key)
             } else if (isPrimitive(value)) {
                 // TODO: detect exact primitiveFactory!
                 this.props[key] = new ValueProperty(key, createDefaultValueFactory(primitiveFactory, value))
@@ -144,8 +145,6 @@ export class ObjectType extends ComplexType {
     // TODO: remove node arg
     @action applySnapshot(node: Node, target: any, snapshot: any): void {
         // TODO typecheck?
-        if (this.identifierAttribute && target[this.identifierAttribute] /* empty before applying first snapshot */ && snapshot[this.identifierAttribute] !== target[this.identifierAttribute])
-            fail(`It is not allowed to update an object with a snapshot that has a different identifier. Expected '${target[this.identifierAttribute]}', got '${snapshot[this.identifierAttribute]}`)
         for (let key in snapshot) {
             invariant(key in this.props, `It is not allowed to assign a value to non-declared property ${key} of ${this.name}`)
             this.props[key].deserialize(target, snapshot)

--- a/src/types/property-types/action-property.ts
+++ b/src/types/property-types/action-property.ts
@@ -1,0 +1,20 @@
+import { addHiddenFinalProp } from "../../utils"
+import { createActionInvoker } from "../../core/action"
+import { Property } from "./property"
+
+export class ActionProperty extends Property {
+    invokeAction: Function
+
+    constructor(name: string, fn: Function) {
+        super(name)
+        this.invokeAction =  createActionInvoker(name, fn)
+    }
+
+    initialize(target) {
+        addHiddenFinalProp(target, this.name, this.invokeAction)
+    }
+
+    isValidSnapshot(snapshot) {
+        return !(this.name in snapshot)
+    }
+}

--- a/src/types/property-types/computed-property.ts
+++ b/src/types/property-types/computed-property.ts
@@ -1,0 +1,20 @@
+import { computed } from "mobx"
+import { Property } from "./property"
+
+export class ComputedProperty extends Property {
+    constructor(propertyName, public getter, public setter) {
+        super(propertyName)
+    }
+
+    initializePrototype(proto) {
+        Object.defineProperty(
+            proto,
+            this.name,
+            computed(proto, this.name, { get: this.getter, set: this.setter, configurable: true, enumerable: false }) as any
+        )
+    }
+
+    isValidSnapshot(snapshot) {
+        return !(this.name in snapshot)
+    }
+}

--- a/src/types/property-types/identifier-property.ts
+++ b/src/types/property-types/identifier-property.ts
@@ -1,6 +1,6 @@
 import { observable, IObjectWillChange } from "mobx"
 import { Property } from "./property"
-import { isValidIdentifier } from "../../utils"
+import { isValidIdentifier, fail } from "../../utils"
 
 export class IdentifierProperty extends Property {
     constructor(propertyName: string) {
@@ -16,7 +16,7 @@ export class IdentifierProperty extends Property {
             fail(`Not a valid identifier: '${change.newValue}`)
         const oldValue = change.object[this.name]
         if (oldValue !== undefined && oldValue !== change.newValue)
-            fail(`It is not allowed to change the identifier of an object, got: '${change.newValue}`)
+            fail(`It is not allowed to change the identifier of an object, got: '${change.newValue}'`)
 
         return change
     }

--- a/src/types/property-types/identifier-property.ts
+++ b/src/types/property-types/identifier-property.ts
@@ -1,0 +1,37 @@
+import { observable, IObjectWillChange } from "mobx"
+import { Property } from "./property"
+import { isValidIdentifier } from "../../utils"
+
+export class IdentifierProperty extends Property {
+    constructor(propertyName: string) {
+        super(propertyName)
+    }
+
+    initializePrototype(proto: any) {
+        observable.ref(proto, this.name, { value: undefined })
+    }
+
+    willChange(change: IObjectWillChange): IObjectWillChange | null {
+        if (!isValidIdentifier(change.newValue))
+            fail(`Not a valid identifier: '${change.newValue}`)
+        const oldValue = change.object[this.name]
+        if (oldValue !== undefined && oldValue !== change.newValue)
+            fail(`It is not allowed to change the identifier of an object, got: '${change.newValue}`)
+
+        return change
+    }
+
+    serialize(instance: any, snapshot: any) {
+        if (!isValidIdentifier(instance[this.name]))
+            fail(`Object does not have a valid identifier yet: '${instance[this.name]}`)
+        snapshot[this.name] = instance[this.name]
+    }
+
+    deserialize(instance: any, snapshot: any) {
+        instance[this.name] = snapshot[this.name]
+    }
+
+    isValidSnapshot(snapshot: any) {
+        return isValidIdentifier(snapshot[this.name])
+    }
+}

--- a/src/types/property-types/property.ts
+++ b/src/types/property-types/property.ts
@@ -1,0 +1,21 @@
+import { IObjectChange, IObjectWillChange } from "mobx"
+import { IObjectInstance } from "../object"
+
+export abstract class Property {
+    constructor(public name: string) {
+        // empty
+    }
+
+    initializePrototype(prototype: any) { }
+    initialize(targetInstance: IObjectInstance) { }
+
+    willChange(change: IObjectWillChange): IObjectWillChange | null {
+        return null
+    }
+
+    didChange(change: IObjectChange) { }
+
+    serialize(instance: IObjectInstance, snapshot) { }
+    deserialize(instance: IObjectInstance, snapshot) { }
+    abstract isValidSnapshot(snapshot): boolean
+}

--- a/src/types/property-types/transformed-property.ts
+++ b/src/types/property-types/transformed-property.ts
@@ -1,0 +1,45 @@
+import { observable } from "mobx"
+import { Property } from "./property"
+import { getNode, valueToSnapshot } from "../../core/node"
+import { escapeJsonPath } from "../../core/json-patch"
+import { addHiddenWritableProp } from "../../utils"
+
+export class TransformedProperty extends Property {
+    constructor(propertyName, public setter: Function, public getter: Function) {
+        super(propertyName)
+    }
+
+    initialize(targetInstance) {
+        const box = observable.shallowBox(null, targetInstance.constructor.name + "." + this.name)
+        addHiddenWritableProp(targetInstance, this.name + "$value", box)
+        const self = this
+        Object.defineProperty(targetInstance, this.name, {
+            get: function() {
+                return self.getter.call(this, box.get())
+            },
+            set: function(v) {
+                const node = getNode(this)
+                const newValue = self.setter.call(this, v)
+                box.set(newValue)
+                node.emitPatch({
+                    op: "replace",
+                    path: "/" + escapeJsonPath(self.name),
+                    value: valueToSnapshot(newValue)
+                }, node)
+            }
+        })
+    }
+
+    serialize(instance, snapshot) {
+        snapshot[this.name] = valueToSnapshot(instance[this.name + "$value"].get())
+    }
+
+    deserialize(instance, snapshot) {
+        instance[this.name + "$value"].set(snapshot[this.name])
+    }
+
+    isValidSnapshot(snapshot) {
+        // TODO: is a better check possible?
+        return this.name in snapshot
+    }
+}

--- a/src/types/property-types/transformed-property.ts
+++ b/src/types/property-types/transformed-property.ts
@@ -18,6 +18,8 @@ export class TransformedProperty extends Property {
                 return self.getter.call(this, box.get())
             },
             set: function(v) {
+                if (this[self.name] === v)
+                    return
                 const node = getNode(this)
                 const newValue = self.setter.call(this, v)
                 box.set(newValue)

--- a/src/types/property-types/value-property.ts
+++ b/src/types/property-types/value-property.ts
@@ -1,0 +1,55 @@
+import { observable, IObjectWillChange, IObjectChange } from "mobx"
+import { Property } from "./property"
+import { getNode, maybeNode, valueToSnapshot } from "../../core/node"
+import { IFactory } from "../../core/factories"
+import { escapeJsonPath } from "../../core/json-patch"
+
+export class ValueProperty extends Property {
+    constructor(propertyName, public factory: IFactory<any, any>) {
+        super(propertyName)
+    }
+
+    initializePrototype(proto) {
+        observable.ref(proto, this.name, { value: undefined })
+    }
+
+    initialize(targetInstance) {
+        targetInstance[this.name] = this.factory()
+    }
+
+    willChange(change: IObjectWillChange): IObjectWillChange | null {
+        const node = getNode(change.object)
+        const oldValue = change.object[this.name]
+
+        // TODO check type
+        // TODO: check if tree is editable
+        maybeNode(oldValue, adm => adm.setParent(null))
+        change.newValue = node.prepareChild(this.name, change.newValue)
+        return change
+    }
+
+    didChange(change: IObjectChange) {
+        const node = getNode(change.object)
+        node.emitPatch({
+            op: "replace",
+            path: "/" + escapeJsonPath(this.name),
+            value: valueToSnapshot(change.newValue)
+        }, node)
+    }
+
+    serialize(instance, snapshot) {
+        snapshot[this.name] = valueToSnapshot(instance[this.name])
+    }
+
+    deserialize(instance, snapshot) {
+        maybeNode(
+            instance[this.name],
+            propertyNode => { propertyNode.applySnapshot(snapshot[this.name]) },
+            () => { instance[this.name] = snapshot[this.name] }
+        )
+    }
+
+    isValidSnapshot(snapshot) {
+        return this.factory.is(snapshot[this.name])
+    }
+}

--- a/src/types/recursive.ts
+++ b/src/types/recursive.ts
@@ -11,8 +11,8 @@ class Recursive extends Type {
         this.type = def(this.factory)
     }
 
-    create(snapshot, environment?) {
-        return this.type(snapshot, environment)
+    create(snapshot) {
+        return this.type(snapshot)
     }
 
     is(thing: any): boolean {

--- a/src/types/reference.ts
+++ b/src/types/reference.ts
@@ -1,5 +1,4 @@
-// TODO: move file to better place, not really a type
-
+import {isObservableArray, isObservableMap} from "mobx"
 import {IModel, IFactory, isFactory, isModel} from "../core/factories"
 import {resolve} from "../top-level-api"
 import {invariant, fail} from "../utils"
@@ -11,55 +10,12 @@ export interface IReferenceDescription {
     isReference: true
 }
 
-// export function reference<T>(path: string): T;
-// export function reference<T>(getter: IReferenceGetter<T>, setter?: IReferenceSetter<T>): T;
-export function reference<T>(factory: IFactory<any, T>): T;
-export function reference(arg1, arg2?) {
-    if (isFactory(arg1))
-        return createGenericRelativeReference(arg1)
-    throw "TODO"
-    // if (typeof arg1 === "string")
-    //     return createRelativeReferenceTo(arg1)
-    // return {
-    //     isReference: true,
-    //     getter: arg1,
-    //     setter: arg2 || unwritableReference
-    // } as IReferenceDescription
+export function reference<T>(factory: IFactory<any, T>, basePath?: string): T {
+    if (arguments.length === 1)
+        return createGenericRelativeReference(factory) as any
+    else
+        return createReferenceWithBasePath(factory, basePath!) as any
 }
-
-// function createRelativeReferenceTo(path: string) {
-//     // TODO: remove this option?
-//     const targetIdAttribute = path.split("/").slice(-1)[0]
-//     path = path.split("/").slice(0, -1).join("/")
-//     return reference(
-//         (identifier: string, owner: IModel) => resolve(owner, `${path}/${identifier}`),
-//         (value: any, owner: IModel, name)   => {
-//             invariant(!value || (getNode(value).root === getNode(owner).root), `The value assigned to the reference '${name}' should already be part of the same model tree`)
-//             return value[targetIdAttribute]
-//         }
-//     )
-// }
-
-// function createGenericRelativeReference(factory: IFactory<any, any>) {
-//     // TODO: store as {$ref: "..."} instead of just the string
-//     return reference(
-//         (identifier: string, owner: IModel) => {
-//             if (identifier === null || identifier === undefined)
-//                 return identifier
-//             return resolve(owner, identifier)
-//         },
-//         (value: any, owner: IModel, name) => {
-//             if (value === null || value === undefined)
-//                 return value
-//             invariant(isModel(value), `The value assigned to the reference '${name}' is not a model instance`)
-//             invariant(factory.is(value), `The value assigned to the reference '${name}' is not a model of type ${factory}`)
-//             const base = getNode(owner)
-//             const target = getNode(value)
-//             invariant(base.root === target.root, `The value assigned to the reference '${name}' should already be part of the same model tree`)
-//             return getRelativePath(base, target)
-//         }
-//     )
-// }
 
 function createGenericRelativeReference(factory: IFactory<any, any>): IReferenceDescription {
     // TODO: store as {$ref: "..."} instead of just the string
@@ -83,30 +39,45 @@ function createGenericRelativeReference(factory: IFactory<any, any>): IReference
     }
 }
 
+function createReferenceWithBasePath(factory: IFactory<any, any>, path: string): IReferenceDescription {
+    const targetIdAttribute = path.split("/").slice(-1)[0]
+    path = path.split("/").slice(0, -1).join("/")
 
-// export function createReferenceProps(name: string, ref: IReferenceDescription) {
-//     const sourceIdAttribute = `${name}_id`
-//     const res = {
-//         [sourceIdAttribute]: "" // the raw attribute value
-//     }
-//     Object.defineProperty(res, name, {
-//         get: function() {
-//             // Optimization: reuse closures based on the same name or configuration
-//             const id = this[sourceIdAttribute]
-//             return id ? ref.getter(id, this, name) : null
-//         },
-//         set: function(v) {
-//             invariant(getNode(this).isRunningAction(), `Reference '${name}' can only be modified from within an action`)
-//             this[sourceIdAttribute] = v ? ref.setter(v, this, name) : ""
-//         },
-//         enumerable: true
-//     })
-//     return res
-// }
-
-// function unwritableReference(_, owner, propertyName) {
-//     return fail(`Cannot assign a new value to the reference '${propertyName}', the reference is read-only`)
-// }
+    return {
+        isReference: true,
+        getter: function (this: IModel, identifier: string | null | undefined): any {
+            if (identifier === null || identifier === undefined)
+                return identifier
+            const targetCollection = resolve(this, `${path}`)
+            if (isObservableArray(targetCollection)) {
+                return targetCollection.find(item => item && item[targetIdAttribute] === identifier)
+            } else if (isObservableMap(targetCollection)) {
+                const child = targetCollection.get(identifier)
+                invariant(!child || child[targetIdAttribute] === identifier, `Inconsistent collection, the map entry under key '${identifier}' should have property '${targetIdAttribute}' set to value '${identifier}`)
+                return child
+            } else
+                return fail("References with base paths should point to either an `array` or `map` collection")
+        },
+        setter: function(this: IModel, value: IModel): string {
+            if (value === null || value === undefined)
+                return value
+            invariant(isModel(value), `Failed to assign a value to a reference; the value is not a model instance`)
+            invariant(factory.is(value), `Failed to assign a value to a reference; the value is not a model of type ${factory}`)
+            const base = getNode(this)
+            const target = getNode(value)
+            invariant(base.root === target.root, `Failed to assign a value to a reference; the value should already be part of the same model tree`)
+            const identifier = value[targetIdAttribute]
+            const targetCollection = resolve(this, `${path}`)
+            if (isObservableArray(targetCollection)) {
+                invariant(targetCollection.indexOf(value) !== -1, `The assigned value is not part of the collection the reference resolves to`)
+            } else if (isObservableMap(targetCollection)) {
+                invariant(targetCollection.get(identifier) === value, `The assigned value was not found in the collection the reference resolves to, under key '${identifier}'`)
+            } else
+                return fail("References with base paths should point to either an `array` or `map` collection")
+            return identifier
+        }
+    }
+}
 
 export function isReferenceFactory(thing): thing is IReferenceDescription {
     return thing.isReference === true

--- a/src/types/reference.ts
+++ b/src/types/reference.ts
@@ -1,8 +1,9 @@
 import {isObservableArray, isObservableMap} from "mobx"
-import {IModel, IFactory, isFactory, isModel} from "../core/factories"
+import {IModel, IFactory, isModel} from "../core/factories"
 import {resolve} from "../top-level-api"
 import {invariant, fail} from "../utils"
 import { getNode, getRelativePath } from "../core/node"
+import { getIdentifierAttribute } from "./object"
 
 export interface IReference {
     $ref: string
@@ -45,8 +46,9 @@ function createGenericRelativeReference(factory: IFactory<any, any>): IReference
 }
 
 function createReferenceWithBasePath(factory: IFactory<any, any>, path: string): IReferenceDescription {
-    const targetIdAttribute = path.split("/").slice(-1)[0]
-    path = path.split("/").slice(0, -1).join("/")
+    const targetIdAttribute = getIdentifierAttribute(factory)
+    if (!targetIdAttribute)
+        return fail(`Cannot create reference to path '${path}'; the targetted type, ${factory.type.describe()}, does not specify an identifier property`)
 
     return {
         isReference: true,

--- a/src/types/reference.ts
+++ b/src/types/reference.ts
@@ -5,88 +5,109 @@ import {resolve} from "../top-level-api"
 import {invariant, fail} from "../utils"
 import { getNode, getRelativePath } from "../core/node"
 
-export type IReferenceGetter<T> = (identifier: string, owner: IModel, propertyName: string) => T
-export type IReferenceSetter<T> = (value: T, owner: IModel, propertyName: string) => string
-
 export interface IReferenceDescription {
-    getter: IReferenceGetter<any>
-    setter: IReferenceSetter<any>
+    getter: (value: any) => any
+    setter: (value: any) => any
     isReference: true
 }
 
-export function reference<T>(path: string): T;
-export function reference<T>(getter: IReferenceGetter<T>, setter?: IReferenceSetter<T>): T;
+// export function reference<T>(path: string): T;
+// export function reference<T>(getter: IReferenceGetter<T>, setter?: IReferenceSetter<T>): T;
 export function reference<T>(factory: IFactory<any, T>): T;
 export function reference(arg1, arg2?) {
     if (isFactory(arg1))
         return createGenericRelativeReference(arg1)
-    if (typeof arg1 === "string")
-        return createRelativeReferenceTo(arg1)
+    throw "TODO"
+    // if (typeof arg1 === "string")
+    //     return createRelativeReferenceTo(arg1)
+    // return {
+    //     isReference: true,
+    //     getter: arg1,
+    //     setter: arg2 || unwritableReference
+    // } as IReferenceDescription
+}
+
+// function createRelativeReferenceTo(path: string) {
+//     // TODO: remove this option?
+//     const targetIdAttribute = path.split("/").slice(-1)[0]
+//     path = path.split("/").slice(0, -1).join("/")
+//     return reference(
+//         (identifier: string, owner: IModel) => resolve(owner, `${path}/${identifier}`),
+//         (value: any, owner: IModel, name)   => {
+//             invariant(!value || (getNode(value).root === getNode(owner).root), `The value assigned to the reference '${name}' should already be part of the same model tree`)
+//             return value[targetIdAttribute]
+//         }
+//     )
+// }
+
+// function createGenericRelativeReference(factory: IFactory<any, any>) {
+//     // TODO: store as {$ref: "..."} instead of just the string
+//     return reference(
+//         (identifier: string, owner: IModel) => {
+//             if (identifier === null || identifier === undefined)
+//                 return identifier
+//             return resolve(owner, identifier)
+//         },
+//         (value: any, owner: IModel, name) => {
+//             if (value === null || value === undefined)
+//                 return value
+//             invariant(isModel(value), `The value assigned to the reference '${name}' is not a model instance`)
+//             invariant(factory.is(value), `The value assigned to the reference '${name}' is not a model of type ${factory}`)
+//             const base = getNode(owner)
+//             const target = getNode(value)
+//             invariant(base.root === target.root, `The value assigned to the reference '${name}' should already be part of the same model tree`)
+//             return getRelativePath(base, target)
+//         }
+//     )
+// }
+
+function createGenericRelativeReference(factory: IFactory<any, any>): IReferenceDescription {
+    // TODO: store as {$ref: "..."} instead of just the string
     return {
         isReference: true,
-        getter: arg1,
-        setter: arg2 || unwritableReference
-    } as IReferenceDescription
-}
-
-function createRelativeReferenceTo(path: string) {
-    // TODO: remove this option?
-    const targetIdAttribute = path.split("/").slice(-1)[0]
-    path = path.split("/").slice(0, -1).join("/")
-    return reference(
-        (identifier: string, owner: IModel) => resolve(owner, `${path}/${identifier}`),
-        (value: any, owner: IModel, name)   => {
-            invariant(!value || (getNode(value).root === getNode(owner).root), `The value assigned to the reference '${name}' should already be part of the same model tree`)
-            return value[targetIdAttribute]
-        }
-    )
-}
-
-function createGenericRelativeReference(factory: IFactory<any, any>) {
-    // TODO: store as {$ref: "..."} instead of just the string
-    return reference(
-        (identifier: string, owner: IModel) => {
+        getter: function (this: IModel, identifier: string | null | undefined): any {
             if (identifier === null || identifier === undefined)
                 return identifier
-            return resolve(owner, identifier)
+            return resolve(this, identifier)
         },
-        (value: any, owner: IModel, name) => {
+        setter: function(this: IModel, value: IModel): string {
             if (value === null || value === undefined)
                 return value
-            invariant(isModel(value), `The value assigned to the reference '${name}' is not a model instance`)
-            invariant(factory.is(value), `The value assigned to the reference '${name}' is not a model of type ${factory}`)
-            const base = getNode(owner)
+            invariant(isModel(value), `Failed to assign a value to a reference; the value is not a model instance`)
+            invariant(factory.is(value), `Failed to assign a value to a reference; the value is not a model of type ${factory}`)
+            const base = getNode(this)
             const target = getNode(value)
-            invariant(base.root === target.root, `The value assigned to the reference '${name}' should already be part of the same model tree`)
+            invariant(base.root === target.root, `Failed to assign a value to a reference; the value should already be part of the same model tree`)
             return getRelativePath(base, target)
         }
-    )
-}
-
-export function createReferenceProps(name: string, ref: IReferenceDescription) {
-    const sourceIdAttribute = `${name}_id`
-    const res = {
-        [sourceIdAttribute]: "" // the raw attribute value
     }
-    Object.defineProperty(res, name, {
-        get: function() {
-            // Optimization: reuse closures based on the same name or configuration
-            const id = this[sourceIdAttribute]
-            return id ? ref.getter(id, this, name) : null
-        },
-        set: function(v) {
-            invariant(getNode(this).isRunningAction(), `Reference '${name}' can only be modified from within an action`)
-            this[sourceIdAttribute] = v ? ref.setter(v, this, name) : ""
-        },
-        enumerable: true
-    })
-    return res
 }
 
-function unwritableReference(_, owner, propertyName) {
-    return fail(`Cannot assign a new value to the reference '${propertyName}', the reference is read-only`)
-}
 
-export function isReferenceFactory(thing) {
+// export function createReferenceProps(name: string, ref: IReferenceDescription) {
+//     const sourceIdAttribute = `${name}_id`
+//     const res = {
+//         [sourceIdAttribute]: "" // the raw attribute value
+//     }
+//     Object.defineProperty(res, name, {
+//         get: function() {
+//             // Optimization: reuse closures based on the same name or configuration
+//             const id = this[sourceIdAttribute]
+//             return id ? ref.getter(id, this, name) : null
+//         },
+//         set: function(v) {
+//             invariant(getNode(this).isRunningAction(), `Reference '${name}' can only be modified from within an action`)
+//             this[sourceIdAttribute] = v ? ref.setter(v, this, name) : ""
+//         },
+//         enumerable: true
+//     })
+//     return res
+// }
+
+// function unwritableReference(_, owner, propertyName) {
+//     return fail(`Cannot assign a new value to the reference '${propertyName}', the reference is read-only`)
+// }
+
+export function isReferenceFactory(thing): thing is IReferenceDescription {
     return thing.isReference === true
 }

--- a/src/types/refinement.ts
+++ b/src/types/refinement.ts
@@ -19,9 +19,9 @@ export class Refinement extends Type {
         return this.name
     }
 
-    create(value, environment?) {
+    create(value) {
         // create the child type
-        const inst = this.type(value, environment)
+        const inst = this.type(value)
         const snapshot = hasNode(inst) ? getNode(inst).snapshot : inst
 
         // check if pass the predicate

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -18,12 +18,12 @@ export class Union extends Type {
         return "(" + this.types.map(factory => factory.type.describe()).join(" | ") + ")"
     }
 
-    create(value, environment?) {
+    create(value) {
         invariant(this.is(value), `Value ${JSON.stringify(value)} is not assignable to union ${this.name}`)
 
         // try the dispatcher, if defined
         if (this.dispatcher !== null) {
-            return this.dispatcher(value)(value, environment)
+            return this.dispatcher(value)(value)
         }
 
         // find the most accomodating type

--- a/src/types/with-default.ts
+++ b/src/types/with-default.ts
@@ -17,7 +17,7 @@ export class DefaultValue extends Type {
         return "(" + this.type.type.describe() + " = " + JSON.stringify(this.defaultValue) + ")"
     }
 
-    create(value, environment?) {
+    create(value) {
         return typeof value === "undefined" ? this.type(this.defaultValue) : this.type(value)
     }
 

--- a/src/types/with-default.ts
+++ b/src/types/with-default.ts
@@ -14,7 +14,9 @@ export class DefaultValue extends Type {
     }
 
     describe() {
-        return "(" + this.type.type.describe() + " = " + JSON.stringify(this.defaultValue) + ")"
+        // return "(" + this.type.type.describe() + " = " + JSON.stringify(this.defaultValue) + ")"
+        // MWE: discuss a default value is not part of the type description? (unlike a literal)
+        return this.type.type.describe()
     }
 
     create(value) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -88,3 +88,10 @@ const prototypeHasOwnProperty = Object.prototype.hasOwnProperty
 export function hasOwnProperty(object: Object, propName: string) {
     return prototypeHasOwnProperty.call(object, propName)
 }
+
+export function argsToArray(args: IArguments): any [] {
+    const res = new Array(args.length)
+    for (let i = 0; i < args.length; i++)
+        res[i] = args[i]
+    return res
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,3 +95,7 @@ export function argsToArray(args: IArguments): any [] {
         res[i] = args[i]
     return res
 }
+
+export function createNamedFunction(name: string, fn: Function) {
+    return new Function("f", `return function ${name}() { return f.apply(this, arguments)}`)(fn)
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,6 +66,15 @@ export function addHiddenFinalProp(object: any, propName: string, value: any) {
     })
 }
 
+export function addHiddenWritableProp(object: any, propName: string, value: any) {
+    Object.defineProperty(object, propName, {
+        enumerable: false,
+        writable: true,
+        configurable: true,
+        value
+    })
+}
+
 export function addReadOnlyProp(object: any, propName: string, value: any) {
     Object.defineProperty(object, propName, {
         enumerable: true,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -108,3 +108,9 @@ export function argsToArray(args: IArguments): any [] {
 export function createNamedFunction(name: string, fn: Function) {
     return new Function("f", `return function ${name}() { return f.apply(this, arguments)}`)(fn)
 }
+
+export function isValidIdentifier(identifier: any): boolean {
+    if (typeof identifier !== "string")
+        return false
+    return /^[a-z0-9_-]+$/i.test(identifier)
+}

--- a/test/action.ts
+++ b/test/action.ts
@@ -70,7 +70,9 @@ const OrderStore = createFactory({
 function createTestStore() {
     return OrderStore({
         customers: [{ name: "Mattia" }],
-        orders: [{}]
+        orders: [{
+            customer: null
+        }]
     })
 }
 
@@ -88,7 +90,7 @@ test("it should be possible to pass a complex object", t => {
             name: "Mattia"
         }],
         orders: [{
-            // TODO: customer: "../../customers/0"
+            customer: "../../customers/0"
         }]
     })
 

--- a/test/action.ts
+++ b/test/action.ts
@@ -89,7 +89,7 @@ test("it should be possible to pass a complex object", t => {
             name: "Mattia"
         }],
         orders: [{
-            customer: "../../customers/0"
+            customer: { $ref: "../../customers/0" }
         }]
     })
 

--- a/test/action.ts
+++ b/test/action.ts
@@ -93,7 +93,6 @@ test("it should be possible to pass a complex object", t => {
         }]
     })
 
-    console.dir(JSON.stringify(recorder.actions))
     t.deepEqual(
         recorder.actions,
         [{ "name": "setCustomer", "path": "orders/0", "args": [{ "$ref": "../../customers/0" }] }]

--- a/test/action.ts
+++ b/test/action.ts
@@ -84,7 +84,6 @@ test("it should be possible to pass a complex object", t => {
     store.orders[0].setCustomer(store.customers[0])
     t.is(store.orders[0].customer.name, "Mattia")
     t.is(store.orders[0].customer, store.customers[0])
-    console.dir(getSnapshot(store))
     t.deepEqual(getSnapshot(store) as any, {
         customers: [{
             name: "Mattia"
@@ -94,9 +93,10 @@ test("it should be possible to pass a complex object", t => {
         }]
     })
 
+    console.dir(JSON.stringify(recorder.actions))
     t.deepEqual(
         recorder.actions,
-        [{ "name": "setCustomer", "path": "/orders/0", "args": [{ "$ref": "/../../customers/0" }] }]
+        [{ "name": "setCustomer", "path": "orders/0", "args": [{ "$ref": "../../customers/0" }] }]
     )
 
     const store2  = createTestStore()

--- a/test/array.ts
+++ b/test/array.ts
@@ -165,3 +165,63 @@ test("it should check the type correctly", (t) => {
     t.deepEqual(Factory.is([{to: 'mars'}]), true)
     t.deepEqual(Factory.is([{wrongKey: true}]), false)
 })
+
+test("it should reconciliate instances correctly", (t) => {
+    const Store = createFactory({
+        todos: types.array(createFactory("Task", {
+            id: types.identifier(),
+            task: "",
+            done: false
+        }))
+    })
+
+    const store = Store({
+        todos: [
+            { id: "1", task: "coffee", done: false},
+            { id: "2", task: "tea", done: false},
+            { id: "3", task: "biscuit", done: false}
+        ]
+    })
+
+    t.deepEqual(store.todos.map(todo => todo.task), ["coffee", "tea", "biscuit"])
+    t.deepEqual(store.todos.map(todo => todo.done), [false, false, false])
+    t.deepEqual(store.todos.map(todo => todo.id), ["1", "2", "3"])
+
+    const a = store.todos[0]
+    const b = store.todos[1]
+    const c = store.todos[2]
+
+    applySnapshot(store, {
+        todos: [
+            { id: "2", task: "Tee", done: true},
+            { id: "1", task: "coffee", done: true},
+            { id: "4", task: "biscuit", done: false},
+            { id: "5", task: "stuffz", done: false}
+        ]
+    })
+
+    t.deepEqual(store.todos.map(todo => todo.task), ["Tee", "coffee", "biscuit", "stuffz"])
+    t.deepEqual(store.todos.map(todo => todo.done), [true, true, false, false])
+    t.deepEqual(store.todos.map(todo => todo.id), ["2", "1", "4", "5"])
+
+    t.is(store.todos[0] === b, true)
+    t.is(store.todos[1] === a, true)
+    t.is(store.todos[2] === c, false)
+})
+
+// test("it should reconciliate instances correctly", (t) => {
+//     const Store = createFactory({
+//         todos: types.array(types.union(
+//             createFactory("completedTask", {
+//                 id: types.identifier(),
+//                 task: "",
+//                 done: types.literal(true)
+//             }),
+//             createFactory("uncompletedTask", {
+//                 id: types.identifier()
+//                 task: "",
+//                 done: types.literal(true)
+//             })
+//         ))
+//     })
+// })

--- a/test/literal.ts
+++ b/test/literal.ts
@@ -12,7 +12,7 @@ test("it should allow only primitives", t => {
 })
 
 test("it should throw if a different type is given", t => {
-    const Factory = createFactory({
+    const Factory = createFactory("TestFactory", {
         shouldBeOne: types.literal(1)
     })
 
@@ -20,5 +20,5 @@ test("it should throw if a different type is given", t => {
         const doc = Factory({ shouldBeOne: 2 })
     })
 
-    t.is(error.message, '[mobx-state-tree] Snapshot {"shouldBeOne":2} is not assignable to type unnamed-object-factory. Expected { shouldBeOne: 1 } instead.')
+    t.is(error.message, '[mobx-state-tree] Snapshot {"shouldBeOne":2} is not assignable to type TestFactory. Expected { shouldBeOne: 1 } instead.')
 })

--- a/test/node.ts
+++ b/test/node.ts
@@ -7,7 +7,6 @@ test("it should resolve to the parent instance", (t) => {
         article_id: 0
     })
 
-    debugger;
     const Document = createFactory({
         rows: types.array(Row)
     })
@@ -72,19 +71,18 @@ test("it should resolve to the parent object instance", (t) => {
 
 // getRoot
 test("it should resolve to the root of an object", (t) => {
-    const Row = createFactory({
+    const Row = createFactory("Row", {
         article_id: 0
     })
 
-    const Document = createFactory({
+    const Document = createFactory("Document", {
         rows: types.array(Row)
     })
 
     const doc = Document()
     const row = Row()
     doc.rows.push(row)
-
-    t.deepEqual(getRoot(row), doc)
+    t.is(getRoot(row), doc)
 })
 
 // getPath

--- a/test/node.ts
+++ b/test/node.ts
@@ -7,6 +7,7 @@ test("it should resolve to the parent instance", (t) => {
         article_id: 0
     })
 
+    debugger;
     const Document = createFactory({
         rows: types.array(Row)
     })

--- a/test/object.ts
+++ b/test/object.ts
@@ -42,13 +42,14 @@ const createTestFactories = () => {
 test("it should create a factory", (t) => {
     const {Factory} = createTestFactories()
 
-    t.deepEqual(Factory(), {to: 'world'})
+    t.deepEqual(getSnapshot(Factory()) as any, {to: 'world'})
+    t.deepEqual(Factory().toString(), "AnonymousModel{\"to\":\"world\"}")
 })
 
 test("it should restore the state from the snapshot", (t) => {
     const {Factory} = createTestFactories()
 
-    t.deepEqual(Factory({to: 'universe'}), { to: 'universe' })
+    t.deepEqual(Factory({to: 'universe'}).toJSON(), { to: 'universe' })
 })
 
 // === SNAPSHOT TESTS ===
@@ -70,7 +71,7 @@ test("it should apply snapshots", (t) => {
 
     applySnapshot(doc, {to: 'universe'})
 
-    t.deepEqual(doc, {to: 'universe'})
+    t.deepEqual(doc.toJSON(), {to: 'universe'})
 })
 
 test("it should return a snapshot", (t) => {
@@ -101,7 +102,7 @@ test("it should apply a patch", (t) => {
 
     applyPatch(doc, {op: "replace", path: "/to", value: "universe"})
 
-    t.deepEqual(doc, {to: 'universe'})
+    t.deepEqual(doc.toJSON(), {to: 'universe'})
 })
 
 test("it should apply patches", (t) => {
@@ -110,7 +111,7 @@ test("it should apply patches", (t) => {
 
     applyPatches(doc, [{op: "replace", path: "/to", value: "mars"}, {op: "replace", path: "/to", value: "universe"}])
 
-    t.deepEqual(doc, {to: 'universe'})
+    t.deepEqual(doc.toJSON(), {to: 'universe'})
 })
 
 // === ACTIONS TESTS ===
@@ -120,7 +121,7 @@ test("it should call actions correctly", (t) => {
 
     doc.setTo('universe')
 
-    t.deepEqual(doc, {to: 'universe'})
+    t.deepEqual(doc.toJSON(), {to: 'universe'})
 })
 
 test("it should emit action calls", (t) => {
@@ -141,7 +142,7 @@ test("it should apply action call", (t) => {
 
     applyAction(doc, {name: "setTo", path: "", args: ["universe"]})
 
-    t.deepEqual(doc, {to: 'universe'})
+    t.deepEqual(doc.toJSON(), {to: 'universe'})
 })
 
 
@@ -151,7 +152,7 @@ test("it should apply actions calls", (t) => {
 
     applyActions(doc, [{name: "setTo", path: "", args: ["mars"]}, {name: "setTo", path: "", args: ["universe"]}])
 
-    t.deepEqual(doc, {to: 'universe'})
+    t.deepEqual(doc.toJSON(), {to: 'universe'})
 })
 
 
@@ -173,7 +174,7 @@ test("it should throw if snapshot has computed properties", (t) => {
         const doc = ComputedFactory({area: 3})
     })
 
-    t.is(error.message, "[mobx-state-tree] Snapshot {\"area\":3} is not assignable to type unnamed-object-factory. Expected { width: primitive; height: primitive } instead.")
+    t.is(error.message, "[mobx-state-tree] Snapshot {\"area\":3} is not assignable to type AnonymousModel. Expected { width: primitive; height: primitive } instead.")
 })
 
 // === COMPOSE FACTORY ===
@@ -181,7 +182,7 @@ test("it should compose factories", (t) => {
     const {BoxFactory, ColorFactory} = createTestFactories()
     const ComposedFactory = composeFactory(BoxFactory, ColorFactory)
 
-    t.deepEqual(ComposedFactory(), {width: 0, height: 0, color: "#FFFFFF"})
+    t.deepEqual(ComposedFactory().toJSON(), {width: 0, height: 0, color: "#FFFFFF"})
 })
 
 

--- a/test/reference.ts
+++ b/test/reference.ts
@@ -1,8 +1,8 @@
-import { createFactory, action, recordActions, types, getSnapshot } from "../"
+import { createFactory, types, getSnapshot } from "../"
 import { test } from "ava"
 
 
-test("it should support relative paths", t => {
+test("it should support generic relative paths", t => {
     const User = createFactory({
         name: types.primitive()
     })
@@ -12,7 +12,7 @@ test("it should support relative paths", t => {
     })
 
     const store = UserStore({
-        user: "users/17",
+        user: { $ref: "users/17" },
         users: {
             "17": { name: "Michel" },
             "18": { name: "Veria" }
@@ -29,7 +29,7 @@ test("it should support relative paths", t => {
     store.users.get("18").name = "Noa" as any // TODO: improve typings.
     t.is(store.user.name as string, "Noa") // TODO: improve typings
 
-    t.deepEqual(getSnapshot(store), {user: "users/18", "users": {"17": {name: "Michel"}, "18": {name: "Noa"}}} as any) // TODO: better typings
+    t.deepEqual(getSnapshot(store), {user: { $ref: "users/18" }, "users": {"17": {name: "Michel"}, "18": {name: "Noa"}}} as any) // TODO: better typings
 })
 
 test("it should support prefixed paths in maps", t => {

--- a/test/reference.ts
+++ b/test/reference.ts
@@ -1,0 +1,95 @@
+import { createFactory, action, recordActions, types, getSnapshot } from "../"
+import { test } from "ava"
+
+
+test("it should support relative paths", t => {
+    const User = createFactory({
+        name: types.primitive()
+    })
+    const UserStore = createFactory({
+        user: types.reference(User),
+        users: types.map(User)
+    })
+
+    const store = UserStore({
+        user: "users/17",
+        users: {
+            "17": { name: "Michel" },
+            "18": { name: "Veria" }
+        }
+    })
+
+    t.is(store.users.get("17").name as string, "Michel") // TODO: improve typings
+    t.is(store.users.get("18").name as string, "Veria") // TODO: improve typings
+    t.is(store.user.name as string, "Michel") // TODO: improve typings
+
+    store.user =  store.users.get("18")
+    t.is(store.user.name as string, "Veria") // TODO: improve typings
+
+    store.users.get("18").name = "Noa" as any // TODO: improve typings.
+    t.is(store.user.name as string, "Noa") // TODO: improve typings
+
+    t.deepEqual(getSnapshot(store), {user: "users/18", "users": {"17": {name: "Michel"}, "18": {name: "Noa"}}} as any) // TODO: better typings
+})
+
+test("it should support prefixed paths in maps", t => {
+    const User = createFactory({
+        id: types.primitive(),
+        name: types.primitive()
+    })
+    const UserStore = createFactory({
+        user: types.reference(User, "users/id"),
+        users: types.map(User)
+    })
+
+    const store = UserStore({
+        user: "17",
+        users: {
+            "17": { id: "17", name: "Michel" },
+            "18": { id: "18", name: "Veria" }
+        }
+    })
+
+    t.is(store.users.get("17").name as string, "Michel") // TODO: improve typings
+    t.is(store.users.get("18").name as string, "Veria") // TODO: improve typings
+    t.is(store.user.name as string, "Michel") // TODO: improve typings
+
+    store.user =  store.users.get("18")
+    t.is(store.user.name as string, "Veria") // TODO: improve typings
+
+    store.users.get("18").name = "Noa" as any // TODO: improve typings.
+    t.is(store.user.name as string, "Noa") // TODO: improve typings
+
+    t.deepEqual(getSnapshot(store), {user: "18", "users": {"17": {id: "17", name: "Michel"}, "18": {id: "18", name: "Noa"}}} as any) // TODO: better typings
+})
+
+test("it should support prefixed paths in arrays", t => {
+    const User = createFactory({
+        id: types.primitive(),
+        name: types.primitive()
+    })
+    const UserStore = createFactory({
+        user: types.reference(User, "/users/id"),
+        users: types.array(User)
+    })
+
+    const store = UserStore({
+        user: "17",
+        users: [
+            { id: "17", name: "Michel" },
+            { id: "18", name: "Veria" }
+        ]
+    })
+
+    t.is(store.users[0].name as string, "Michel") // TODO: improve typings
+    t.is(store.users[1].name as string, "Veria") // TODO: improve typings
+    t.is(store.user.name as string, "Michel") // TODO: improve typings
+
+    store.user =  store.users[1]
+    t.is(store.user.name as string, "Veria") // TODO: improve typings
+
+    store.users[1].name = "Noa" as any // TODO: improve typings.
+    t.is(store.user.name as string, "Noa") // TODO: improve typings
+
+    t.deepEqual(getSnapshot(store), {user: "18", "users": [{id: "17", name: "Michel"}, {id: "18", name: "Noa"}]} as any) // TODO: better typings
+})

--- a/test/reference.ts
+++ b/test/reference.ts
@@ -34,11 +34,11 @@ test("it should support generic relative paths", t => {
 
 test("it should support prefixed paths in maps", t => {
     const User = createFactory({
-        id: types.primitive(),
+        id: types.identifier(),
         name: types.primitive()
     })
     const UserStore = createFactory({
-        user: types.reference(User, "users/id"),
+        user: types.reference(User, "users"),
         users: types.map(User)
     })
 
@@ -65,11 +65,11 @@ test("it should support prefixed paths in maps", t => {
 
 test("it should support prefixed paths in arrays", t => {
     const User = createFactory({
-        id: types.primitive(),
+        id: types.identifier(),
         name: types.primitive()
     })
     const UserStore = createFactory({
-        user: types.reference(User, "/users/id"),
+        user: types.reference(User, "/users/"),
         users: types.array(User)
     })
 

--- a/test/reference.ts
+++ b/test/reference.ts
@@ -1,4 +1,4 @@
-import { createFactory, types, getSnapshot } from "../"
+import { createFactory, types, getSnapshot, applySnapshot } from "../"
 import { test } from "ava"
 
 
@@ -92,4 +92,25 @@ test("it should support prefixed paths in arrays", t => {
     t.is(store.user.name as string, "Noa") // TODO: improve typings
 
     t.deepEqual(getSnapshot(store), {user: "18", "users": [{id: "17", name: "Michel"}, {id: "18", name: "Noa"}]} as any) // TODO: better typings
+})
+
+test.skip("identifiers are required", (t) => {
+    const Todo = createFactory({
+        id: types.identifier()
+    })
+
+    t.is(Todo.is({}), false)
+    t.is(Todo.is({ id: "x" }), true)
+
+    t.throws(() => Todo(), "bla")
+})
+
+test("identifiers cannot be modified", (t) => {
+    const Todo = createFactory({
+        id: types.identifier()
+    })
+
+    const todo = Todo({ id: "x" })
+    t.throws(() => todo.id = "stuff", "[mobx-state-tree] It is not allowed to change the identifier of an object, got: 'stuff'")
+    t.throws(() => applySnapshot(todo, {}), "[mobx-state-tree] Snapshot {} is not assignable to type AnonymousModel. Expected { id: identifier() } instead.")
 })

--- a/test/refinement.ts
+++ b/test/refinement.ts
@@ -20,7 +20,7 @@ test("it should throw if a correct type with failing predicate is given", t => {
         const doc = Factory({ number: "givenStringInstead" })
     })
 
-    t.is(error.message, '[mobx-state-tree] Snapshot {\"number\":\"givenStringInstead\"} is not assignable to type unnamed-object-factory. Expected { number: Number } instead.')
+    t.is(error.message, '[mobx-state-tree] Snapshot {\"number\":\"givenStringInstead\"} is not assignable to type AnonymousModel. Expected { number: Number } instead.')
 })
 
 test("it should throw if default value does not pass the predicate", t => {

--- a/test/with-default.ts
+++ b/test/with-default.ts
@@ -46,5 +46,5 @@ test("it should throw if default value is invalid snapshot", t => {
         })
     })
 
-    t.is(error.message, '[mobx-state-tree] Default value [{"wrongProp":true}] is not assignable to type unnamed-object-factory[]. Expected "{ name: primitive; quantity: primitive }[]"')
+    t.is(error.message, '[mobx-state-tree] Default value [{"wrongProp":true}] is not assignable to type AnonymousModel[]. Expected "{ name: primitive; quantity: primitive }[]"')
 })


### PR DESCRIPTION
* [x] Introduce `identifier()` type
* [x] Use identifiers for prefixed `reference`'s
* [x] Use identifiers for better array item reconciliation
* [x] Use identifiers in unprefixed references
* [x] Use identifiers in maps; make sure they are unique and support simple `set(item)` operation (infering the key)
* [x] documentation
* Future work: forbid references to objects without identifier (also in patches etc?)

cc: @mattiamanzati 

Fixes #54, #22