### PR TITLE
Export also simple type to allow for easier typing of frozen types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import "./types/complex-types/complex-type"
 // unescapeJsonPath
 
 export {
-    types, IType
+    types, IType, ISimpleType
 } from "./types"
 
 export * from "./core/mst-operations"


### PR DESCRIPTION
Example

```js
export const NumberFieldModel = types.model("Field", {
  value: types.number,
  validation: types.frozen as ISimpleType<RegExp>
});
```

instead of

```js
export const NumberFieldModel = types.model("Field", {
  value: types.number,
  validation: types.frozen as IType<RegExp, RegExp>
});
```