### PR TITLE
Allow Mobx observables as snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 test-lib
 coverage
 .nyc_output
+.idea

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 * Applying a snapshot or patches will now emit an action as well. The name of the emitted action will be `@APPLY_PATCHES`resp `@APPLY_SNAPSHOT`. See [#107](https://github.com/mobxjs/mobx-state-tree/issues/107)
 * Fixed issue where same Date instance could'nt be used two times in the same state tree [#229](https://github.com/mobxjs/mobx-state-tree/issues/229)
 * Declaring `types.maybe(types.frozen)` will now result into an error [#224](https://github.com/mobxjs/mobx-state-tree/issues/224)
+* Added support for Mobx observable arrays in type checks [#221](https://github.com/mobxjs/mobx-state-tree/issues/221) (from [alessioscalici](https://github.com/alessioscalici))
 
 # 0.9.0
 

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -1,4 +1,5 @@
 import { action as mobxAction, isObservable } from "mobx"
+import { isArray } from '../utils'
 
 export type ISerializedActionCall = {
     name: string
@@ -83,7 +84,7 @@ function serializeArgument(node: Node, actionName: string, index: number, arg: a
         throw new Error(
             `Argument ${index} that was passed to action '${actionName}' should be a primitive, model object or plain object, received a function`
         )
-    if (typeof arg === "object" && !isPlainObject(arg) && !Array.isArray(arg))
+    if (typeof arg === "object" && !isPlainObject(arg) && !isArray(arg))
         throw new Error(
             `Argument ${index} that was passed to action '${actionName}' should be a primitive, model object or plain object, received a ${(arg as any) &&
                 (arg as any).constructor

--- a/src/types/complex-types/array.ts
+++ b/src/types/complex-types/array.ts
@@ -18,7 +18,7 @@ import {
     isStateTreeNode,
     IStateTreeNode
 } from "../../core"
-import { addHiddenFinalProp, fail, isMutable } from "../../utils"
+import { addHiddenFinalProp, fail, isMutable, isArray } from "../../utils"
 import { ComplexType, IComplexType, IType } from "../type"
 import { TypeFlags } from "../type-flags"
 import {
@@ -189,12 +189,12 @@ export class ArrayType<S, T> extends ComplexType<S[], IObservableArray<T>> {
     }
 
     isValidSnapshot(value: any, context: IContext): IValidationResult {
-        if (!Array.isArray(value)) {
+        if (!isArray(value)) {
             return typeCheckFailure(context, value)
         }
 
         return flattenTypeErrors(
-            value.map((item, index) =>
+            value.map((item:any, index:any) =>
                 this.subType.validate(item, getContextForPath(context, "" + index, this.subType))
             )
         )

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,7 @@
+import {
+    isObservableArray
+} from 'mobx'
+
 declare const global: any
 
 export const EMPTY_ARRAY = Object.freeze([])
@@ -18,10 +22,14 @@ export function nothing(): null {
 
 export function noop() {}
 
+export function isArray(val: any): boolean {
+    return !!(Array.isArray(val) || isObservableArray(val)) as boolean
+}
+
 export function asArray<T>(val: undefined | null | T | T[]): T[] {
     if (!val) return (EMPTY_ARRAY as any) as T[]
-    if (Array.isArray(val)) return val
-    return [val]
+    if (isArray(val)) return val as T[]
+    return [val] as T[]
 }
 
 export function extend<A, B>(a: A, b: B): A & B

--- a/test/array.ts
+++ b/test/array.ts
@@ -11,6 +11,7 @@ import {
     types
 } from '../src'
 import { test } from 'ava'
+import { observable } from 'mobx'
 
 interface ITestSnapshot {
     to: string
@@ -395,4 +396,15 @@ test('it should not be allowed to add the same item twice to the same store', t 
     t.throws(() => {
         s.todos.push(b, b)
     }, "[mobx-state-tree] Cannot add an object to a state tree if it is already part of the same or another state tree. Tried to assign an object to '/todos/2', but it lives already at '/todos/1'")
+})
+
+test('it should support observable arrays', t => {
+
+    const TestArray = types.array(types.number)
+
+    const testArray = TestArray.create(observable([1, 2]))
+
+    t.true(testArray[0] === 1)
+    t.true(testArray.length === 2)
+    t.true(Array.isArray(testArray.slice()))
 })


### PR DESCRIPTION
Case scenario:
The user's state tree contains an array (types.array). The user wants to store a snapshot in a normal mobx observable. The array in the snapshot becomes an ObservableArray, thus it won't be matched anymore by Array.isArray (As described in https://mobx.js.org/best/pitfalls.html).
If the user tries to apply this snapshot with _applySnapshot_, the type check will fail.

This PR is to allow applying observable snapshots


