### PR TITLE
Fix for not being able to add to a map of a map when using environments

### DIFF
--- a/src/core/node.ts
+++ b/src/core/node.ts
@@ -314,7 +314,7 @@ export class Node {
             if (
                 !this._parent &&
                 !!this._environment &&
-                this._environment !== newParent._environment
+                this._environment !== newParent.root._environment
             ) {
                 fail(
                     `A state tree cannot be made part of another state tree as long as their environments are different.`

--- a/src/core/node.ts
+++ b/src/core/node.ts
@@ -313,8 +313,8 @@ export class Node {
             }
             if (
                 !this._parent &&
-                !!this._environment &&
-                this._environment !== newParent.root._environment
+                !!this.root._environment &&
+                this.root._environment !== newParent.root._environment
             ) {
                 fail(
                     `A state tree cannot be made part of another state tree as long as their environments are different.`

--- a/test/env.ts
+++ b/test/env.ts
@@ -49,7 +49,7 @@ test("detach should preserve environment", t => {
     t.is(todo.description, "test")
 })
 
-test("it possible to assign instance with the same environment as the parent to a tree", t => {
+test("it is possible to assign instance with the same environment as the parent to a tree", t => {
     const env = createEnvironment()
     const store = Store.create({ todos: [] }, env)
     const todo = Todo.create({}, env)
@@ -72,7 +72,7 @@ test("it is not possible to assign instance with a different environment than th
     )
 })
 
-test("it possible to set a value inside a map of a map when using the same environment", t => {
+test("it is possible to set a value inside a map of a map when using the same environment", t => {
     const env = createEnvironment()
     const EmptyModel = types.model({})
     const MapOfEmptyModel = types.model({

--- a/test/env.ts
+++ b/test/env.ts
@@ -74,25 +74,28 @@ test("it is not possible to assign instance with a different environment than th
 
 test("it possible to set a value inside a map of a map when using the same environment", t => {
     const env = createEnvironment()
-    const EmptyModel = types.model({});
+    const EmptyModel = types.model({})
     const MapOfEmptyModel = types.model({
-        map: types.map(EmptyModel),
-    });
+        map: types.map(EmptyModel)
+    })
     const MapOfMapOfEmptyModel = types.model({
-        map: types.map(MapOfEmptyModel),
-    });
-    const mapOfMap = MapOfMapOfEmptyModel.create({
-        map: {
-            whatever: {
-                map: {}
+        map: types.map(MapOfEmptyModel)
+    })
+    const mapOfMap = MapOfMapOfEmptyModel.create(
+        {
+            map: {
+                whatever: {
+                    map: {}
+                }
             }
         },
-    }, env);
-    unprotect(mapOfMap);
+        env
+    )
+    unprotect(mapOfMap)
     // this should not throw
-    mapOfMap.map.get('whatever')!.map.set('1234', EmptyModel.create({}, env));
+    mapOfMap.map.get("whatever")!.map.set("1234", EmptyModel.create({}, env))
     t.true(getEnv(mapOfMap) === env)
-    t.true(getEnv(mapOfMap.map.get('whatever')!.map.get('1234')!) === env)
+    t.true(getEnv(mapOfMap.map.get("whatever")!.map.get("1234")!) === env)
 })
 
 test("clone preserves environnment", t => {

--- a/test/env.ts
+++ b/test/env.ts
@@ -72,6 +72,29 @@ test("it is not possible to assign instance with a different environment than th
     )
 })
 
+test("it possible to set a value inside a map of a map when using the same environment", t => {
+    const env = createEnvironment()
+    const EmptyModel = types.model({});
+    const MapOfEmptyModel = types.model({
+        map: types.map(EmptyModel),
+    });
+    const MapOfMapOfEmptyModel = types.model({
+        map: types.map(MapOfEmptyModel),
+    });
+    const mapOfMap = MapOfMapOfEmptyModel.create({
+        map: {
+            whatever: {
+                map: {}
+            }
+        },
+    }, env);
+    unprotect(mapOfMap);
+    // this should not throw
+    mapOfMap.map.get('whatever')!.map.set('1234', EmptyModel.create({}, env));
+    t.true(getEnv(mapOfMap) === env)
+    t.true(getEnv(mapOfMap.map.get('whatever')!.map.get('1234')!) === env)
+})
+
 test("clone preserves environnment", t => {
     const env = createEnvironment()
     const store = Store.create({ todos: [{}] }, env)


### PR DESCRIPTION
Basically I stumbled upon a problem while trying to add a node to a map of a map when using environments, failing saying that the environments were not the same.

The newParent environment was undefined and this._environment was correctly set.
Upon checking getEnv (which was actually giving the proper value) I found out that the proper way to get a node environment is to use node.root._environment, and thus this fix.