### PR TITLE
undoManger - grouping & declarative withoutUndo

### DIFF
--- a/packages/mst-middlewares/README.md
+++ b/packages/mst-middlewares/README.md
@@ -360,13 +360,13 @@ import {undoManager} from './Store/'
 })
 ```
 
-StartGroup, EndGroup - within a react  component:
+StartGroup, StopGroup - within a react  component:
 ```js
 import {undoManager} from '../Store'
 ...
 handleStop = (mousePosition, { dx, dy }) => {
   this.stopTrackingDrag();
-  undoManager.endGroup();
+  undoManager.stopGroup();
 }
 
 handleDrag = (mousePosition, { dx, dy }) => {

--- a/packages/mst-middlewares/src/undo-manager.ts
+++ b/packages/mst-middlewares/src/undo-manager.ts
@@ -167,8 +167,9 @@ const UndoManager = types
                 return flow(function*() {
                     skipping = true
                     flagSkipping = true
-                    yield* generatorFn()
+                    const result = yield* generatorFn()
                     flagSkipping = false
+                    return result
                 })
             },
             startGroup(fn: () => any) {

--- a/packages/mst-middlewares/src/undo-manager.ts
+++ b/packages/mst-middlewares/src/undo-manager.ts
@@ -166,7 +166,7 @@ const UndoManager = types
                 grouping = true
                 return fn()
             },
-            endGroup(fn: () => any) {
+            stopGroup(fn: () => any) {
                 if (fn) fn()
                 grouping = false
                 ;(self as any).addUndoState(groupRecorder)

--- a/packages/mst-middlewares/src/undo-manager.ts
+++ b/packages/mst-middlewares/src/undo-manager.ts
@@ -1,5 +1,6 @@
 import {
     types,
+    flow,
     getEnv,
     recordPatches,
     addMiddleware,
@@ -161,6 +162,14 @@ const UndoManager = types
                 } finally {
                     flagSkipping = false
                 }
+            },
+            withoutUndoFlow(generatorFn: () => any) {
+                return flow(function*() {
+                    skipping = true
+                    flagSkipping = true
+                    yield* generatorFn()
+                    flagSkipping = false
+                })
             },
             startGroup(fn: () => any) {
                 grouping = true

--- a/packages/mst-middlewares/src/undo-manager.ts
+++ b/packages/mst-middlewares/src/undo-manager.ts
@@ -159,7 +159,8 @@ const UndoManager = types
                 grouping = true
                 return fn()
             },
-            endGroup() {
+            endGroup(fn: () => any) {
+                if (fn) fn()
                 grouping = false
                 ;(self as any).addUndoState(groupRecorder)
                 groupRecorder = { patches: [], inversePatches: [] }


### PR DESCRIPTION
- the undoManager can now handle actions within actions

 - similarly to withoutUndo users can now add groups like:
```
handleStop = (mousePosition, { dx, dy }) => {
  this.stopTrackingDrag();
  undoManager.stopGroup();
}

handleDrag = (mousePosition, { dx, dy }) => {
  if (dx === 0 && dy === 0) return;

  const { view, parentNode } = this.props;
  undoManager.startGroup(() =>
    parentNode.moveSelectedNodes({ dx: dx / view.zoom, dy: dy / view.zoom })
  );
}
```
