### PR TITLE
enable model base type -- types.model<SomeBaseType>(...)

### DIFF
--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -439,7 +439,7 @@ export type Snapshot<T> = {
     [K in keyof T]?: Snapshot<T[K]> | any // Any because we cannot express conditional types yet, so this escape is needed for refs and such....
 }
 
-export function model<T = {}>(
+export function model<S = {}, T extends S = S>(
     name: string,
     properties?: IModelProperties<T>
 ): IModelType<Snapshot<T>, T>


### PR DESCRIPTION
Here's a use case for this PR:
```typescript
export type WalletType = {
   currency: string,
   amount: number,
}
// note: Wallet is used on API side:
export async function getWallet(user: UserType): Promise<WalletType> {
  ...
}
export const Wallet = types.model<WalletType>('wallet', {
  currency: types.string,
  amount: types.number,
})
.actions(self => ({
  action1() {
  },
});

const wallet = Wallet.create( ... )
// before this PR, wallet loses types defined in actions
wallet.action1(); // works with PR
```