### PR TITLE
Remove usage of eval to support usage of CSP self

### DIFF
--- a/src/types/complex-types/object.ts
+++ b/src/types/complex-types/object.ts
@@ -70,8 +70,8 @@ export class ObjectType extends ComplexType<any, any> {
         if (!/^\w[\w\d_]*$/.test(name)) fail(`Typename should be a valid identifier: ${name}`)
         // fancy trick to get a named function...., http://stackoverflow.com/questions/5905492/dynamic-function-name-in-javascript
         // Although object.defineProperty on a real function could also be used, that name is not used everywhere, for example when logging an object to the Chrome console, so this works better:
-        this.modelConstructor = function() {}
-        Object.defineProperty(this.modelConstructor, 'name', {
+        this.modelConstructor = class { }
+        Object.defineProperty(this.modelConstructor, "name", {
             value: name,
             writable: false
         })

--- a/src/types/complex-types/object.ts
+++ b/src/types/complex-types/object.ts
@@ -70,7 +70,11 @@ export class ObjectType extends ComplexType<any, any> {
         if (!/^\w[\w\d_]*$/.test(name)) fail(`Typename should be a valid identifier: ${name}`)
         // fancy trick to get a named function...., http://stackoverflow.com/questions/5905492/dynamic-function-name-in-javascript
         // Although object.defineProperty on a real function could also be used, that name is not used everywhere, for example when logging an object to the Chrome console, so this works better:
-        this.modelConstructor = new Function(`return function ${name} (){}`)()
+        this.modelConstructor = function() {}
+        Object.defineProperty(this.modelConstructor, 'name', {
+            value: name,
+            writable: false
+        })
         this.modelConstructor.prototype.toString = objectTypeToString
         this.parseModelProps()
         this.forAllProps(prop => prop.initializePrototype(this.modelConstructor.prototype))


### PR DESCRIPTION
Because of the fact that it uses a new Function(""), I have to use Content Security Policy script-src: 'unsafe-eval' insted of just 'self'.
Look's like Object.defineProperty also should work.

https://stackoverflow.com/a/40918734
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name#Description