### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ This may be desired if the default protection of `mobx-state-tree` doesn't fit y
 Any fact that can be derived from your state is called a "view" or "derivation".
 See the [Mobx concepts & principles](https://mobx.js.org/intro/concepts.html) for some background.
 
-Views come in two flavors. Views with arguments and views without arguments. The latter are called computed values, based on the [computed](https://mobx.js.org/refguide/computed-decorator.html) concept in mobx. They main difference between the two is that computed properties create an explicit caching point, but further they work the same and any other computed value or Mobx based reaction like [`@observer`](https://mobx.js.org/refguide/observer-component.html) components can react to them. Computed values are defined using _getter_ functions.
+Views come in two flavors. Views with arguments and views without arguments. The latter are called computed values, based on the [computed](https://mobx.js.org/refguide/computed-decorator.html) concept in mobx. The main difference between the two is that computed properties create an explicit caching point, but further they work the same and any other computed value or Mobx based reaction like [`@observer`](https://mobx.js.org/refguide/observer-component.html) components can react to them. Computed values are defined using _getter_ functions.
 
 Example:
 


### PR DESCRIPTION
They main difference -> The main difference

btw. I'm not a native English speaker so I might be wrong (but I think not) - I've noticed that mweststrate often uses the apostrophe in a wrong way, eg. PR's (incorrect, and can be seen in the [readme](https://github.com/mobxjs/mobx-state-tree#philosophy--overview)) vs PRs - in this case the s denotes the plural form of "pull request" (which is "pull requests" and not "pull request's"). Using an s after an apostrophe is used to denote possession: eg. "Pull request's comments" - the comments that belong to a particular PR. It doesn't, however, work always. Eg. "That car belongs to her" <=> "That car is hers." (no apostrophe). I don't mean to give lessons here, but just wanna point this out, since @mweststrate is likely to do a lot of writing in the times to come (github readmes, conference slides...) and I think it would be nice to have it done correctly. :) Thanks for the lib!