### PR TITLE
applySnapshot fails on types.maybe(complexType)

### DIFF
--- a/test/object.ts
+++ b/test/object.ts
@@ -92,6 +92,20 @@ test("it should apply snapshots", (t) => {
     t.deepEqual(getSnapshot(doc), {to: 'universe'})
 })
 
+test("it should apply and accept null value for types.maybe(complexType)", (t) => {
+  const Item = types.model({
+    value: types.string
+  })
+  const Model = types.model({
+    item: types.maybe(Item)
+  })
+  const myModel = Model.create()
+  applySnapshot(myModel, {item: {value: "something"}})
+  applySnapshot(myModel, {item: null})
+
+  t.deepEqual(getSnapshot(myModel), {item: null})
+})
+
 test("it should return a snapshot", (t) => {
     const {Factory} = createTestFactories()
     const doc = Factory.create()


### PR DESCRIPTION
Hello, thanks for your work, we love MST!

We stumbled upon a bug when applying snapshots to a `types.maybe`.
When we first set the value to a legal object, then set it to null, it fails type checking:

```
[Error: [mobx-state-tree] Error while converting `null` to `AnonymousModel`:
    value `null` is not assignable to type: `AnonymousModel`, expected an instance of `AnonymousModel` or a snapshot like `{ value: string }` instead.]
```

We noticed that the bug was fixed on the `box-all-the-things` branch and we're looking forward to testing it.

We thought we could contribute a test to ensure no regression happens in further versions.
