### PR TITLE
fixing incomplete types.identifier() call and default value for maps

### DIFF
--- a/src/types/complex-types/map.ts
+++ b/src/types/complex-types/map.ts
@@ -273,7 +273,7 @@ export class MapType<S, T> extends ComplexType<{ [key: string]: S }, IExtendedOb
  *
  * @example
  * const Todo = types.model({
- *   id: types.identifier,
+ *   id: types.identifier(),
  *   task: types.string
  * })
  *
@@ -281,7 +281,7 @@ export class MapType<S, T> extends ComplexType<{ [key: string]: S }, IExtendedOb
  *   todos: types.map(Todo)
  * })
  *
- * const s = TodoStore.create({ todos: [] })
+ * const s = TodoStore.create({ todos: {} })
  * s.todos.set(17, { task: "Grab coffee", id: 17 })
  * s.todos.put({ task: "Grab cookie", id: 18 }) // put will infer key from the identifier
  * console.log(s.todos.get(17)) // prints: "Grab coffee"


### PR DESCRIPTION
` id: types.identifier,` throws
> Error: [mobx-state-tree] Functions are not supported as properties, use views instead

`const s = TodoStore.create({ todos: [] })` throws

> [mobx-state-tree] Error while converting `{"todos":[]}` to `AnonymousModel`:
> at path "/todos" snapshot `[]` is not assignable to type: `map<string, Todo>` (Value is not a plain object), expected an instance of `map<string, Todo>` or a snapshot like `Map<string, { id: identifier(string); task: string }>` instead.
