### PR TITLE
Fixed invalid relative paths to example middleware in README's

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Introduction blog post [The curious case of MobX state tree](https://medium.com/
 * [Tips](#tips)
 * [FAQ](#FAQ)
 * [Full Api Docs](API.md)
-* [Built-in / example middlewares](middleware/README.md)
+* [Built-in / example middlewares](packages/mst-middlewares/README.md)
 * [Changelog](changelog.md)
 
 # Installation

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -1,6 +1,6 @@
 # Middleware
 
-MST ships with a small set of [pre-built / example middlewares](../middleware/README.md)
+MST ships with a small set of [pre-built / example middlewares](../packages/mst-middlewares/README.md)
 
 Middleware can be used to intercept any action is invoked on the subtree where it is attached.
 If a tree is protected (by default), this means that any mutation of the tree will pass through your middleware.


### PR DESCRIPTION
 * In 1.1.0, example middleware were moved to a lerna folder structure
 * fixes #503 