### PR TITLE
fixed rendering issue for "clone" in api overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ Property types can only be used as direct member of a `types.model` type and not
 | `applyPatch(node, jsonPatch)` | Applies a JSON patch to a node in the tree |
 | `applySnapshot(node, snapshot)` | Updates a node with the given snapshot |
 | `asReduxStore(node)` | Wraps a node in a Redux store compatible api |
-| `clone(node, keepEnvironment?: true | false | newEnvironment)` | Creates a full clone of a certain node. By default preserves the same environment |
+| `clone(node, keepEnvironment?: true \| false \| newEnvironment)` | Creates a full clone of a certain node. By default preserves the same environment |
 | `connectReduxDevtools(removeDevModule, node)` | Connects a node to the redux development tools [example](https://github.com/mobxjs/mobx-state-tree/blob/b01fe97d427ca664f7ecc99349d10e58d08d2d98/examples/redux-todomvc/src/index.js)  |
 | `destroy(node)` | Kills a node, making it unusable. Removes it from any parent in the process |
 | `detach(node)` | Removes a node from it's current parent, and let's it live on as stand alone tree |


### PR DESCRIPTION
The markdown for "clone" method in the api overview is malformed due to not escaping the pipe symbol.