### PR TITLE
[ready to merge] New array reconciler algo

### DIFF
--- a/test/array.ts
+++ b/test/array.ts
@@ -316,6 +316,26 @@ test("it correctly reconciliate when swapping", t => {
     t.deepEqual(s.todos.map(getPath), ["/todos/0", "/todos/1"])
 })
 
+test("it correctly reconciliate when swapping using snapshots", t => {
+    const Task = types.model("Task", {})
+    const Store = types.model({
+        todos: types.optional(types.array(Task), [])
+    })
+    const s = Store.create()
+    unprotect(s)
+    const a = Task.create()
+    const b = Task.create()
+    s.todos.push(a, b)
+    s.todos.replace([getSnapshot(b), getSnapshot(a)])
+    t.true(s.todos[0] === b)
+    t.true(s.todos[1] === a)
+    t.deepEqual(s.todos.map(getPath), ["/todos/0", "/todos/1"])
+    s.todos.push({})
+    t.true(s.todos[0] === b)
+    t.true(s.todos[1] === a)
+    t.deepEqual(s.todos.map(getPath), ["/todos/0", "/todos/1", "/todos/2"])
+})
+
 test("it should not be allowed to add the same item twice to the same store", t => {
     const Task = types.model("Task", {})
     const Store = types.model({


### PR DESCRIPTION
This is a new algo for the array reconciler.
Instead of performing 3/4 for loops through all the nodes, it will instead perform all the steps of reconciling in one pass.
The algo will try to do its best job and also supports reconciling based on snapshot reference identity.
If you pick the snapshot of an array element without identifier and move it along the array, this algo will identify it by checking if oldNode.snapshot === newValue.
This means that if you move around snapshot of array elements with nodes without identifiers, it will reuse the existing node for that snapshot.
This could open for new ways of managing arrays of !isStateTreeNode() elements that should be less memory-stressfull as it would reuse existing nodes instead of dropping and recreating them.