### PR TITLE
Fixed typo at documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ An example:
 
 ```javascript
 const TodoStore = types.model("TodoStore", {      // 1
-    loaded: type.boolean                          // 2
+    loaded: types.boolean                         // 2
     endpoint: "http://localhost",                 // 3
     todos: types.array(Todo),                     // 4
     selectedTodo: types.reference(Todo, "todos"), // 5


### PR DESCRIPTION
Fixed a typo at the Readme.md documentation.

It was missing an `s` at `Creating Models` first example, to be more specific at `type.boolean`, instead of `types.boolean`.