### PR TITLE
Fix applySnapshot to map<string,boolean> bug

### DIFF
--- a/src/types/complex-types/map.ts
+++ b/src/types/complex-types/map.ts
@@ -158,7 +158,6 @@ export class MapType<S, T> extends ComplexType<{[key: string]: S}, IExtendedObse
                     fail(`A map of objects containing an identifier should always store the object under their own identifier. Trying to store key '${key}', but expected: '${item[identifierAttr]}'`)
                 // if snapshot[key] is non-primitive, and this.get(key) has a Node, update it, instead of replace
                 if (key in currentKeys && !isPrimitive(item)) {
-                    currentKeys[key] = true
                     maybeMST(
                         target.get(key),
                         propertyNode => {
@@ -172,6 +171,7 @@ export class MapType<S, T> extends ComplexType<{[key: string]: S}, IExtendedObse
                 } else {
                     target.set(key, item)
                 }
+                currentKeys[key] = true
             })
             Object.keys(currentKeys).forEach(key => {
                 if (currentKeys[key] === false)

--- a/test/map.ts
+++ b/test/map.ts
@@ -18,7 +18,7 @@ const createTestFactories = () => {
         types.map(
             ItemFactory
         ), {})
-    
+
     const PrimitiveMapFactory = types.model({
             boolean: types.map(types.boolean),
             string: types.map(types.string),
@@ -84,26 +84,15 @@ test("it should return a snapshot", (t) => {
 test("it should be the same each time", (t) => {
     const {PrimitiveMapFactory} = createTestFactories()
     const data = {
-        string: {
-            a: "a",
-            b: ""
-        },
-        boolean: {
-            c: true,
-            d: false
-        },
-        number: {
-            i: 0,
-            f: 1,
-            g: NaN
-        }
+        string: {a: "a", b: ""},
+        boolean: {a: true, b: false},
+        number: {a: 0, b: 42, c: NaN}
     }
     const doc = PrimitiveMapFactory.create(data)
-    unprotect(doc)
     t.deepEqual<any>(getSnapshot(doc), data)
-    doc.applySnapshot(data)
+    applySnapshot(doc, data)
     t.deepEqual<any>(getSnapshot(doc), data)
-    doc.applySnapshot(data)
+    applySnapshot(doc, data)
     t.deepEqual<any>(getSnapshot(doc), data)
 })
 

--- a/test/map.ts
+++ b/test/map.ts
@@ -18,8 +18,14 @@ const createTestFactories = () => {
         types.map(
             ItemFactory
         ), {})
+    
+    const PrimitiveMapFactory = types.model({
+            boolean: types.map(types.boolean),
+            string: types.map(types.string),
+            number: types.map(types.number)
+        }, {})
 
-    return {Factory, ItemFactory}
+    return {Factory, ItemFactory, PrimitiveMapFactory}
 }
 
 // === FACTORY TESTS ===
@@ -73,6 +79,32 @@ test("it should return a snapshot", (t) => {
     doc.set("hello", ItemFactory.create())
 
     t.deepEqual<any>(getSnapshot(doc), {hello: {to: "world"}})
+})
+
+test("it should be the same each time", (t) => {
+    const {PrimitiveMapFactory} = createTestFactories()
+    const data = {
+        string: {
+            a: "a",
+            b: ""
+        },
+        boolean: {
+            c: true,
+            d: false
+        },
+        number: {
+            i: 0,
+            f: 1,
+            g: NaN
+        }
+    }
+    const doc = PrimitiveMapFactory.create(data)
+    unprotect(doc)
+    t.deepEqual<any>(getSnapshot(doc), data)
+    doc.applySnapshot(data)
+    t.deepEqual<any>(getSnapshot(doc), data)
+    doc.applySnapshot(data)
+    t.deepEqual<any>(getSnapshot(doc), data)
 })
 
 // === PATCHES TESTS ===


### PR DESCRIPTION
Primitive types removes from the map on applySnapshot if key exists.

```javascript
const Store = types.model('Store', {
  tags: types.map(types.boolean),
})
let store = Store.create({tags: {admin: true}})
console.log(JSON.stringify(getSnapshot(store)))
applySnapshot(store, {tags: {admin: true}})
console.log(JSON.stringify(getSnapshot(store)))
applySnapshot(store, {tags: {admin: true}})
console.log(JSON.stringify(getSnapshot(store)))
```
> Output:
> {"tags":{"admin":true}}
> {"tags":{}}
> {"tags":{"admin":true}}
