### PR TITLE
Improve validation messages making them more explanatory

### DIFF
--- a/src/types/complex-types/array.ts
+++ b/src/types/complex-types/array.ts
@@ -193,7 +193,7 @@ export class ArrayType<S, T> extends ComplexType<S[], IObservableArray<T>> {
 
     isValidSnapshot(value: any, context: IContext): IValidationResult {
         if (!isArray(value)) {
-            return typeCheckFailure(context, value)
+            return typeCheckFailure(context, value, "Value is not an array")
         }
 
         return flattenTypeErrors(

--- a/src/types/complex-types/map.ts
+++ b/src/types/complex-types/map.ts
@@ -246,7 +246,7 @@ export class MapType<S, T> extends ComplexType<{ [key: string]: S }, IExtendedOb
 
     isValidSnapshot(value: any, context: IContext): IValidationResult {
         if (!isPlainObject(value)) {
-            return typeCheckFailure(context, value)
+            return typeCheckFailure(context, value, "Value is not a plain object")
         }
 
         return flattenTypeErrors(

--- a/src/types/complex-types/object.ts
+++ b/src/types/complex-types/object.ts
@@ -241,7 +241,7 @@ export class ObjectType extends ComplexType<any, any> {
         let snapshot = this.preProcessSnapshot(value)
 
         if (!isPlainObject(snapshot)) {
-            return typeCheckFailure(context, snapshot)
+            return typeCheckFailure(context, snapshot, "Value is not a plain object")
         }
 
         return flattenTypeErrors(

--- a/src/types/primitives.ts
+++ b/src/types/primitives.ts
@@ -33,7 +33,7 @@ export class CoreType<S, T> extends Type<S, T> {
         if (isPrimitive(value) && this.checker(value)) {
             return typeCheckSuccess()
         }
-        return typeCheckFailure(context, value)
+        return typeCheckFailure(context, value, `Value is not a ${this.name}`)
     }
 }
 

--- a/src/types/primitives.ts
+++ b/src/types/primitives.ts
@@ -33,7 +33,8 @@ export class CoreType<S, T> extends Type<S, T> {
         if (isPrimitive(value) && this.checker(value)) {
             return typeCheckSuccess()
         }
-        return typeCheckFailure(context, value, `Value is not a ${this.name}`)
+        const typeName = this.name === "Date" ? "Date or a unix milliseconds timestamp" : this.name
+        return typeCheckFailure(context, value, `Value is not a ${typeName}`)
     }
 }
 

--- a/src/types/property-types/volatile-property.ts
+++ b/src/types/property-types/volatile-property.ts
@@ -1,6 +1,12 @@
 import { extendObservable, IObjectWillChange } from "mobx"
 import { Property } from "./property"
-import { IContext, IValidationResult, getContextForPath, typeCheckFailure, typeCheckSuccess } from "../type-checker"
+import {
+    IContext,
+    IValidationResult,
+    getContextForPath,
+    typeCheckFailure,
+    typeCheckSuccess
+} from "../type-checker"
 import { fail } from "../../utils"
 
 export class VolatileProperty extends Property {
@@ -28,7 +34,7 @@ export class VolatileProperty extends Property {
             return typeCheckFailure(
                 getContextForPath(context, this.name),
                 snapshot[this.name],
-                "volatile state should not be provided in the snapshot"
+                "Volatile state should not be provided in the snapshot"
             )
         }
         return typeCheckSuccess()

--- a/src/types/utility-types/frozen.ts
+++ b/src/types/utility-types/frozen.ts
@@ -22,7 +22,11 @@ export class Frozen<T> extends Type<T, T> {
 
     isValidSnapshot(value: any, context: IContext): IValidationResult {
         if (!isSerializable(value)) {
-            return typeCheckFailure(context, value)
+            return typeCheckFailure(
+                context,
+                value,
+                "Value is not serializable and cannot be frozen"
+            )
         }
         return typeCheckSuccess()
     }

--- a/src/types/utility-types/identifier.ts
+++ b/src/types/utility-types/identifier.ts
@@ -51,7 +51,11 @@ export class IdentifierType<T> extends Type<T, T> {
             typeof value === "number"
         )
             return this.identifierType.validate(value, context)
-        return typeCheckFailure(context, value, "References should be a primitive value")
+        return typeCheckFailure(
+            context,
+            value,
+            "Value is not a valid identifier, which is a string or a number"
+        )
     }
 }
 

--- a/src/types/utility-types/literal.ts
+++ b/src/types/utility-types/literal.ts
@@ -1,7 +1,12 @@
 import { ISimpleType, Type } from "../type"
 import { TypeFlags } from "../type-flags"
 import { fail, isPrimitive } from "../../utils"
-import { IContext, IValidationResult, typeCheckSuccess, typeCheckFailure } from "../type-checker"
+import {
+    IContext,
+    IValidationResult,
+    typeCheckSuccess,
+    typeCheckFailure
+} from "../type-checker"
 import { Node, createNode } from "../../core"
 
 export class Literal<T> extends Type<T, T> {
@@ -25,7 +30,11 @@ export class Literal<T> extends Type<T, T> {
         if (isPrimitive(value) && value === this.value) {
             return typeCheckSuccess()
         }
-        return typeCheckFailure(context, value)
+        return typeCheckFailure(
+            context,
+            value,
+            `Value is not a literal ${JSON.stringify(this.value)}`
+        )
     }
 }
 

--- a/src/types/utility-types/literal.ts
+++ b/src/types/utility-types/literal.ts
@@ -1,12 +1,7 @@
 import { ISimpleType, Type } from "../type"
 import { TypeFlags } from "../type-flags"
 import { fail, isPrimitive } from "../../utils"
-import {
-    IContext,
-    IValidationResult,
-    typeCheckSuccess,
-    typeCheckFailure
-} from "../type-checker"
+import { IContext, IValidationResult, typeCheckSuccess, typeCheckFailure } from "../type-checker"
 import { Node, createNode } from "../../core"
 
 export class Literal<T> extends Type<T, T> {
@@ -14,7 +9,7 @@ export class Literal<T> extends Type<T, T> {
     readonly flags = TypeFlags.Literal
 
     constructor(value: any) {
-        super("" + value)
+        super(JSON.stringify(value))
         this.value = value
     }
 

--- a/src/types/utility-types/reference.ts
+++ b/src/types/utility-types/reference.ts
@@ -95,9 +95,7 @@ export class ReferenceType<T> extends Type<string | number, T> {
             : typeCheckFailure(
                   context,
                   value,
-                  `Value '${prettyPrintValue(
-                      value
-                  )}' is not a valid reference. Expected a string or number.`
+                  "Value is not a valid identifier, which is a string or a number"
               )
     }
 }

--- a/src/types/utility-types/refinement.ts
+++ b/src/types/utility-types/refinement.ts
@@ -33,14 +33,20 @@ export class Refinement<S, T> extends Type<S, T> {
     }
 
     isValidSnapshot(value: any, context: IContext): IValidationResult {
-        if (this.type.is(value)) {
-            const snapshot = isStateTreeNode(value) ? getStateTreeNode(value).snapshot : value
+        const subtypeErrors = this.type.validate(value, context)
+        if (subtypeErrors.length > 0) return subtypeErrors
 
-            if (this.predicate(snapshot)) {
-                return typeCheckSuccess()
-            }
+        const snapshot = isStateTreeNode(value) ? getStateTreeNode(value).snapshot : value
+
+        if (!this.predicate(snapshot)) {
+            return typeCheckFailure(
+                context,
+                value,
+                "Value does not respect the refinement predicate"
+            )
         }
-        return typeCheckFailure(context, value)
+
+        return typeCheckSuccess()
     }
 }
 

--- a/src/types/utility-types/union.ts
+++ b/src/types/utility-types/union.ts
@@ -77,14 +77,12 @@ export class Union extends Type<any, any> {
             return typeCheckFailure(
                 context,
                 value,
-                "Multiple types are applicable and no dispatch method is defined for the union"
+                "Multiple types are applicable for the union (hint: provide a dispatch function)"
             )
-        } else if (applicableTypes.length < 1) {
-            return typeCheckFailure(
-                context,
-                value,
-                "No type is applicable and no dispatch method is defined for the union"
-            ).concat(flattenTypeErrors(errors))
+        } else if (applicableTypes.length === 0) {
+            return typeCheckFailure(context, value, "No type is applicable for the union").concat(
+                flattenTypeErrors(errors)
+            )
         }
 
         return typeCheckSuccess()

--- a/test/action.ts
+++ b/test/action.ts
@@ -165,8 +165,11 @@ test("it should not be possible to set the wrong type", t => {
         () => {
             store.orders[0].setCustomer(store.orders[0])
         }, // wrong type!
-        "[mobx-state-tree] Error while converting <Order@/orders/0> to `reference(Customer) | null`:\n" +
-            "value of type Order: <Order@/orders/0> is not assignable to type: `reference(Customer) | null`, expected an instance of `reference(Customer) | null` or a snapshot like `(reference(Customer) | null?)` instead."
+        err =>
+            err.message.includes("[mobx-state-tree]") &&
+            err.message.includes("Order@/orders/0") &&
+            err.message.includes("type Order") &&
+            err.message.includes("reference(Customer) | null")
     )
 })
 
@@ -174,9 +177,10 @@ test("it should not be possible to pass the element of another tree", t => {
     const store1 = createTestStore()
     const store2 = createTestStore()
 
-    t.throws(() => {
-        store1.orders[0].setCustomer(store2.customers[0])
-    }, "Argument 0 that was passed to action 'setCustomer' is a model that is not part of the same state tree. Consider passing a snapshot or some representative ID instead")
+    t.throws(
+        () => store1.orders[0].setCustomer(store2.customers[0]),
+        "Argument 0 that was passed to action 'setCustomer' is a model that is not part of the same state tree. Consider passing a snapshot or some representative ID instead"
+    )
 })
 
 test("it should not be possible to pass an unserializable object", t => {

--- a/test/enum.ts
+++ b/test/enum.ts
@@ -36,6 +36,6 @@ test("should support anonymous enums", t => {
     // Note, any cast needed, compiler should correctly error otherwise
     t.throws(
         () => (l.color = "Blue" as any),
-        /Error while converting `"Blue"` to `Orange | Green | Red`/
+        /Error while converting `"Blue"` to `"Orange" | "Green" | "Red"`/
     )
 })

--- a/test/identifier.ts
+++ b/test/identifier.ts
@@ -38,17 +38,13 @@ test("should throw if multiple identifiers provided", t => {
 })
 
 test("should throw if identifier of wrong type", t => {
-    t.throws(
-        () => {
-            const Model = types.model("Model", {
-                id: types.identifier(types.number)
-            })
+    t.throws(() => {
+        const Model = types.model("Model", {
+            id: types.identifier(types.number)
+        })
 
-            Model.create({ id: "1" })
-        },
-        `[mobx-state-tree] Error while converting \`{"id":"1"}\` to \`Model\`:
-at path "/id" value \`"1"\` is not assignable to type: \`identifier(number)\`, expected an instance of \`identifier(number)\` or a snapshot like \`identifier(number)\` instead.`
-    )
+        Model.create({ id: "1" })
+    }, err => err.message.includes("[mobx-state-tree]") && err.message.includes("id") && err.message.includes('"1"') && err.message.includes("Model") && err.message.includes("/id") && err.message.includes("identifier(number)"))
 })
 
 test("identifier should be used only on model types - no parent provided", t => {

--- a/test/literal.ts
+++ b/test/literal.ts
@@ -11,13 +11,9 @@ test("it should allow only primitives", t => {
 
 test("it should fail if not optional and no default provided", t => {
     const Factory = types.literal("hello")
-    t.throws(
-        () => {
-            Factory.create()
-        },
-        `[mobx-state-tree] Error while converting \`undefined\` to \`hello\`:
-value \`undefined\` is not assignable to type: \`hello\`, expected an instance of \`hello\` or a snapshot like \`"hello"\` instead.`
-    )
+    t.throws(() => {
+        Factory.create()
+    }, err => err.message.includes("[mobx-state-tree]") && err.message.includes("undefined") && err.message.includes('"hello"') && err.message.includes("not assignable"))
 })
 
 test("it should throw if a different type is given", t => {
@@ -25,13 +21,9 @@ test("it should throw if a different type is given", t => {
         shouldBeOne: types.literal(1)
     })
 
-    const error = t.throws(
-        () => {
-            Factory.create({ shouldBeOne: 2 })
-        },
-        `[mobx-state-tree] Error while converting \`{"shouldBeOne":2}\` to \`TestFactory\`:
-at path "/shouldBeOne" value \`2\` is not assignable to type: \`1\`, expected an instance of \`1\` or a snapshot like \`1\` instead.`
-    )
+    const error = t.throws(() => {
+        Factory.create({ shouldBeOne: 2 })
+    }, err => err.message.includes("[mobx-state-tree]") && err.message.includes("TestFactory") && err.message.includes("/shouldBeOne") && err.message.includes("1") && err.message.includes("2") && err.message.includes("not assignable"))
 })
 
 test("it should support null type", t => {

--- a/test/map.ts
+++ b/test/map.ts
@@ -281,16 +281,12 @@ test("#192 - put should not throw when identifier is a number", t => {
         })
     })
 
-    t.throws(
-        () => {
-            todoStore.addTodo({
-                todo_id: "1",
-                title: "Test"
-            })
-        },
-        `[mobx-state-tree] Error while converting \`{"todo_id":"1","title":"Test"}\` to \`Todo\`:
-at path "/todo_id" value \`"1"\` is not assignable to type: \`identifier(number)\`, expected an instance of \`identifier(number)\` or a snapshot like \`identifier(number)\` instead.`
-    )
+    t.throws(() => {
+        todoStore.addTodo({
+            todo_id: "1",
+            title: "Test"
+        })
+    }, err => err.message.includes("[mobx-state-tree]") && err.message.includes("Todo") && err.message.includes("/todo_id") && err.message.includes('"1"') && err.message.includes("not assignable") && err.message.includes("identifier(number)"))
 })
 
 test("#192 - map should not mess up keys when putting twice", t => {

--- a/test/object.ts
+++ b/test/object.ts
@@ -242,13 +242,9 @@ test("it should have computed properties", t => {
 
 test("it should throw if snapshot has computed properties", t => {
     const { ComputedFactory } = createTestFactories()
-    const error = t.throws(
-        () => {
-            const doc = ComputedFactory.create({ area: 3 })
-        },
-        `[mobx-state-tree] Error while converting \`{"area":3}\` to \`AnonymousModel\`:
-at path "/area" value \`3\` is not assignable  (Computed properties should not be provided in the snapshot).`
-    )
+    const error = t.throws(() => {
+        const doc = ComputedFactory.create({ area: 3 })
+    }, err => err.message.includes("[mobx-state-tree]") && err.message.includes("AnonymousModel") && err.message.includes("/area") && err.message.includes("3") && err.message.toLowerCase().includes("computed properties"))
 })
 
 test("it should throw if a replaced object is read or written to", t => {

--- a/test/optional.ts
+++ b/test/optional.ts
@@ -35,16 +35,11 @@ test("it should throw if default value is invalid snapshot", t => {
         quantity: types.number
     })
 
-    const error = t.throws(
-        () => {
-            types.model({
-                rows: types.optional(types.array(Row), [{}])
-            })
-        },
-        `[mobx-state-tree] Error while converting \`[{}]\` to \`AnonymousModel[]\`:
-at path "/0/name" value \`undefined\` is not assignable to type: \`string\`.
-at path "/0/quantity" value \`undefined\` is not assignable to type: \`number\`.`
-    )
+    const error = t.throws(() => {
+        types.model({
+            rows: types.optional(types.array(Row), [{}])
+        })
+    }, err => err.message.includes("[mobx-state-tree]") && err.message.includes("AnonymousModel[]") && err.message.includes("/0/name") && err.message.includes("/0/quantity"))
 })
 
 test("it should throw bouncing errors from its sub-type", t => {
@@ -73,8 +68,11 @@ test("it should accept a function to provide dynamic values", t => {
     defaultValue = "hello world!"
     t.throws(
         () => Factory.create(),
-        `[mobx-state-tree] Error while converting \`"hello world!\"\` to \`number\`:
-value \`"hello world!"\` is not assignable to type: \`number\`.`
+        err =>
+            err.message.includes("[mobx-state-tree]") &&
+            err.message.includes("hello world!") &&
+            err.message.includes("not assignable") &&
+            err.message.includes("number")
     )
 })
 

--- a/test/reference.ts
+++ b/test/reference.ts
@@ -84,7 +84,7 @@ test("it should support prefixed paths in arrays", t => {
 })
 
 test("identifiers are required", t => {
-    const Todo = types.model({
+    const Todo = types.model("TodoTest", {
         id: types.identifier()
     })
 
@@ -93,8 +93,13 @@ test("identifiers are required", t => {
 
     t.throws(
         () => Todo.create(),
-        "[mobx-state-tree] Error while converting `{}` to `AnonymousModel`:\n" +
-            'at path "/id" value `undefined` is not assignable to type: `identifier(string)`, expected an instance of `identifier(string)` or a snapshot like `identifier(string)` instead.'
+        err =>
+            err.message.includes("[mobx-state-tree]") &&
+            err.message.includes("{}") &&
+            err.message.includes("TodoTest") &&
+            err.message.includes("undefined") &&
+            err.message.includes("identifier(string)") &&
+            err.message.includes("/id")
     )
 })
 
@@ -222,7 +227,12 @@ test("identifiers should only support types.string and types.number", t => {
                     id: types.identifier(types.model({ x: 1 }))
                 })
                 .create({ id: {} }),
-        /References should be a primitive value/
+        err =>
+            err.message.includes("[mobx-state-tree]") &&
+            err.message.includes("/id") &&
+            err.message.includes("not assignable") &&
+            err.message.includes("identifier") &&
+            err.message.includes("AnonymousModel")
     )
 })
 
@@ -524,10 +534,10 @@ test("it should support relative lookups", t => {
 })
 
 test("References are non-nullable by default", t => {
-    const Todo = types.model({
+    const Todo = types.model("TodoTest", {
         id: types.identifier(types.number)
     })
-    const Store = types.model({
+    const Store = types.model("StoreTest", {
         todo: types.maybe(Todo),
         ref: types.reference(Todo),
         maybeRef: types.maybe(types.reference(Todo))
@@ -556,20 +566,34 @@ test("References are non-nullable by default", t => {
     t.is(store.maybeRef, null)
     t.throws(
         () => store.ref,
-        "[mobx-state-tree] Failed to resolve reference of type AnonymousModel: '4' (in: /ref)"
+        err =>
+            err.message.includes("[mobx-state-tree]") &&
+            err.message.includes("reference") &&
+            err.message.includes("TodoTest") &&
+            err.message.includes("4") &&
+            err.message.includes("/ref")
     )
     store.maybeRef = 3 as any
     t.is(store.maybeRef, store.todo)
     store.maybeRef = 4 as any
     t.throws(
         () => store.maybeRef,
-        "[mobx-state-tree] Failed to resolve reference of type AnonymousModel: '4' (in: /maybeRef)"
+        err =>
+            err.message.includes("[mobx-state-tree]") &&
+            err.message.includes("reference") &&
+            err.message.includes("TodoTest") &&
+            err.message.includes("4") &&
+            err.message.includes("/maybeRef")
     )
     store.maybeRef = null
     t.is(store.maybeRef, null)
     t.throws(
         () => (store.ref = null as any),
-        "[mobx-state-tree] Error while converting `null` to `reference(AnonymousModel)`:\nvalue `null` is not assignable to type: `reference(AnonymousModel)` (Value '`null`' is not a valid reference. Expected a string or number.), expected an instance of `reference(AnonymousModel)` or a snapshot like `reference(AnonymousModel)` instead."
+        err =>
+            err.message.includes("[mobx-state-tree]") &&
+            err.message.includes("null") &&
+            err.message.includes("reference") &&
+            err.message.includes("TodoTest")
     )
 })
 

--- a/test/refinement.ts
+++ b/test/refinement.ts
@@ -16,7 +16,7 @@ test("it should allow if type and predicate is correct", t => {
 })
 
 test("it should throw if a correct type with failing predicate is given", t => {
-    const Factory = types.model({
+    const Factory = types.model("FactoryTest", {
         number: types.refinement(
             "positive number",
             types.optional(types.number, 0),
@@ -24,19 +24,11 @@ test("it should throw if a correct type with failing predicate is given", t => {
         )
     })
 
-    t.throws(
-        () => {
-            Factory.create({ number: "givenStringInstead" })
-        },
-        `[mobx-state-tree] Error while converting \`{"number":"givenStringInstead"}\` to \`AnonymousModel\`:
-at path "/number" value \`"givenStringInstead"\` is not assignable to type: \`positive number\`.`
-    )
+    t.throws(() => {
+        Factory.create({ number: "givenStringInstead" })
+    }, err => err.message.includes("[mobx-state-tree]") && err.message.includes('"givenStringInstead"') && err.message.includes("FactoryTest") && err.message.includes("/number") && err.message.includes("positive number"))
 
-    t.throws(
-        () => {
-            Factory.create({ number: -4 })
-        },
-        `[mobx-state-tree] Error while converting \`{"number":-4}\` to \`AnonymousModel\`:
-at path "/number" value \`-4\` is not assignable to type: \`positive number\`.`
-    )
+    t.throws(() => {
+        Factory.create({ number: -4 })
+    }, err => err.message.includes("[mobx-state-tree]") && err.message.includes("-4") && err.message.includes("FactoryTest") && err.message.includes("/number") && err.message.includes("positive number"))
 })

--- a/test/type-system.ts
+++ b/test/type-system.ts
@@ -1,5 +1,5 @@
-import { test } from 'ava'
-import { types, getSnapshot, unprotect } from '../src'
+import { test } from "ava"
+import { types, getSnapshot, unprotect } from "../src"
 
 const createTestFactories = () => {
     const Box = types.model({
@@ -21,20 +21,20 @@ const createTestFactories = () => {
     return { Box, Square, Cube }
 }
 
-test('it should recognize a valid snapshot', t => {
+test("it should recognize a valid snapshot", t => {
     const { Box } = createTestFactories()
 
     t.deepEqual(Box.is({ width: 1, height: 2 }), true)
     t.deepEqual(Box.is({ width: 1, height: 2, depth: 3 }), true)
 })
 
-test('it should recognize an invalid snapshot', t => {
+test("it should recognize an invalid snapshot", t => {
     const { Box } = createTestFactories()
 
-    t.deepEqual(Box.is({ width: '1', height: '2' }), false)
+    t.deepEqual(Box.is({ width: "1", height: "2" }), false)
 })
 
-test('it should check valid nodes as well', t => {
+test("it should check valid nodes as well", t => {
     const { Box } = createTestFactories()
 
     const doc = Box.create()
@@ -42,7 +42,7 @@ test('it should check valid nodes as well', t => {
     t.deepEqual(Box.is(doc), true)
 })
 
-test('it should check invalid nodes as well', t => {
+test("it should check invalid nodes as well", t => {
     const { Box } = createTestFactories()
 
     const doc = Box.create()
@@ -50,13 +50,13 @@ test('it should check invalid nodes as well', t => {
     t.deepEqual(types.model({ anotherAttr: types.number }).is(doc), false)
 })
 
-test('it should do typescript type inference correctly', t => {
+test("it should do typescript type inference correctly", t => {
     const A = types.model(
         {
             x: types.number,
             y: types.maybe(types.string),
             get z(): string {
-                return 'hi'
+                return "hi"
             },
             set z(v: string) {}
         },
@@ -70,7 +70,7 @@ test('it should do typescript type inference correctly', t => {
     )
 
     // factory is invokable
-    const a = A.create({ x: 2, y: '7' })
+    const a = A.create({ x: 2, y: "7" })
     unprotect(a)
 
     // property can be used as proper type
@@ -103,14 +103,14 @@ test('it should do typescript type inference correctly', t => {
     a.y = null
 
     const zz: string = a.z
-    a.z = 'test'
+    a.z = "test"
 
     b.sub.method()
 
     t.is(true, true) // supress no asserts warning
 })
 
-test('#66 - it should accept superfluous fields', t => {
+test("#66 - it should accept superfluous fields", t => {
     const Item = types.model({
         id: types.number,
         name: types.string
@@ -118,70 +118,73 @@ test('#66 - it should accept superfluous fields', t => {
 
     t.is(Item.is({}), false)
     t.is(Item.is({ id: 3 }), false)
-    t.is(Item.is({ id: 3, name: '' }), true)
-    t.is(Item.is({ id: 3, name: '', description: '' }), true)
+    t.is(Item.is({ id: 3, name: "" }), true)
+    t.is(Item.is({ id: 3, name: "", description: "" }), true)
 
-    const a = Item.create({ id: 3, name: '', description: 'bla' } as any)
+    const a = Item.create({ id: 3, name: "", description: "bla" } as any)
     t.is((a as any).description, undefined)
 })
 
-test('#66 - it should not require defaulted fields', t => {
+test("#66 - it should not require defaulted fields", t => {
     const Item = types.model({
         id: types.number,
-        name: types.optional(types.string, 'boo')
+        name: types.optional(types.string, "boo")
     })
 
     t.is(Item.is({}), false)
     t.is(Item.is({ id: 3 }), true)
-    t.is(Item.is({ id: 3, name: '' }), true)
-    t.is(Item.is({ id: 3, name: '', description: '' }), true)
+    t.is(Item.is({ id: 3, name: "" }), true)
+    t.is(Item.is({ id: 3, name: "", description: "" }), true)
 
-    const a = Item.create({ id: 3, description: 'bla' } as any)
+    const a = Item.create({ id: 3, description: "bla" } as any)
     t.is((a as any).description, undefined)
-    t.is(a.name, 'boo')
+    t.is(a.name, "boo")
 })
 
-test('#66 - it should be possible to omit defaulted fields', t => {
+test("#66 - it should be possible to omit defaulted fields", t => {
     const Item = types.model({
         id: types.number,
-        name: 'boo'
+        name: "boo"
     })
 
     t.is(Item.is({}), false)
     t.is(Item.is({ id: 3 }), true)
-    t.is(Item.is({ id: 3, name: '' }), true)
-    t.is(Item.is({ id: 3, name: '', description: '' }), true)
+    t.is(Item.is({ id: 3, name: "" }), true)
+    t.is(Item.is({ id: 3, name: "", description: "" }), true)
 
-    const a = Item.create({ id: 3, description: 'bla' } as any)
+    const a = Item.create({ id: 3, description: "bla" } as any)
     t.is((a as any).description, undefined)
-    t.is(a.name, 'boo')
+    t.is(a.name, "boo")
 })
 
-test('#66 - it should pick the correct type of defaulted fields', t => {
+test("#66 - it should pick the correct type of defaulted fields", t => {
     const Item = types.model({
         id: types.number,
-        name: 'boo'
+        name: "boo"
     })
 
     const a = Item.create({ id: 3 })
     unprotect(a)
 
-    t.is(a.name, 'boo')
+    t.is(a.name, "boo")
     t.throws(
         () => (a.name = 3 as any),
-        `[mobx-state-tree] Error while converting \`3\` to \`string\`:
-value \`3\` is not assignable to type: \`string\`.`
+        err =>
+            err.message.includes("[mobx-state-tree]") &&
+            err.message.includes("3") &&
+            err.message.includes("string") &&
+            err.message.includes("not assignable")
     )
 })
 
-test('cannot create factories with null values', t => {
+test("cannot create factories with null values", t => {
     t.throws(
         () => types.model({ x: null }),
         /The default value of an attribute cannot be null or undefined as the type cannot be inferred. Did you mean `types.maybe\(someType\)`?/
     )
 })
 
-test('can create factories with maybe primitives', t => {
+test("can create factories with maybe primitives", t => {
     const F = types.model({
         x: types.maybe(types.string)
     })
@@ -189,16 +192,16 @@ test('can create factories with maybe primitives', t => {
     t.is(F.is(undefined as any), false)
     t.is(F.is({}), true)
     t.is(F.is({ x: null }), true)
-    t.is(F.is({ x: 'test' }), true)
+    t.is(F.is({ x: "test" }), true)
     t.is(F.is({ x: 3 }), false)
 
     t.is(F.create().x, null)
     t.is(F.create({ x: undefined }).x, null)
-    t.is(F.create({ x: '' }).x, '')
-    t.is(F.create({ x: '3' }).x, '3')
+    t.is(F.create({ x: "" }).x, "")
+    t.is(F.create({ x: "3" }).x, "3")
 })
 
-test('it is possible to refer to a type', t => {
+test("it is possible to refer to a type", t => {
     const Todo = types.model(
         {
             title: types.string
@@ -209,20 +212,20 @@ test('it is possible to refer to a type', t => {
     )
 
     function x(): typeof Todo.Type {
-        return Todo.create({ title: 'test' }) as any // as any to make sure the type is not inferred accidentally
+        return Todo.create({ title: "test" }) as any // as any to make sure the type is not inferred accidentally
     }
 
     const z = x()
     unprotect(z)
 
-    z.setTitle('bla')
-    z.title = 'bla'
+    z.setTitle("bla")
+    z.title = "bla"
     // z.title = 3 // Test manual: should give compile error
 
     t.is(true, true) // supress no asserts warning
 })
 
-test('.Type should not be callable', t => {
+test(".Type should not be callable", t => {
     const Todo = types.model(
         {
             title: types.string
@@ -235,7 +238,7 @@ test('.Type should not be callable', t => {
     t.throws(() => Todo.Type)
 })
 
-test('.SnapshotType should not be callable', t => {
+test(".SnapshotType should not be callable", t => {
     const Todo = types.model(
         {
             title: types.string
@@ -248,22 +251,22 @@ test('.SnapshotType should not be callable', t => {
     t.throws(() => Todo.SnapshotType)
 })
 
-test('types instances with compatible snapshots should not be interchangeable', t => {
+test("types instances with compatible snapshots should not be interchangeable", t => {
     const A = types.model(
-        'A',
+        "A",
         {},
         {
             doA() {}
         }
     )
     const B = types.model(
-        'B',
+        "B",
         {},
         {
             doB() {}
         }
     )
-    const C = types.model('C', {
+    const C = types.model("C", {
         x: types.maybe(A)
     })
 
@@ -289,7 +292,7 @@ test('types instances with compatible snapshots should not be interchangeable', 
     }, /value of type B: <B@<root>> is not assignable to type: `A | null`/)
 })
 
-test('it handles complex types correctly', t => {
+test("it handles complex types correctly", t => {
     const Todo = types.model(
         {
             title: types.string
@@ -321,7 +324,7 @@ test('it handles complex types correctly', t => {
     t.is(true, true) // supress no asserts warning
 })
 
-test('it should provide detailed reasons why the value is not appicable', t => {
+test("it should provide detailed reasons why the value is not appicable", t => {
     const Todo = types.model(
         {
             title: types.string
@@ -332,6 +335,7 @@ test('it should provide detailed reasons why the value is not appicable', t => {
     )
 
     const Store = types.model(
+        "StoreTest",
         {
             todos: types.map(Todo),
             get amount() {
@@ -354,23 +358,28 @@ test('it should provide detailed reasons why the value is not appicable', t => {
         () =>
             Store.create({
                 todos: {
-                    '1': {
+                    "1": {
                         title: true,
-                        setTitle: 'hello'
+                        setTitle: "hello"
                     }
                 },
                 amount: 1,
-                getAmount: 'hello'
+                getAmount: "hello"
             }),
-        `[mobx-state-tree] Error while converting \`{"todos":{"1":{"title":true,"setTitle":"hello"}},"amount":1,"getAmount":"hello"}\` to \`AnonymousModel\`:
-at path "/todos/1/title" value \`true\` is not assignable to type: \`string\`.
-at path "/todos/1/setTitle" value \`"hello"\` is not assignable  (Action properties should not be provided in the snapshot).
-at path "/amount" value \`1\` is not assignable  (Computed properties should not be provided in the snapshot).
-at path "/getAmount" value \`"hello"\` is not assignable  (View properties should not be provided in the snapshot).`
+        err =>
+            err.message.includes("[mobx-state-tree]") &&
+            err.message.includes("StoreTest") &&
+            err.message.includes("/todos/1/title") &&
+            err.message.includes("/todos/1/setTitle") &&
+            err.message.includes("/amount") &&
+            err.message.includes("/getAmount") &&
+            err.message.toLowerCase().includes("action properties") &&
+            err.message.toLowerCase().includes("computed properties") &&
+            err.message.toLowerCase().includes("view properties")
     )
 })
 
-test('it should type compose correctly', t => {
+test("it should type compose correctly", t => {
     const Car = types.model(
         {
             wheels: 3
@@ -386,7 +395,7 @@ test('it should type compose correctly', t => {
 
     const Logger = types.model(
         {
-            logNode: 'test'
+            logNode: "test"
         },
         {
             log(msg: string) {}
@@ -394,17 +403,17 @@ test('it should type compose correctly', t => {
     )
 
     const LoggableCar = types.compose(Car, Logger)
-    const x = LoggableCar.create({ wheels: 3, logNode: 'test' /* compile error: x: 7  */ })
+    const x = LoggableCar.create({ wheels: 3, logNode: "test" /* compile error: x: 7  */ })
 
     //x.test() // compile error
     x.drive()
-    x.log('z')
+    x.log("z")
     x.connection.then(() => {})
 
     t.pass()
 })
 
-test('it should extend types correctly', t => {
+test("it should extend types correctly", t => {
     const Car = types.model(
         {
             wheels: 3
@@ -415,10 +424,10 @@ test('it should extend types correctly', t => {
     )
 
     const LoggableCar = types.compose(
-        'LoggableCar',
+        "LoggableCar",
         Car,
         {
-            logNode: 'test'
+            logNode: "test"
         },
         { connection: (null as any) as Promise<any> },
         {
@@ -428,11 +437,11 @@ test('it should extend types correctly', t => {
             }
         }
     )
-    const x = LoggableCar.create({ wheels: 3, logNode: 'test' /* compile error: x: 7  */ })
+    const x = LoggableCar.create({ wheels: 3, logNode: "test" /* compile error: x: 7  */ })
 
     // x.test() // compile error
     x.drive()
-    x.log('z')
+    x.log("z")
     x.connection.then(() => {})
 
     t.pass()

--- a/test/volatile.ts
+++ b/test/volatile.ts
@@ -13,14 +13,17 @@ test("it should support volatiles", t => {
     )
     t.is(Todo.create().y, 7)
     t.is(Todo.is({ x: 3, y: 2 }), false)
-    t.throws(() => Todo.create({ y: 2 } as any), /volatile state should not be provided in the snapshot/)
+    t.throws(
+        () => Todo.create({ y: 2 } as any),
+        /volatile state should not be provided in the snapshot/i
+    )
     const x = Todo.create()
     t.throws(
         () =>
             applySnapshot(x, {
                 y: 3
             }),
-        /volatile state should not be provided in the snapshot/
+        /volatile state should not be provided in the snapshot/i
     )
     unprotect(x)
     x.y = 7
@@ -31,7 +34,10 @@ test("it should support volatiles", t => {
 })
 
 test("should warn about non primitive props should survive reconciliation", t => {
-    t.throws(() => types.model({ id: types.identifier() }, { buf: {} }, {}), /Please provide an initializer/)
+    t.throws(
+        () => types.model({ id: types.identifier() }, { buf: {} }, {}),
+        /Please provide an initializer/
+    )
 })
 
 test("volatiles should survive reconciliation", t => {


### PR DESCRIPTION
This is a preliminary PR for the work I'd like to do on validation messages.

A quick example of the improved messages:

```diff
-snapshot X is not assignable to type: `Y` (No type is applicable and no dispatch method is defined for the union).
+snapshot X is not assignable to type: `Y` (No type is applicable for the union).

-snapshot X is not assignable to type: `Y`.
+snapshot X is not assignable to type: `Y` (Value is not a string).

-snapshot X is not assignable to type: `Y`.
+snapshot X is not assignable to type: `Y` (Value is not a boolean).

-snapshot X is not assignable to type: `Y`.
+snapshot X is not assignable to type: `Y` (Value is not a Date).

-snapshot X is not assignable to type: `Y`.
+snapshot X is not assignable to type: `Y` (Value is not a plain object).

-snapshot X is not assignable to type: `Y`.
+snapshot X is not assignable to type: `Y` (Value is not serializable and cannot be frozen).

-snapshot X is not assignable to type: `Y`.
+snapshot X is not assignable to type: `Y` (Value is not a literal null).

-snapshot X is not assignable to type: `Y`.
+snapshot X is not assignable to type: `Y` (Value is not a literal undefined).

-snapshot X is not assignable to type: `Y`.
+snapshot X is not assignable to type: `Y` (Value is not a literal 42).

-snapshot X is not assignable to type: `Y`.
+snapshot X is not assignable to type: `Y` (Value is not a literal "YOYO").

-snapshot X is not assignable to type: `Y`.
+snapshot X is not assignable to type: `Y` (Value is not a number).

```

The complete diff in [an example of validation error messages](https://github.com/caesarsol/mobx-state-tree/commit/e817f97b2df8ce6871b8a0144dc163b0229598d2) can be previewed [here](https://github.com/caesarsol/mobx-state-tree/commit/c48ddafde8eae9eab019e3899aaeb0dceaead25d#diff-643021844c7bcf7ea98b82b13768bd21).

**Note** that all the tests that check the error strings are now broken, I'll fix them if everything seems ok to you. If you agree I'll make them more decoupled from the specific error message as in [this example fixed test](https://github.com/mobxjs/mobx-state-tree/compare/master...caesarsol:validation-messages?expand=1#diff-6e925890810880df491b771eaf629fb3).

----

My next steps would be improving the messages' formatting and solving a [problem on the potentially unreadable pretty-printing of big JSON values](https://user-images.githubusercontent.com/1799710/28031696-69bed010-65a8-11e7-8aa6-f08d5b576794.png), on which I have a couple ideas.
