### PR TITLE
Handle monitor actions from Redux DevTools

### DIFF
--- a/packages/mst-middlewares/src/redux.ts
+++ b/packages/mst-middlewares/src/redux.ts
@@ -67,6 +67,8 @@ export const connectReduxDevtools = function connectReduxDevtools(remoteDevDep: 
         }
     })
 
+    remotedev.init(model.toJSON())
+
     // Send changes to the remote monitor
     mst.onAction(model, action => {
         if (applyingSnapshot) return

--- a/packages/mst-middlewares/src/redux.ts
+++ b/packages/mst-middlewares/src/redux.ts
@@ -63,7 +63,7 @@ export const connectReduxDevtools = function connectReduxDevtools(remoteDevDep: 
         }
     })
 
-    const initialState = model.toJSON()
+    const initialState = mst.getSnapshot(model)
     remotedev.init(initialState)
 
     // Send changes to the remote monitor
@@ -85,7 +85,7 @@ export const connectReduxDevtools = function connectReduxDevtools(remoteDevDep: 
                 applySnapshot(model, initialState)
                 return remotedev.init(initialState)
             case "COMMIT":
-                return remotedev.init(model.toJSON())
+                return remotedev.init(mst.getSnapshot(model))
             case "ROLLBACK":
                 return remotedev.init(remoteDevDep.extractState(message))
             case "JUMP_TO_STATE":

--- a/packages/mst-middlewares/src/redux.ts
+++ b/packages/mst-middlewares/src/redux.ts
@@ -60,12 +60,6 @@ export const connectReduxDevtools = function connectReduxDevtools(remoteDevDep: 
     remotedev.subscribe((message: any) => {
         if (message.type === "DISPATCH") {
             handleMonitorActions(remotedev, model, message)
-            return
-        }
-        // Helper when only time travelling needed
-        const state = remoteDevDep.extractState(message)
-        if (state) {
-            applySnapshot(model, state)
         }
     })
 

--- a/packages/mst-middlewares/src/redux.ts
+++ b/packages/mst-middlewares/src/redux.ts
@@ -73,13 +73,17 @@ export const connectReduxDevtools = function connectReduxDevtools(remoteDevDep: 
     remotedev.init(initialState)
 
     // Send changes to the remote monitor
-    mst.onAction(model, action => {
-        if (applyingSnapshot) return
-        const copy: any = {}
-        copy.type = action.name
-        if (action.args) action.args.forEach((value, index) => (copy[index] = value))
-        remotedev.send(copy, mst.getSnapshot(model))
-    })
+    mst.onAction(
+        model,
+        action => {
+            if (applyingSnapshot) return
+            const copy: any = {}
+            copy.type = action.name
+            if (action.args) action.args.forEach((value, index) => (copy[index] = value))
+            remotedev.send(copy, mst.getSnapshot(model))
+        },
+        true
+    )
 
     function handleMonitorActions(remotedev: any, model: any, message: any) {
         switch (message.payload.type) {


### PR DESCRIPTION
Currently the `connectReduxDevtools` middleware have no handle monitor actions, in addition of jump state. It will be useful, we can reset state, commit actions, import / export state:

![2017-10-13 23_10_59](https://user-images.githubusercontent.com/3001525/31553075-e3a22490-affe-11e7-804b-0f757d8525cf.gif)

I have yet to handle `TOGGLE_ACTION`, so currently we can't use `SKIP` button.