### PR TITLE
fix(union): Union.create() shouldn't ignore extra arguments

### DIFF
--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -18,7 +18,7 @@ export interface IType<S, T> {
     flags: TypeFlags
     is(thing: any): thing is S | T
     validate(thing: any, context: IContext): IValidationResult
-    create(snapshot?: S, environment?: any): T
+    create(snapshot?: S, environment?: any, parent?: MSTAdministration | null, subpath?: string): T
     isType: boolean
     describe(): string
     Type: T
@@ -67,3 +67,4 @@ export abstract class Type<S, T> implements IType<S, T> {
 import { fail } from "../utils"
 import { IMSTNode } from "../core/mst-node"
 import { IContext, IValidationResult } from "./type-checker"
+import { MSTAdministration } from "../core/mst-node-administration"

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -18,7 +18,7 @@ export interface IType<S, T> {
     flags: TypeFlags
     is(thing: any): thing is S | T
     validate(thing: any, context: IContext): IValidationResult
-    create(snapshot?: S, environment?: any, parent?: MSTAdministration | null, subpath?: string): T
+    create(snapshot?: S, environment?: any): T
     isType: boolean
     describe(): string
     Type: T

--- a/src/types/utility-types/union.ts
+++ b/src/types/utility-types/union.ts
@@ -1,6 +1,7 @@
-import {isType, IType, TypeFlags, Type} from "../type"
+import { isType, IType, TypeFlags, Type } from "../type"
 import { IContext, IValidationResult, typeCheckSuccess, typeCheckFailure, flattenTypeErrors, typecheck } from "../type-checker"
-import {fail} from "../../utils"
+import { MSTAdministration } from "../../core/mst-node-administration"
+import { fail } from "../../utils"
 
 export type ITypeDispatcher = (snapshot: any) => IType<any, any>
 
@@ -10,7 +11,7 @@ export class Union extends Type<any, any> {
 
     get flags () {
         let result: TypeFlags = 0
-        
+
         this.types.forEach(type => {
             result |= type.flags
         })
@@ -28,12 +29,12 @@ export class Union extends Type<any, any> {
         return "(" + this.types.map(factory => factory.describe()).join(" | ") + ")"
     }
 
-    create(value: any) {
+    create(value: any, environment: any = undefined, parent: MSTAdministration | null = null, subpath: string = "") {
         typecheck(this, value)
 
         // try the dispatcher, if defined
         if (this.dispatcher !== null) {
-            return this.dispatcher(value).create(value)
+            return this.dispatcher(value).create(value, environment, parent, subpath)
         }
 
         // find the most accomodating type
@@ -41,7 +42,7 @@ export class Union extends Type<any, any> {
         if (applicableTypes.length > 1)
              return fail(`Ambiguos snapshot ${JSON.stringify(value)} for union ${this.name}. Please provide a dispatch in the union declaration.`)
 
-        return applicableTypes[0].create(value)
+        return applicableTypes[0].create(value, environment, parent, subpath)
     }
 
     validate(value: any, context: IContext): IValidationResult {

--- a/src/types/utility-types/union.ts
+++ b/src/types/utility-types/union.ts
@@ -34,7 +34,7 @@ export class Union extends Type<any, any> {
 
         // try the dispatcher, if defined
         if (this.dispatcher !== null) {
-            return this.dispatcher(value).create(value, environment, parent, subpath)
+            return (this.dispatcher(value) as any).create(value, environment, parent, subpath)
         }
 
         // find the most accomodating type
@@ -42,7 +42,7 @@ export class Union extends Type<any, any> {
         if (applicableTypes.length > 1)
              return fail(`Ambiguos snapshot ${JSON.stringify(value)} for union ${this.name}. Please provide a dispatch in the union declaration.`)
 
-        return applicableTypes[0].create(value, environment, parent, subpath)
+        return (applicableTypes[0] as any).create(value, environment, parent, subpath)
     }
 
     validate(value: any, context: IContext): IValidationResult {


### PR DESCRIPTION
Children in type Union could be any type, currently means it could be either `SimpleType` or `ComplexType` so the rest arguments such as `environment, parent, subpath` shouldn't be ignored in method `Union.create()`.

I would have tried to declare the method `create` into the type `IComplexType` such as:
```
export interface IComplexType<S, T> extends IType<S, T & ISnapshottable<S> & IMSTNode> {
    create(snapshot?: S, environment?: any, parent?: MSTAdministration, subpath?: string): T
}
```
Then it might be a type `IComplexType<any, any>|IType<any, any>` or `IComplexType<any, any>|ISimpleType<any, any>` could be used in the Class Union.

But I'm confused with the current structure in MST:
```
IComplexType extends IType
ISimpleType extends IType
Type implements IType
```
So far so good, but why `ComplexType extends Type` rather than `ComplexType extends Type implements IComplexType`? It doesn't make sense to me.

Besides, if I use the union type like `IComplexType<any, any>|IType<any, any>` or `IComplexType<any, any>|ISimpleType<any, any>`, I wouldn't know how to distinguish them in runtime so that I cannot give it a specific assertion.

That's why finally I just changed the parameter declarations in `IType.create()`.

