### PR TITLE
Kill prototype usage

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,10 @@
+# 0.10.2
+
+* Object model instances no longer share a prototype.
+
 # 0.10.1
 
 * Removed accidental dependency on the codemod
-* Object model instances no longer share a prototype.
 
 # 0.10.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # 0.10.1
 
-Removed accidental dependency on the codemod
+* Removed accidental dependency on the codemod
+* Object model instances no longer share a prototype.
 
 # 0.10.0
 

--- a/src/core/node.ts
+++ b/src/core/node.ts
@@ -73,7 +73,7 @@ export class Node {
 
         let sawException = true
         try {
-            if (canAttachTreeNode) addReadOnlyProp(this.storedValue, "toJSON", toJSON)
+            if (canAttachTreeNode) addHiddenFinalProp(this.storedValue, "toJSON", toJSON)
 
             this._isRunningAction = true
             finalizeNewInstance(this, initialValue)

--- a/src/types/complex-types/object.ts
+++ b/src/types/complex-types/object.ts
@@ -231,7 +231,7 @@ export class ObjectType<S, T> extends ComplexType<S, T> implements IModelType<S,
 
     createNewInstance = () => {
         const instance = observable.shallowObject(EMPTY_OBJECT)
-        instance.toString = objectTypeToString
+        addHiddenFinalProp(instance, "toString", objectTypeToString)
         return instance as Object
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import { isObservableArray } from "mobx"
 declare const global: any
 
 export const EMPTY_ARRAY: ReadonlyArray<any> = Object.freeze([])
+export const EMPTY_OBJECT: {} = Object.freeze({})
 
 export type IDisposer = () => void
 

--- a/test/boxes-store.ts
+++ b/test/boxes-store.ts
@@ -140,6 +140,7 @@ test("box operations works correctly", t => {
         arrows: [{ id: "dd", from: "cc", to: "aa" }, { id: "aa2b", from: "aa", to: "b" }],
         selection: "b"
     })
+    t.deepEqual(JSON.stringify(s), JSON.stringify(getSnapshot(s)))
     s.boxes.get("a")!.move(50, 50)
     t.deepEqual(getSnapshot(s), {
         boxes: {


### PR DESCRIPTION
The prototype is not (hardly) used in MST. The benefits of prototypes were: 

* `instanceof` checks could potentially be used, although nowhere documented.
* Sharing of methods. The only shared method atm was `toString` though

Benefits of not using prototypes: Better interoperability with other libraries. In fact, with this change `JSON.stringify(obj) === JSON.stringify(getSnapshot(obj))`

Probably fixes #316 as a side effect