### PR TITLE
Fix types.map example errors

### DIFF
--- a/API.md
+++ b/API.md
@@ -767,18 +767,27 @@ This type will always produce [observable maps](https://mobx.js.org/refguide/map
 
 ```javascript
 const Todo = types.model({
-  id: types.identifier,
-  task: types.string
+    id: types.identifier(types.number),
+    task: types.string
 })
 
-const TodoStore = types.model({
-  todos: types.map(Todo)
-})
+const TodoStore = types
+    .model({
+        todos: types.map(Todo)
+    })
+    .actions(self => ({
+        setTodo(id, todo) {
+            self.todos.set(id, todo)
+        },
+        putTodo(todo) {
+            self.todos.set(todo.id, todo)
+        }
+    }))
 
-const s = TodoStore.create({ todos: [] })
-s.todos.set(17, { task: "Grab coffee", id: 17 })
-s.todos.put({ task: "Grab cookie", id: 18 }) // put will infer key from the identifier
-console.log(s.todos.get(17)) // prints: "Grab coffee"
+const s = TodoStore.create({ todos: {} })
+s.setTodo(17, { task: "Grab coffee", id: 17 })
+s.putTodo({ task: "Grab cookie", id: 18 })
+console.log(s.todos.get(17).task) // prints: "Grab coffee"
 ```
 
 Returns **IComplexType&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;S>, IObservableArray&lt;T>>** 


### PR DESCRIPTION
The types.map example appears to be incomplete with numerous errors. I updated it so it actually works correctly.