### PR TITLE
avoid apply snapshot if it is the same as the current one

### DIFF
--- a/src/core/node.ts
+++ b/src/core/node.ts
@@ -53,6 +53,9 @@ export class Node {
             }
         ).bind(this.storedValue)
         this.applySnapshot = createActionInvoker("@APPLY_SNAPSHOT", (snapshot: any) => {
+            // if the snapshot is the same as the current one, avoid performing a reconcile
+            if (snapshot === this.snapshot) return
+            // else, apply it by calling the type logic
             return this.type.applySnapshot(this, snapshot)
         }).bind(this.storedValue)
 

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -89,7 +89,9 @@ export abstract class ComplexType<S, T> implements IType<S, T> {
     }
 
     reconcile(current: Node, newValue: any): Node {
-        const { parent, subpath } = current
+        if (current.snapshot === newValue)
+            // newValue is the current snapshot of the node, noop
+            return current
         if (isStateTreeNode(newValue) && getStateTreeNode(newValue) === current)
             // the current node is the same as the new one
             return current
@@ -106,6 +108,7 @@ export abstract class ComplexType<S, T> implements IType<S, T> {
             return current
         }
         // current node cannot be recycled in any way
+        const { parent, subpath } = current
         current.die()
         // attempt to reuse the new one
         if (isStateTreeNode(newValue) && this.isAssignableFrom(getType(newValue))) {

--- a/test/optimizations.ts
+++ b/test/optimizations.ts
@@ -1,0 +1,36 @@
+import { getSnapshot, applySnapshot, unprotect, types } from "../src"
+import { test } from "ava"
+
+test("it should avoid processing patch if is exactly the current one in applySnapshot", t => {
+    let called = false
+    const Model = types.model({
+        a: types.number,
+        b: types.string
+    })
+
+    const store = Model.create({ a: 1, b: "hello" })
+    called = false
+
+    const snapshot = getSnapshot(store)
+    applySnapshot(store, snapshot)
+    t.is(getSnapshot(store), snapshot) // no new snapshot emitted
+})
+
+test("it should avoid processing patch if is exactly the current one in reconcile", t => {
+    const Model = types.model({
+        a: types.number,
+        b: types.string
+    })
+
+    const RootModel = types.model({
+        a: Model
+    })
+
+    const store = RootModel.create({ a: { a: 1, b: "hello" } })
+    unprotect(store)
+
+    const snapshot = getSnapshot(store)
+    store.a = snapshot.a
+    t.is(getSnapshot(store.a), snapshot.a)
+    t.deepEqual(getSnapshot(store), snapshot)
+})


### PR DESCRIPTION
Should address #251 
I think that checks in reconciler and applySnapshot should be enough, and they are actually pretty cheap. Am I missing something else?