### PR TITLE
Increase validation information for OptionalValue

### DIFF
--- a/test/optional.ts
+++ b/test/optional.ts
@@ -47,6 +47,18 @@ at path "/0/quantity" value \`undefined\` is not assignable to type: \`number\`.
     )
 })
 
+test("it should throw bouncing errors from its sub-type", t => {
+    const Row = types.model({
+        name: types.string,
+        quantity: types.number
+    })
+    const RowList = types.optional(types.array(Row), [])
+
+    const error = t.throws(() => {
+        RowList.create([{ name: "a", quantity: 1 }, { name: "b", quantity: "x" }])
+    }, /at path "\/1\/quantity" value `"x"` is not assignable to type: `number`/g)
+})
+
 test("it should accept a function to provide dynamic values", t => {
     let defaultValue: any = 1
     const Factory = types.model({


### PR DESCRIPTION
Type validation errors at runtime were masked if the type was wrapped in an `OptionalValue`.

This was very annoying for large snapshots, since the specific model key that caused the error was difficult to find.

With this PR the model keys are explicitly listed in the error.

```js
const { types: t } = require('mobx-state-tree')
const Aaa = t.optional(t.array(t.model('Aaa', {a: t.number})), [])
Aaa.create([{a:1}, {a:2}, {a:3}, {}, {a:5}, {}])
```

Before:

    Error: [mobx-state-tree] Error while converting `[{"a":1},{"a":2},{"a":3},{},{"a":5},{}]` to `Aaa[]`:
    snapshot `[{"a":1},{"a":2},{"a":3},{},{"a":5},{}]` is not assignable to type: `Aaa[]`, expected an instance of `Aaa[]` or a snapshot like `{ a: number }[]?` instead.

After:

    Error: [mobx-state-tree] Error while converting `[{"a":1},{"a":2},{"a":3},{},{"a":5},{}]` to `Aaa[]`:
    at path "/3/a" value `undefined` is not assignable to type: `number`.
    at path "/5/a" value `undefined` is not assignable to type: `number`.

@mweststrate I'd like to work on console errors verbosity, I have in mind a couple of PRs on improving the message and details, are you open to it?