### PR TITLE
Introduce livelyness

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ See [#10](https://github.com/mobxjs/mobx-state-tree/issues/10)
 
 ## Factory composition
 
+## Tree semantics
+
 ## Single or multiple state
 
 ## Using mobx and mobx-state-tree together

--- a/README.md
+++ b/README.md
@@ -149,6 +149,32 @@ Useful methods:
 -   `onAction(model, middleware)` listens to any action that is invoked on the model or any of it's descendants. See `onAction` for more details.
 -   `applyAction(model, action)` invokes an action on the model according to the given action description
 
+It is not necessary to express all logic around models as actions. For example it is not possible to define constructors on models. Rather, it is recommended to create stateless utility methods that operate on your models. It is recommended to keep models self-contained and to do orchestration around models in utilities around it.
+
+## Protecting the state tree
+
+By default it is allowed to both directly modify a model or through an action.
+However, in some cases you want to guarantee that the state tree is only modified through actions.
+So that replaying action will reflect everything that can possible have happened to your objects, or that every mutation passes through your action middleware etc.
+To disable modifying data in the tree without action, simple call `protect(model)`. Protect protects the passed model an all it's children
+
+```javascript
+const Todo = types.model({
+    done: false,
+    toggle() {
+        this.done = !this.done
+    }
+})
+
+const todo = new Todo()
+todo.done = true // OK
+protect(todo)
+todo.done = false // throws!
+todo.toggle() // OK
+```
+
+
+
 ## Identifiers
 
 Identifiers and references are two powerful abstraction that work well together.
@@ -278,9 +304,9 @@ The result of this function is the return value of the callbacks
 
 **Parameters**
 
--   `value`  
--   `asNodeCb`  
--   `asPrimitiveCb`  
+-   `value`
+-   `asNodeCb`
+-   `asPrimitiveCb`
 
 ## get
 
@@ -297,7 +323,7 @@ escape slashes and backslashes
 
 **Parameters**
 
--   `str`  
+-   `str`
 
 ## unescapeJsonPath
 
@@ -307,7 +333,7 @@ unescape slashes and backslashes
 
 **Parameters**
 
--   `str`  
+-   `str`
 
 ## map
 
@@ -370,7 +396,7 @@ Example of a logging middleware:
 **Parameters**
 
 -   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** model to intercept actions on
--   `callback`  
+-   `callback`
 
 Returns **IDisposer** function to remove the middleware
 
@@ -385,7 +411,7 @@ Patches can be used to deep observe a model tree.
 **Parameters**
 
 -   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** the model instance from which to receive patches
--   `callback`  
+-   `callback`
 
 Returns **IDisposer** function to remove the listener
 
@@ -398,10 +424,10 @@ The listener will only be fire at the and a MobX (trans)action
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `callback`  
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `callback`
 
-Returns **IDisposer** 
+Returns **IDisposer**
 
 ## applyPatch
 
@@ -411,8 +437,8 @@ Applies a JSON-patch to the given model instance or bails out if the patch could
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `patch` **IJsonPatch** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `patch` **IJsonPatch**
 
 ## applyPatches
 
@@ -422,8 +448,8 @@ Applies a number of JSON patches in a single MobX transaction
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `patches` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;IJsonPatch>** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `patches` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;IJsonPatch>**
 
 ## applyAction
 
@@ -434,9 +460,9 @@ Returns the value of the last actoin
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `action` **IActionCall** 
--   `options` **\[IActionCallOptions]** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `action` **IActionCall**
+-   `options` **\[IActionCallOptions]**
 
 ## applyActions
 
@@ -448,9 +474,9 @@ Does not return any value
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `actions` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;IActionCall>** 
--   `options` **\[IActionCallOptions]** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `actions` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;IActionCall>**
+-   `options` **\[IActionCallOptions]**
 
 ## applySnapshot
 
@@ -460,8 +486,8 @@ Applies a snapshot to a given model instances. Patch and snapshot listeners will
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `snapshot` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `snapshot` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
 ## getSnapshot
 
@@ -472,9 +498,9 @@ structural sharing where possible. Doesn't require MobX transactions to be compl
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
-Returns **Any** 
+Returns **Any**
 
 ## hasParent
 
@@ -484,10 +510,10 @@ Given a model instance, returns `true` if the object has a parent, that is, is p
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 -   `strict` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]**  (optional, default `false`)
 
-Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**
 
 ## getParent
 
@@ -498,10 +524,10 @@ TODO:? strict mode?
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 -   `strict` **\[[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]**  (optional, default `false`)
 
-Returns **Any** 
+Returns **Any**
 
 ## getParent
 
@@ -513,10 +539,10 @@ map or array.
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `strict`  
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `strict`
 
-Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**
 
 ## getRoot
 
@@ -527,9 +553,9 @@ Returns the closest parent that is a model instance, but which isn't an array or
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
-Returns **Any** 
+Returns **Any**
 
 ## getRoot
 
@@ -539,9 +565,9 @@ Given an object in a model tree, returns the root object of that tree
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
-Returns **Any** 
+Returns **Any**
 
 ## getPath
 
@@ -551,9 +577,9 @@ Returns the path of the given object in the model tree
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
-Returns **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+Returns **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)**
 
 ## getPathParts
 
@@ -563,9 +589,9 @@ Returns the path of the given object as unescaped string array
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
-Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** 
+Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>**
 
 ## isRoot
 
@@ -575,9 +601,9 @@ Returns true if the given object is the root of a model tree
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
-Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**
 
 ## resolve
 
@@ -587,10 +613,10 @@ Resolves a path relatively to a given object.
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 -   `path` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** escaped json path
 
-Returns **Any** 
+Returns **Any**
 
 ## tryResolve
 
@@ -598,10 +624,10 @@ Returns **Any**
 
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `path` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `path` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)**
 
-Returns **Any** 
+Returns **Any**
 
 ## clone
 
@@ -609,9 +635,9 @@ Returns **Any**
 
 **Parameters**
 
--   `source` **T** 
+-   `source` **T**
 
-Returns **T** 
+Returns **T**
 
 ## \_getNode
 
@@ -621,7 +647,7 @@ Internal function, use with care!
 
 **Parameters**
 
--   `thing`  
+-   `thing`
 
 ## \_getNode
 
@@ -629,9 +655,9 @@ Internal function, use with care!
 
 **Parameters**
 
--   `thing` **any** 
+-   `thing` **any**
 
-Returns **Any** 
+Returns **Any**
 
 # FAQ
 
@@ -676,8 +702,8 @@ So far this might look a lot like an immutable state tree as found for example i
 
 ## TypeScript & MST
 
-When using models, you write interface along with it's property types that will be used to perform type checks at runtime. 
-What about compile time? You can use TypeScript interfaces indeed to perform those checks, but that would require writing again all the properties and their actions! 
+When using models, you write interface along with it's property types that will be used to perform type checks at runtime.
+What about compile time? You can use TypeScript interfaces indeed to perform those checks, but that would require writing again all the properties and their actions!
 Good news? You don't need to write it twice! Using the `typeof` operator of TypeScript over the `.Type` property of a MST Type, will result in a valid TypeScript Type!
 
 ```typescript

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 0.2.0
+
+* Introduced the concept of livelyness; if nodes are removed from the the tree because they are replaced by some other value, they will be marked as "died". This should help to early signal when people hold on to references that are not part of the tree anymore. To explicitly remove an node from a tree, with the intent to spawn a new state tree from it, use `detach`.
+* Introduced the convenience method `destroy` to remove a model from it's parent and mark it as dead.
+
 # 0.2.1
 
 * Introduced .Type and .SnapshotType to be used with TypeScript to get the type for a model

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -13,6 +13,7 @@ export function createActionInvoker(name: string, fn: Function) {
 
     const actionInvoker = function () {
         const adm = getMST(this)
+        adm.assertAlive()
         if (adm.isRunningAction()) {
             // an action is already running in this tree, invoking this action does not emit a new action
             return action.apply(this, arguments)

--- a/src/core/complex-type.ts
+++ b/src/core/complex-type.ts
@@ -24,6 +24,7 @@ export abstract class ComplexType<S, T> extends Type<S, T> {
     abstract applyPatchLocally(node: MSTAdminisration, target: any, subpath: string, patch: IJsonPatch): void
     abstract getChildType(key: string): IType<any, any>
     abstract isValidSnapshot(snapshot: any): boolean
+    abstract removeChild(node: MSTAdminisration, subpath: string): void
 
     is(value: any): value is S | IMSTNode<S, T> {
         if (!value || typeof value !== "object")

--- a/src/core/mst-node-administration.ts
+++ b/src/core/mst-node-administration.ts
@@ -179,19 +179,6 @@ export class MSTAdminisration {
         }
     }
 
-    detach() {
-        // TODO: change to return a clone
-        // TODO: detach / remove marks as End of life!...
-        if (this.isRoot)
-            return
-        if (isObservableArray(this.parent!.target))
-            this.parent!.target.splice(parseInt(this.subpath), 1)
-        else if (isObservableMap(this.parent!.target))
-            this.parent!.target.delete(this.subpath)
-        else // Object
-            this.parent!.target[this.subpath] = null
-    }
-
     resolve(pathParts: string): MSTAdminisration;
     resolve(pathParts: string, failIfResolveFails: boolean): MSTAdminisration | undefined;
     resolve(path: string, failIfResolveFails: boolean = true): MSTAdminisration | undefined {
@@ -297,5 +284,16 @@ export class MSTAdminisration {
         if (!this.isRunningAction() && this.isProtected) {
             fail(`Cannot modify '${this.path}', the object is protected and can only be modified from model actions`)
         }
+    }
+
+    removeChild(subpath: string) {
+        this.type.removeChild(this, subpath)
+    }
+
+    detach() {
+        if (this.isRoot)
+            return
+        else
+            this.parent!.removeChild(this.subpath)
     }
 }

--- a/src/core/mst-node-administration.ts
+++ b/src/core/mst-node-administration.ts
@@ -99,6 +99,9 @@ export class MSTAdminisration {
         if (!this.isRoot)
             fail(`Model ${this.path} cannot die while it is still in a tree`)
         this.snapshotDisposer()
+        this.patchSubscribers.splice(0)
+        this.snapshotSubscribers.splice(0)
+        this.patchSubscribers.splice(0)
         this._isAlive = false
     }
 
@@ -118,6 +121,7 @@ export class MSTAdminisration {
     }
 
     public applySnapshot(snapshot: any) {
+        this.assertWritable()
         typecheck(this.type, snapshot)
         return this.type.applySnapshot(this, this.target, snapshot)
     }
@@ -129,6 +133,7 @@ export class MSTAdminisration {
     }
 
     applyPatchLocally(subpath: string, patch: IJsonPatch): void {
+        this.assertWritable()
         this.type.applyPatchLocally(this, this.target, subpath, patch)
     }
 
@@ -163,7 +168,7 @@ export class MSTAdminisration {
                  this.snapshotSubscribers.length > 0 ||
                  (this instanceof ObjectType && this.actionSubscribers.length > 0)
             ) {
-                console.warn("An object with active event listeners was removed from the tree. This might introduce a memory leak. Use detach() if this is intentional")
+                console.warn("An object with active event listeners was removed from the tree. The subscriptions have been disposed.")
             }
             this._parent = newParent
             this.die()

--- a/src/top-level-api.ts
+++ b/src/top-level-api.ts
@@ -388,6 +388,9 @@ export function _getNode(thing: IMSTNode<any, any>): any {
     return getMST(thing)
 }
 
+/**
+ * Removes a model element from the state tree, and let it live on as a new state tree
+ */
 export function detach<T extends IMSTNode<any, any>>(thing: T): T {
     getMST(thing).detach()
     return thing

--- a/src/top-level-api.ts
+++ b/src/top-level-api.ts
@@ -396,6 +396,16 @@ export function detach<T extends IMSTNode<any, any>>(thing: T): T {
     return thing
 }
 
+
+/**
+ * Removes a model element from the state tree, and mark it as end-of-life; the element should not be used anymore
+ */
+export function destroy(thing: IMSTNode<any, any>) {
+    const node = getMST(thing)
+    node.detach()
+    node.die()
+}
+
 export function testActions<S, T>(factory: IType<S, IMSTNode<S, T>>, initialState: S, ...actions: IActionCall[]): S {
     const testInstance = factory.create(initialState)
     applyActions(testInstance, actions)

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -134,6 +134,10 @@ export class ArrayType<T> extends ComplexType<T[], IObservableArray<T>> {
     getDefaultSnapshot() {
         return []
     }
+
+    removeChild(node: MSTAdminisration, subpath: string) {
+        node.target.splice(parseInt(subpath, 10), 1)
+    }
 }
 
 function reconcileArrayItems(identifierAttr: string, target: IObservableArray<any>, snapshot: any[], factory: IType<any, any>): any[] {

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -44,11 +44,13 @@ export class ArrayType<T> extends ComplexType<T[], IObservableArray<T>> {
     }
 
     willChange = (change: IArrayWillChange<any> | IArrayWillSplice<any>): Object | null => {
+        const node = getMST(change.object)
+        node.assertWritable()
+
         // TODO: verify type
                 // TODO check type
-        // TODO: check if tree is editable
+
         // TODO: check for key duplication
-        const node = getMST(change.object)
         switch (change.type) {
             case "update":
                 const {newValue} = change

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -63,6 +63,10 @@ export class MapType<S, T> extends ComplexType<{[key: string]: S}, IExtendedObse
 
     willChange(change: IMapWillChange<any>): IMapWillChange<any> | null {
         const node = getMST(change.object)
+        node.assertWritable()
+
+         // TODO: verify type
+        // TODO check type
         const identifierAttr = getIdentifierAttribute(node)
         if (identifierAttr && change.newValue && typeof change.newValue === "object" && change.newValue[identifierAttr] !== change.name)
             fail(`A map of objects containing an identifier should always store the object under their own identifier. Trying to store key '${change.name}', but expected: '${change.newValue[identifierAttr!]}'`)

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -178,6 +178,10 @@ export class MapType<S, T> extends ComplexType<{[key: string]: S}, IExtendedObse
     getDefaultSnapshot() {
         return {}
     }
+
+    removeChild(node: MSTAdminisration, subpath: string) {
+        (node.target as ObservableMap<any>).delete(subpath)
+    }
 }
 
 export function createMapFactory<S, T>(subtype: IType<S, T>): IType<{[key: string]: S}, IMSTNode<{[key: string]: S}, IExtendedObservableMap<T>>> {

--- a/src/types/object.ts
+++ b/src/types/object.ts
@@ -149,7 +149,6 @@ export class ObjectType extends ComplexType<any, any> {
 
     // TODO: remove node arg
     @action applySnapshot(node: MSTAdminisration, target: any, snapshot: any): void {
-        node.assertWritable()
         for (let key in snapshot) if (key in this.props) {
             this.props[key].deserialize(target, snapshot)
         }

--- a/src/types/object.ts
+++ b/src/types/object.ts
@@ -5,7 +5,7 @@ import { MSTAdminisration, maybeMST } from "../core"
 import { isReferenceFactory } from "./reference"
 import { primitiveFactory } from "./primitive"
 import { isIdentifierFactory } from "./identifier"
-import { ComplexType, getType, IMSTNode, isType, IType } from '../core';
+import { ComplexType, getType, IMSTNode, isType, IType, getMST } from '../core';
 import { createDefaultValueFactory } from "./with-default"
 import { Property } from "./property-types/property"
 import { TransformedProperty } from "./property-types/transformed-property"
@@ -76,6 +76,9 @@ export class ObjectType extends ComplexType<any, any> {
     }
 
     willChange = (change: IObjectWillChange): IObjectWillChange | null => {
+        const node = getMST(change.object)
+        node.assertWritable()
+
         return this.props[change.name].willChange(change)
     }
 
@@ -146,9 +149,8 @@ export class ObjectType extends ComplexType<any, any> {
 
     // TODO: remove node arg
     @action applySnapshot(node: MSTAdminisration, target: any, snapshot: any): void {
-        // TODO typecheck?
-        for (let key in snapshot) {
-            invariant(key in this.props, `It is not allowed to assign a value to non-declared property ${key} of ${this.name}`)
+        node.assertWritable()
+        for (let key in snapshot) if (key in this.props) {
             this.props[key].deserialize(target, snapshot)
         }
     }

--- a/src/types/object.ts
+++ b/src/types/object.ts
@@ -188,6 +188,10 @@ export class ObjectType extends ComplexType<any, any> {
     getDefaultSnapshot(): any {
         return {}
     }
+
+    removeChild(node: MSTAdminisration, subpath: string) {
+        node.target[subpath] = null
+    }
 }
 
 export type IBaseModelDefinition<T> = {

--- a/src/types/property-types/identifier-property.ts
+++ b/src/types/property-types/identifier-property.ts
@@ -1,3 +1,4 @@
+import { getMST } from "../../core";
 import { extendObservable, observable, IObjectWillChange } from "mobx"
 import { Property } from "./property"
 import { isValidIdentifier, fail } from "../../utils"
@@ -16,6 +17,8 @@ export class IdentifierProperty extends Property {
     willChange(change: IObjectWillChange): IObjectWillChange | null {
         if (!isValidIdentifier(change.newValue))
             fail(`Not a valid identifier: '${change.newValue}`)
+        const node = getMST(change.object)
+        node.assertWritable()
         const oldValue = change.object[this.name]
         if (oldValue !== undefined && oldValue !== change.newValue)
             fail(`It is not allowed to change the identifier of an object, got: '${change.newValue}'`)

--- a/src/types/property-types/transformed-property.ts
+++ b/src/types/property-types/transformed-property.ts
@@ -14,6 +14,7 @@ export class TransformedProperty extends Property {
         const self = this
         Object.defineProperty(targetInstance, this.name, {
             get: function() {
+                getMST(this).assertAlive() // Expensive for each read, so optimize away in prod builds!
                 return self.getter.call(this, box.get())
             },
             set: function(v) {

--- a/src/types/property-types/transformed-property.ts
+++ b/src/types/property-types/transformed-property.ts
@@ -17,9 +17,10 @@ export class TransformedProperty extends Property {
                 return self.getter.call(this, box.get())
             },
             set: function(v) {
+                const node = getMST(this)
+                node.assertWritable()
                 if (this[self.name] === v)
                     return
-                const node = getMST(this)
                 const newValue = self.setter.call(this, v)
                 box.set(newValue)
                 node.emitPatch({

--- a/src/types/property-types/value-property.ts
+++ b/src/types/property-types/value-property.ts
@@ -36,6 +36,7 @@ export class ValueProperty extends Property {
     }
 
     serialize(instance: any, snapshot: any) {
+        getMST(instance).assertAlive()
         snapshot[this.name] = valueToSnapshot(instance[this.name])
     }
 

--- a/test/action.ts
+++ b/test/action.ts
@@ -40,16 +40,6 @@ test("it should be possible to record & replay a simple action", t => {
     t.is(t2.done, true)
 })
 
-test.skip("it should not be possible to change state without action", t => {
-    const t1 = Task.create()
-    t.throws(
-        () => {
-            t1.done = !t1.done
-        },
-        "bla"
-    )
-})
-
 // Complex actions
 const Customer = types.model({
     name: ""
@@ -154,3 +144,4 @@ test("it should be possible to pass a complex plain object", t => {
     recorder.replay(t2)
     t.is(t2.done, true)
 })
+

--- a/test/node.ts
+++ b/test/node.ts
@@ -1,4 +1,4 @@
-import {getPath, getSnapshot, getParent, hasParent, getRoot, getPathParts, clone, getType, getChildType, recordActions, recordPatches, types} from "../"
+import {getPath, getSnapshot, getParent, hasParent, getRoot, getPathParts, clone, getType, getChildType, recordActions, recordPatches, types, detach} from "../"
 import {test} from "ava"
 
 // getParent
@@ -186,30 +186,29 @@ test("a node can exists only once in a tree", (t) => {
     t.is(error.message, "[mobx-state-tree] Cannot add an object to a state tree if it is already part of the same or another state tree. Tried to assign an object to '/foos/0', but it lives already at '/rows/0'")
 })
 
-// TODO
-// test("make sure array filter works properly", (t) => {
-//     const Row = types.model({
-//         done: false
-//     })
+test("make sure array filter works properly", (t) => {
+    const Row = types.model({
+        done: false
+    })
 
-//     const Document = types.model({
-//         rows: arrayOf(Row),
-//         clearDone: action(function(){
-//             this.rows =  doc.rows.filter(row => row.done === true)
-//         })
-//     })
+    const Document = types.model({
+        rows: types.array(Row),
+        clearDone() {
+            this.rows.filter(row => row.done === true).forEach(detach)
+        }
+    })
 
-//     const doc = Document.create()
-//     const a = Row.create({ done: true })
-//     const b = Row.create({ done: false })
+    const doc = Document.create()
+    const a = Row.create({ done: true })
+    const b = Row.create({ done: false })
 
-//     doc.rows.push(a)
-//     doc.rows.push(b)
+    doc.rows.push(a)
+    doc.rows.push(b)
 
-//     doc.clearDone()
+    doc.clearDone()
 
-//     t.deepEqual<any>(getSnapshot(doc), {rows: [{done: false}]})
-// })
+    t.deepEqual<any>(getSnapshot(doc), {rows: [{done: false}]})
+})
 
 // === RECORD PATCHES ===
 test("it can record and replay patches", (t) => {

--- a/test/node.ts
+++ b/test/node.ts
@@ -1,4 +1,4 @@
-import {getPath, getSnapshot, getParent, hasParent, getRoot, getPathParts, clone, getType, getChildType, recordActions, recordPatches, types, detach} from "../"
+import {getPath, getSnapshot, getParent, hasParent, getRoot, getPathParts, clone, getType, getChildType, recordActions, recordPatches, types, destroy} from "../"
 import {test} from "ava"
 
 // getParent
@@ -194,7 +194,7 @@ test("make sure array filter works properly", (t) => {
     const Document = types.model({
         rows: types.array(Row),
         clearDone() {
-            this.rows.filter(row => row.done === true).forEach(detach)
+            this.rows.filter(row => row.done === true).forEach(destroy)
         }
     })
 

--- a/test/object.ts
+++ b/test/object.ts
@@ -177,6 +177,44 @@ test("it should throw if snapshot has computed properties", (t) => {
     t.is(error.message, "[mobx-state-tree] Snapshot {\"area\":3} is not assignable to type AnonymousModel. Expected { width: number; height: number } instead.")
 })
 
+test("it should throw if a replaced object is read or written to", (t) => {
+    const Todo = types.model({
+        title: "test",
+        fn() {
+
+        }
+    })
+    const Store = types.model({
+        todo: Todo
+    })
+
+    const s = Store.create({
+        todo: { title: "3" }
+    })
+    const todo = s.todo
+    s.todo = { title: "4"} as any
+
+    t.is(s.todo.title, "4")
+
+    t.throws(
+        () => { getSnapshot(todo) },
+        "[mobx-state-tree] The model cannot be used anymore as it has died; it has been removed from a state tree. If you want to remove an element from a tree and let it live on, use 'detach'"
+    )
+    t.throws(
+        () => { todo.fn() },
+        "[mobx-state-tree] The model cannot be used anymore as it has died; it has been removed from a state tree. If you want to remove an element from a tree and let it live on, use 'detach'"
+    )
+    // Ideally...? But expensive!
+    // t.throws(
+    //     () => { todo.title },
+    //     "bla"
+    // )
+    t.throws(
+        () => { todo.title = "5"},
+        "[mobx-state-tree] The model cannot be used anymore as it has died; it has been removed from a state tree. If you want to remove an element from a tree and let it live on, use 'detach'"
+    )
+})
+
 // === COMPOSE FACTORY ===
 test("it should compose factories", (t) => {
     const {BoxFactory, ColorFactory} = createTestFactories()

--- a/test/protect.ts
+++ b/test/protect.ts
@@ -1,0 +1,74 @@
+import { protect, applySnapshot, types } from "../"
+import { test } from "ava"
+
+function createTestStore() {
+    const Todo = types.model("Todo", {
+        title: "",
+        setTitle(newTitle) {
+            this.title = newTitle
+        }
+    })
+
+    const Store = types.model("Store", {
+        todos: types.array(Todo)
+    })
+
+    return Store.create({
+        todos: [
+            { title: "Get coffee" },
+            { title: "Get biscuit" },
+        ]
+    })
+}
+
+test("it should be possible to protect an object", t => {
+    const store = createTestStore()
+
+    protect(store.todos[0])
+
+    store.todos[1].title = "A"
+
+    t.throws(
+        () => { store.todos[0].title = "B" },
+        "[mobx-state-tree] Cannot modify '/todos/0', the object is protected and can only be modified from model actions"
+    )
+
+    t.is(store.todos[1].title, "A")
+    t.is(store.todos[0].title, "Get coffee")
+
+    store.todos[0].setTitle("B")
+    t.is(store.todos[0].title, "B")
+})
+
+test("protect should protect against any update", t => {
+    const store = createTestStore()
+    protect(store)
+
+    t.throws(
+        () => { applySnapshot(store, { todos: [ { title: "Get tea" } ]}) },
+        "[mobx-state-tree] Cannot modify '', the object is protected and can only be modified from model actions"
+    )
+
+    t.throws(
+        () => { store.todos.push({ title: "test" } as any) },
+        "[mobx-state-tree] Cannot modify '/todos', the object is protected and can only be modified from model actions"
+    )
+
+    t.throws(
+        () => { store.todos[0].title = "test" },
+        "[mobx-state-tree] Cannot modify '/todos/0', the object is protected and can only be modified from model actions"
+    )
+})
+
+test("protect should also protect children", t => {
+    const store = createTestStore()
+    protect(store)
+
+    t.throws(
+        () => { store.todos[0].title = "B" },
+        "[mobx-state-tree] Cannot modify '/todos/0', the object is protected and can only be modified from model actions"
+    )
+
+    store.todos[0].setTitle("B")
+    t.is(store.todos[0].title, "B")
+})

--- a/test/reference.ts
+++ b/test/reference.ts
@@ -94,7 +94,7 @@ test("it should support prefixed paths in arrays", t => {
     t.deepEqual(getSnapshot(store), {user: "18", "users": [{id: "17", name: "Michel"}, {id: "18", name: "Noa"}]} as any) // TODO: better typings
 })
 
-test.skip("identifiers are required", (t) => {
+test("identifiers are required", (t) => {
     const Todo = types.model({
         id: types.identifier()
     })
@@ -102,7 +102,7 @@ test.skip("identifiers are required", (t) => {
     t.is(Todo.is({}), false)
     t.is(Todo.is({ id: "x" }), true)
 
-    t.throws(() => Todo.create(), "bla")
+    t.throws(() => Todo.create(), "[mobx-state-tree] Snapshot {} is not assignable to type AnonymousModel. Expected { id: identifier() } instead.")
 })
 
 test("identifiers cannot be modified", (t) => {


### PR DESCRIPTION
Fixes #34 

If a tree node (model) is overwritten by another value and as a result orphaned, it is marked as dead and becomes unreadable. This should avoid subtle issues where people hang on to values that are not part of the state tree anymore. 

Explicitly detaching an element from the tree to make it a stand-alone tree can be achieved by using `detach`

* [x] implement
* [x] assert livelyness everywhere
* [ ]  tests
* [ ] document in README