### PR TITLE
Introduce `type.Type`, to make it possible to refer to the type produced by a factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,3 +673,19 @@ So far this might look a lot like an immutable state tree as found for example i
 -   mobx-state-tree allows for fine grained and efficient observability on any point in the state tree
 -   mobx-state-tree generates json patches for any modification that is made
 -   (?) mobx-state-tree is a valid redux store, providing the same api (TODO)
+
+## TypeScript & MST
+
+When using models, you write interface along with it's property types that will be used to perform type checks at runtime. 
+What about compile time? You can use TypeScript interfaces indeed to perform those checks, but that would require writing again all the properties and their actions! 
+Good news? You don't need to write it twice! Using the `typeof` operator of TypeScript over the `.Type` property of a MST Type, will result in a valid TypeScript Type!
+
+```typescript
+const Todo = types.model({
+    title: types.string,
+    setTitle(v: string) {
+        this.title = v
+    }
+})
+type ITodo = typeof Todo.Type // => ITodo is now a valid TypeScript type with { title: string; setTitle: (v: string) => void }
+```

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 0.2.1
+
+* Introduced .Type and .SnapshotType to be used with TypeScript to get the type for a model
+
 # 0.2.0
 
 * Renamed `createFactory` to `types.model` (breaking!)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "coverage": "tsc && tsc -p test/ && nyc ava && nyc report -r html && nyc report -r lcov",
     "build-docs": "npm run quick-build && documentation readme lib/index.js --github --section API",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
-    "clean": "rm lib && rm test-lib"
+    "clean": "rm -rf lib && rm -rf test-lib"
   },
   "repository": {
     "type": "git",

--- a/src/core/type.ts
+++ b/src/core/type.ts
@@ -10,6 +10,7 @@ export interface IType<S, T> {
     isType: boolean
     describe(): string,
     Type: T
+    SnapshotType: S
 }
 
 export abstract class Type<S, T> implements IType<S, T> { // TODO: generic for config and state of target
@@ -27,6 +28,9 @@ export abstract class Type<S, T> implements IType<S, T> { // TODO: generic for c
 
     get Type(): T {
         return fail("Factory.Type should not be actually called. It is just a Type signature that can be used at compile time with Typescript, by using `typeof type.Type`")
+    }
+    get SnapshotType(): S {
+        return fail("Factory.SnapshotType should not be actually called. It is just a Type signature that can be used at compile time with Typescript, by using `typeof type.SnapshotType`")
     }
 }
 

--- a/src/core/type.ts
+++ b/src/core/type.ts
@@ -8,7 +8,8 @@ export interface IType<S, T> {
     is(thing: any): thing is S | T
     create(snapshot?: S): T
     isType: boolean
-    describe(): string
+    describe(): string,
+    Type: T
 }
 
 export abstract class Type<S, T> implements IType<S, T> { // TODO: generic for config and state of target
@@ -23,6 +24,10 @@ export abstract class Type<S, T> implements IType<S, T> { // TODO: generic for c
     abstract create(snapshot: any): any
     abstract is(thing: any): thing is S | T
     abstract describe(): string
+
+    get Type(): T {
+        return fail("Factory.Type should not be actually called. It is just a Type signature that can be used at compile time with Typescript, by using `typeof type.Type`")
+    }
 }
 
 export function typecheck(type: IType<any, any>, snapshot: any) {

--- a/test/type-system.ts
+++ b/test/type-system.ts
@@ -215,3 +215,15 @@ test(".Type should not be callable", t => {
 
     t.throws(() => Todo.Type)
 })
+
+
+test(".SnapshotType should not be callable", t => {
+    const Todo = types.model({
+        title: types.string,
+        setTitle(v: string) {
+
+        }
+    })
+
+    t.throws(() => Todo.SnapshotType)
+})

--- a/test/type-system.ts
+++ b/test/type-system.ts
@@ -186,3 +186,32 @@ test("can create factories with maybe primitives", t => {
     t.is(F.create({ x: ""}).x, "")
     t.is(F.create({ x: "3"}).x, "3")
 })
+
+test("it is possible to refer to a type", t => {
+    const Todo = types.model({
+        title: types.string,
+        setTitle(v: string) {
+
+        }
+    })
+
+    function x(): typeof Todo.Type {
+        return Todo.create({ title: "test" }) as any // as any to make sure the type is not inferred accidentally
+    }
+
+    const z = x()
+    z.setTitle("bla")
+    z.title = "bla"
+    // z.title = 3 // Test manual: should give compile error
+})
+
+test(".Type should not be callable", t => {
+    const Todo = types.model({
+        title: types.string,
+        setTitle(v: string) {
+
+        }
+    })
+
+    t.throws(() => Todo.Type)
+})


### PR DESCRIPTION
* [x] implement
* [x] document (update bottom section of readme which is accidentally in one of the other open PR's)

cc @mattiamanzati  @RainerAtSpirit