### PR TITLE
fix: reversepatch key is empty when deleted an item from a nested map

### DIFF
--- a/src/core/node.ts
+++ b/src/core/node.ts
@@ -239,6 +239,7 @@ export class Node {
         this.patchSubscribers.splice(0)
         this._isAlive = false
         this._parent = null
+        this.subpath = ""
 
         // This is quite a hack, once interceptable objects / arrays / maps are extracted from mobx,
         // we could express this in a much nicer way

--- a/src/core/node.ts
+++ b/src/core/node.ts
@@ -239,7 +239,6 @@ export class Node {
         this.patchSubscribers.splice(0)
         this._isAlive = false
         this._parent = null
-        this.subpath = ""
 
         // This is quite a hack, once interceptable objects / arrays / maps are extracted from mobx,
         // we could express this in a much nicer way

--- a/test/map.ts
+++ b/test/map.ts
@@ -282,3 +282,21 @@ test("it should not throw when removing a non existing item from a map", t => {
         t.is(store.something(), false)
     })
 })
+
+test.cb("it should get map keys from reversePatch when deleted an item from a nested map", t => {
+    const AppModel = types
+        .model({
+            value: types.map(types.map(types.map(types.number)))
+        })
+        .actions(self => ({
+            remove(k) {
+                self.value.delete(k)
+            }
+        }))
+    const store = AppModel.create({ value: { a: { b: { c: 10 } } } })
+    onPatch(store, (patch, reversePatch) => {
+        t.deepEqual(reversePatch.value, { b: { c: 10 } })
+        t.end()
+    })
+    store.remove("a")
+})

--- a/test/map.ts
+++ b/test/map.ts
@@ -283,7 +283,7 @@ test("it should not throw when removing a non existing item from a map", t => {
     })
 })
 
-test.cb("it should get map keys from reversePatch when deleted an item from a nested map", t => {
+test("it should get map keys from reversePatch when deleted an item from a nested map", t => {
     const AppModel = types
         .model({
             value: types.map(types.map(types.map(types.number)))
@@ -296,7 +296,6 @@ test.cb("it should get map keys from reversePatch when deleted an item from a ne
     const store = AppModel.create({ value: { a: { b: { c: 10 } } } })
     onPatch(store, (patch, reversePatch) => {
         t.deepEqual(reversePatch.value, { b: { c: 10 } })
-        t.end()
     })
     store.remove("a")
 })


### PR DESCRIPTION
Fixes: #395