### PR TITLE
fix nextState bounds checking in box example

### DIFF
--- a/examples/boxes/src/stores/time.js
+++ b/examples/boxes/src/stores/time.js
@@ -19,7 +19,7 @@ export function previousState() {
 }
 
 export function nextState() {
-    if (currentFrame === states.length)
+    if (currentFrame === states.length - 1)
         return
     currentFrame++;
     applySnapshot(store, states[currentFrame])


### PR DESCRIPTION
It's too late when it's `states.length`...

![image](https://cloud.githubusercontent.com/assets/1001890/26297970/ee85e49a-3f07-11e7-8106-e4faefc5d141.png)
