### PR TITLE
Named models in Redux devtools

### DIFF
--- a/packages/mst-middlewares/src/redux.ts
+++ b/packages/mst-middlewares/src/redux.ts
@@ -53,7 +53,7 @@ function runMiddleWare(action: any, runners: any[], next: any) {
  */
 export const connectReduxDevtools = function connectReduxDevtools(remoteDevDep: any, model: any) {
     // Connect to the monitor
-    const remotedev = remoteDevDep.connectViaExtension()
+    const remotedev = remoteDevDep.connectViaExtension({name: mst.getType(model).name})
     let applyingSnapshot = false
 
     // Subscribe to change state (if need more than just logging)


### PR DESCRIPTION
This gives names in the redux devtools GUI as long as the model has a name to make it easy to track different models.