### PR TITLE
change error layout to format error messages with prettied value long…

### DIFF
--- a/packages/mobx-state-tree/src/core/type/type-checker.ts
+++ b/packages/mobx-state-tree/src/core/type/type-checker.ts
@@ -35,6 +35,14 @@ export function prettyPrintValue(value: any) {
         : isStateTreeNode(value) ? `<${value}>` : `\`${safeStringify(value)}\``
 }
 
+function shortenPrintValue(valueInString: string) {
+    return valueInString.length < 280
+        ? valueInString
+        : `${valueInString.substring(0, 272)}......${valueInString.substring(
+              valueInString.length - 8
+          )}`
+}
+
 function toErrorString(error: IValidationError): string {
     const { value } = error
     const type: IType<any, any> = error.context[error.context.length - 1].type as any
@@ -116,9 +124,11 @@ export function typecheckPublic(type: IType<any, any>, value: any): void {
     const errors = type.validate(value, [{ path: "", type }])
 
     if (errors.length > 0) {
+        console.error("Failed to create `${type.name}` from:", value)
         fail(
-            `Error while converting ${prettyPrintValue(value)} to \`${type.name}\`:\n` +
-                errors.map(toErrorString).join("\n")
+            `Error while converting ${shortenPrintValue(
+                prettyPrintValue(value)
+            )} to \`${type.name}\`:\n\n` + errors.map(toErrorString).join("\n")
         )
     }
 }

--- a/packages/mobx-state-tree/src/core/type/type-checker.ts
+++ b/packages/mobx-state-tree/src/core/type/type-checker.ts
@@ -128,7 +128,7 @@ export function typecheckPublic(type: IType<any, any>, value: any): void {
         fail(
             `Error while converting ${shortenPrintValue(
                 prettyPrintValue(value)
-            )} to \`${type.name}\`:\n\n` + errors.map(toErrorString).join("\n")
+            )} to \`${type.name}\`:\n\n    ` + errors.map(toErrorString).join("\n    ")
         )
     }
 }

--- a/packages/mobx-state-tree/test-lib/test/__snapshots__/literal.js.snap
+++ b/packages/mobx-state-tree/test-lib/test/__snapshots__/literal.js.snap
@@ -2,10 +2,12 @@
 
 exports[`it should fail if not optional and no default provided 1`] = `
 "[mobx-state-tree] Error while converting \`undefined\` to \`\\"hello\\"\`:
+
 value \`undefined\` is not assignable to type: \`\\"hello\\"\` (Value is not a literal \\"hello\\"), expected an instance of \`\\"hello\\"\` or a snapshot like \`\\"hello\\"\` instead."
 `;
 
 exports[`it should throw if a different type is given 1`] = `
 "[mobx-state-tree] Error while converting \`{\\"shouldBeOne\\":2}\` to \`TestFactory\`:
+
 at path \\"/shouldBeOne\\" value \`2\` is not assignable to type: \`1\` (Value is not a literal 1), expected an instance of \`1\` or a snapshot like \`1\` instead."
 `;

--- a/packages/mobx-state-tree/test-lib/test/__snapshots__/literal.js.snap
+++ b/packages/mobx-state-tree/test-lib/test/__snapshots__/literal.js.snap
@@ -3,11 +3,11 @@
 exports[`it should fail if not optional and no default provided 1`] = `
 "[mobx-state-tree] Error while converting \`undefined\` to \`\\"hello\\"\`:
 
-value \`undefined\` is not assignable to type: \`\\"hello\\"\` (Value is not a literal \\"hello\\"), expected an instance of \`\\"hello\\"\` or a snapshot like \`\\"hello\\"\` instead."
+    value \`undefined\` is not assignable to type: \`\\"hello\\"\` (Value is not a literal \\"hello\\"), expected an instance of \`\\"hello\\"\` or a snapshot like \`\\"hello\\"\` instead."
 `;
 
 exports[`it should throw if a different type is given 1`] = `
 "[mobx-state-tree] Error while converting \`{\\"shouldBeOne\\":2}\` to \`TestFactory\`:
 
-at path \\"/shouldBeOne\\" value \`2\` is not assignable to type: \`1\` (Value is not a literal 1), expected an instance of \`1\` or a snapshot like \`1\` instead."
+    at path \\"/shouldBeOne\\" value \`2\` is not assignable to type: \`1\` (Value is not a literal 1), expected an instance of \`1\` or a snapshot like \`1\` instead."
 `;

--- a/packages/mobx-state-tree/test-lib/test/__snapshots__/reference.js.snap
+++ b/packages/mobx-state-tree/test-lib/test/__snapshots__/reference.js.snap
@@ -7,5 +7,5 @@ exports[`References are non-nullable by default 2`] = `"[mobx-state-tree] Failed
 exports[`References are non-nullable by default 3`] = `
 "[mobx-state-tree] Error while converting \`null\` to \`reference(AnonymousModel)\`:
 
-value \`null\` is not assignable to type: \`reference(AnonymousModel)\` (Value is not a valid identifier, which is a string or a number), expected an instance of \`reference(AnonymousModel)\` or a snapshot like \`reference(AnonymousModel)\` instead."
+    value \`null\` is not assignable to type: \`reference(AnonymousModel)\` (Value is not a valid identifier, which is a string or a number), expected an instance of \`reference(AnonymousModel)\` or a snapshot like \`reference(AnonymousModel)\` instead."
 `;

--- a/packages/mobx-state-tree/test-lib/test/__snapshots__/reference.js.snap
+++ b/packages/mobx-state-tree/test-lib/test/__snapshots__/reference.js.snap
@@ -6,5 +6,6 @@ exports[`References are non-nullable by default 2`] = `"[mobx-state-tree] Failed
 
 exports[`References are non-nullable by default 3`] = `
 "[mobx-state-tree] Error while converting \`null\` to \`reference(AnonymousModel)\`:
+
 value \`null\` is not assignable to type: \`reference(AnonymousModel)\` (Value is not a valid identifier, which is a string or a number), expected an instance of \`reference(AnonymousModel)\` or a snapshot like \`reference(AnonymousModel)\` instead."
 `;

--- a/packages/mobx-state-tree/test-lib/test/__snapshots__/union.js.snap
+++ b/packages/mobx-state-tree/test-lib/test/__snapshots__/union.js.snap
@@ -3,14 +3,14 @@
 exports[`it should complain about multiple applicable types no dispatch method 1`] = `
 "[mobx-state-tree] Error while converting \`{\\"width\\":2,\\"height\\":2}\` to \`(Box | Square)\`:
 
-snapshot \`{\\"width\\":2,\\"height\\":2}\` is not assignable to type: \`(Box | Square)\` (Multiple types are applicable for the union (hint: provide a dispatch function)), expected an instance of \`(Box | Square)\` or a snapshot like \`({ width: number; height: number } | { width: number })\` instead."
+    snapshot \`{\\"width\\":2,\\"height\\":2}\` is not assignable to type: \`(Box | Square)\` (Multiple types are applicable for the union (hint: provide a dispatch function)), expected an instance of \`(Box | Square)\` or a snapshot like \`({ width: number; height: number } | { width: number })\` instead."
 `;
 
 exports[`it should complain about no applicable types 1`] = `
 "[mobx-state-tree] Error while converting \`{\\"height\\":2}\` to \`(Cube | Box)\`:
 
-snapshot \`{\\"height\\":2}\` is not assignable to type: \`(Cube | Box)\` (No type is applicable for the union), expected an instance of \`(Cube | Box)\` or a snapshot like \`({ width: number; height: number; depth: number } | { width: number; height: number })\` instead.
-at path \\"/width\\" value \`undefined\` is not assignable to type: \`number\` (Value is not a number).
-at path \\"/depth\\" value \`undefined\` is not assignable to type: \`number\` (Value is not a number).
-at path \\"/width\\" value \`undefined\` is not assignable to type: \`number\` (Value is not a number)."
+    snapshot \`{\\"height\\":2}\` is not assignable to type: \`(Cube | Box)\` (No type is applicable for the union), expected an instance of \`(Cube | Box)\` or a snapshot like \`({ width: number; height: number; depth: number } | { width: number; height: number })\` instead.
+    at path \\"/width\\" value \`undefined\` is not assignable to type: \`number\` (Value is not a number).
+    at path \\"/depth\\" value \`undefined\` is not assignable to type: \`number\` (Value is not a number).
+    at path \\"/width\\" value \`undefined\` is not assignable to type: \`number\` (Value is not a number)."
 `;

--- a/packages/mobx-state-tree/test-lib/test/__snapshots__/union.js.snap
+++ b/packages/mobx-state-tree/test-lib/test/__snapshots__/union.js.snap
@@ -2,11 +2,13 @@
 
 exports[`it should complain about multiple applicable types no dispatch method 1`] = `
 "[mobx-state-tree] Error while converting \`{\\"width\\":2,\\"height\\":2}\` to \`(Box | Square)\`:
+
 snapshot \`{\\"width\\":2,\\"height\\":2}\` is not assignable to type: \`(Box | Square)\` (Multiple types are applicable for the union (hint: provide a dispatch function)), expected an instance of \`(Box | Square)\` or a snapshot like \`({ width: number; height: number } | { width: number })\` instead."
 `;
 
 exports[`it should complain about no applicable types 1`] = `
 "[mobx-state-tree] Error while converting \`{\\"height\\":2}\` to \`(Cube | Box)\`:
+
 snapshot \`{\\"height\\":2}\` is not assignable to type: \`(Cube | Box)\` (No type is applicable for the union), expected an instance of \`(Cube | Box)\` or a snapshot like \`({ width: number; height: number; depth: number } | { width: number; height: number })\` instead.
 at path \\"/width\\" value \`undefined\` is not assignable to type: \`number\` (Value is not a number).
 at path \\"/depth\\" value \`undefined\` is not assignable to type: \`number\` (Value is not a number).

--- a/packages/mobx-state-tree/test/action.ts
+++ b/packages/mobx-state-tree/test/action.ts
@@ -162,13 +162,9 @@ test("it should not be possible to pass a complex object", t => {
 if (process.env.NODE_ENV === "development") {
     test("it should not be possible to set the wrong type", t => {
         const store = createTestStore()
-        t.throws(
-            () => {
-                store.orders[0].setCustomer(store.orders[0])
-            }, // wrong type!
-            "[mobx-state-tree] Error while converting <Order@/orders/0> to `(reference(Customer) | null)`:\n" +
-                "value of type Order: <Order@/orders/0> is not assignable to type: `(reference(Customer) | null)`, expected an instance of `(reference(Customer) | null)` or a snapshot like `(reference(Customer) | null?)` instead."
-        )
+        t.throws(() => {
+            store.orders[0].setCustomer(store.orders[0])
+        }, "[mobx-state-tree] Error while converting <Order@/orders/0> to `(reference(Customer) | null)`:\n\n" + "value of type Order: <Order@/orders/0> is not assignable to type: `(reference(Customer) | null)`, expected an instance of `(reference(Customer) | null)` or a snapshot like `(reference(Customer) | null?)` instead.") // wrong type!
     })
 }
 

--- a/packages/mobx-state-tree/test/action.ts
+++ b/packages/mobx-state-tree/test/action.ts
@@ -164,7 +164,7 @@ if (process.env.NODE_ENV === "development") {
         const store = createTestStore()
         t.throws(() => {
             store.orders[0].setCustomer(store.orders[0])
-        }, "[mobx-state-tree] Error while converting <Order@/orders/0> to `(reference(Customer) | null)`:\n\n" + "value of type Order: <Order@/orders/0> is not assignable to type: `(reference(Customer) | null)`, expected an instance of `(reference(Customer) | null)` or a snapshot like `(reference(Customer) | null?)` instead.") // wrong type!
+        }, "[mobx-state-tree] Error while converting <Order@/orders/0> to `(reference(Customer) | null)`:\n\n    " + "value of type Order: <Order@/orders/0> is not assignable to type: `(reference(Customer) | null)`, expected an instance of `(reference(Customer) | null)` or a snapshot like `(reference(Customer) | null?)` instead.") // wrong type!
     })
 }
 

--- a/packages/mobx-state-tree/test/identifier.ts
+++ b/packages/mobx-state-tree/test/identifier.ts
@@ -85,7 +85,7 @@ if (process.env.NODE_ENV === "development") {
         t.throws(() => {
             const Model = types.model("Model", { id: types.identifier(types.number) })
             Model.create({ id: "1" })
-        }, `[mobx-state-tree] Error while converting \`{\"id\":\"1\"}\` to \`Model\`:\n\nat path \"/id\" value \`\"1\"\` is not assignable to type: \`identifier(number)\` (Value is not a number), expected an instance of \`identifier(number)\` or a snapshot like \`identifier(number)\` instead.`)
+        }, `[mobx-state-tree] Error while converting \`{\"id\":\"1\"}\` to \`Model\`:\n\n    at path \"/id\" value \`\"1\"\` is not assignable to type: \`identifier(number)\` (Value is not a number), expected an instance of \`identifier(number)\` or a snapshot like \`identifier(number)\` instead.`)
     })
 
     test("identifier should be used only on model types - no parent provided", t => {

--- a/packages/mobx-state-tree/test/identifier.ts
+++ b/packages/mobx-state-tree/test/identifier.ts
@@ -85,7 +85,7 @@ if (process.env.NODE_ENV === "development") {
         t.throws(() => {
             const Model = types.model("Model", { id: types.identifier(types.number) })
             Model.create({ id: "1" })
-        }, `[mobx-state-tree] Error while converting \`{\"id\":\"1\"}\` to \`Model\`:\nat path \"/id\" value \`\"1\"\` is not assignable to type: \`identifier(number)\` (Value is not a number), expected an instance of \`identifier(number)\` or a snapshot like \`identifier(number)\` instead.`)
+        }, `[mobx-state-tree] Error while converting \`{\"id\":\"1\"}\` to \`Model\`:\n\nat path \"/id\" value \`\"1\"\` is not assignable to type: \`identifier(number)\` (Value is not a number), expected an instance of \`identifier(number)\` or a snapshot like \`identifier(number)\` instead.`)
     })
 
     test("identifier should be used only on model types - no parent provided", t => {

--- a/packages/mobx-state-tree/test/map.ts
+++ b/packages/mobx-state-tree/test/map.ts
@@ -234,7 +234,7 @@ test("#192 - put should not throw when identifier is a number", t => {
     if (process.env.NODE_ENV === "development") {
         t.throws(() => {
             todoStore.addTodo({ todo_id: "1", title: "Test" })
-        }, `[mobx-state-tree] Error while converting \`{\"todo_id\":\"1\",\"title\":\"Test\"}\` to \`Todo\`:\n\nat path \"/todo_id\" value \`\"1\"\` is not assignable to type: \`identifier(number)\` (Value is not a number), expected an instance of \`identifier(number)\` or a snapshot like \`identifier(number)\` instead.`)
+        }, `[mobx-state-tree] Error while converting \`{\"todo_id\":\"1\",\"title\":\"Test\"}\` to \`Todo\`:\n\n    at path \"/todo_id\" value \`\"1\"\` is not assignable to type: \`identifier(number)\` (Value is not a number), expected an instance of \`identifier(number)\` or a snapshot like \`identifier(number)\` instead.`)
     }
 })
 

--- a/packages/mobx-state-tree/test/map.ts
+++ b/packages/mobx-state-tree/test/map.ts
@@ -234,7 +234,7 @@ test("#192 - put should not throw when identifier is a number", t => {
     if (process.env.NODE_ENV === "development") {
         t.throws(() => {
             todoStore.addTodo({ todo_id: "1", title: "Test" })
-        }, `[mobx-state-tree] Error while converting \`{\"todo_id\":\"1\",\"title\":\"Test\"}\` to \`Todo\`:\nat path \"/todo_id\" value \`\"1\"\` is not assignable to type: \`identifier(number)\` (Value is not a number), expected an instance of \`identifier(number)\` or a snapshot like \`identifier(number)\` instead.`)
+        }, `[mobx-state-tree] Error while converting \`{\"todo_id\":\"1\",\"title\":\"Test\"}\` to \`Todo\`:\n\nat path \"/todo_id\" value \`\"1\"\` is not assignable to type: \`identifier(number)\` (Value is not a number), expected an instance of \`identifier(number)\` or a snapshot like \`identifier(number)\` instead.`)
     }
 })
 

--- a/packages/mobx-state-tree/test/optional.ts
+++ b/packages/mobx-state-tree/test/optional.ts
@@ -64,7 +64,7 @@ test("it should accept a function to provide dynamic values", t => {
     if (process.env.NODE_ENV === "development") {
         t.throws(
             () => Factory.create(),
-            `[mobx-state-tree] Error while converting \`"hello world!"\` to \`number\`:\n\nvalue \`"hello world!"\` is not assignable to type: \`number\` (Value is not a number).`
+            `[mobx-state-tree] Error while converting \`"hello world!"\` to \`number\`:\n\n    value \`"hello world!"\` is not assignable to type: \`number\` (Value is not a number).`
         )
     }
 })

--- a/packages/mobx-state-tree/test/optional.ts
+++ b/packages/mobx-state-tree/test/optional.ts
@@ -64,7 +64,7 @@ test("it should accept a function to provide dynamic values", t => {
     if (process.env.NODE_ENV === "development") {
         t.throws(
             () => Factory.create(),
-            `[mobx-state-tree] Error while converting \`"hello world!"\` to \`number\`:\nvalue \`"hello world!"\` is not assignable to type: \`number\` (Value is not a number).`
+            `[mobx-state-tree] Error while converting \`"hello world!"\` to \`number\`:\n\nvalue \`"hello world!"\` is not assignable to type: \`number\` (Value is not a number).`
         )
     }
 })

--- a/packages/mobx-state-tree/test/reference.ts
+++ b/packages/mobx-state-tree/test/reference.ts
@@ -79,7 +79,7 @@ if (process.env.NODE_ENV === "development") {
         t.is(Todo.is({ id: "x" }), true)
         t.throws(
             () => Todo.create(),
-            "[mobx-state-tree] Error while converting `{}` to `AnonymousModel`:\n" +
+            "[mobx-state-tree] Error while converting `{}` to `AnonymousModel`:\n\n" +
                 'at path "/id" value `undefined` is not assignable to type: `identifier(string)` (Value is not a string), expected an instance of `identifier(string)` or a snapshot like `identifier(string)` instead.'
         )
     })

--- a/packages/mobx-state-tree/test/reference.ts
+++ b/packages/mobx-state-tree/test/reference.ts
@@ -80,7 +80,7 @@ if (process.env.NODE_ENV === "development") {
         t.throws(
             () => Todo.create(),
             "[mobx-state-tree] Error while converting `{}` to `AnonymousModel`:\n\n" +
-                'at path "/id" value `undefined` is not assignable to type: `identifier(string)` (Value is not a string), expected an instance of `identifier(string)` or a snapshot like `identifier(string)` instead.'
+                '    at path "/id" value `undefined` is not assignable to type: `identifier(string)` (Value is not a string), expected an instance of `identifier(string)` or a snapshot like `identifier(string)` instead.'
         )
     })
 

--- a/packages/mobx-state-tree/test/refinement.ts
+++ b/packages/mobx-state-tree/test/refinement.ts
@@ -24,10 +24,10 @@ if (process.env.NODE_ENV === "development") {
         })
         t.throws(() => {
             Factory.create({ number: "givenStringInstead" })
-        }, `[mobx-state-tree] Error while converting \`{\"number\":\"givenStringInstead\"}\` to \`AnonymousModel\`:\nat path \"/number\" value \`\"givenStringInstead\"\` is not assignable to type: \`positive number\` (Value is not a number).`)
+        }, `[mobx-state-tree] Error while converting \`{\"number\":\"givenStringInstead\"}\` to \`AnonymousModel\`:\n\nat path \"/number\" value \`\"givenStringInstead\"\` is not assignable to type: \`positive number\` (Value is not a number).`)
         t.throws(() => {
             Factory.create({ number: -4 })
-        }, `[mobx-state-tree] Error while converting \`{\"number\":-4}\` to \`AnonymousModel\`:\nat path \"/number\" value \`-4\` is not assignable to type: \`positive number\` (Value does not respect the refinement predicate).`)
+        }, `[mobx-state-tree] Error while converting \`{\"number\":-4}\` to \`AnonymousModel\`:\n\nat path \"/number\" value \`-4\` is not assignable to type: \`positive number\` (Value does not respect the refinement predicate).`)
     })
 
     test("it should throw custom error message with failing predicate is given", t => {
@@ -40,9 +40,9 @@ if (process.env.NODE_ENV === "development") {
         })
         t.throws(() => {
             Factory.create({ number: "givenStringInstead" })
-        }, `[mobx-state-tree] Error while converting \`{\"number\":\"givenStringInstead\"}\` to \`AnonymousModel\`:\nat path \"/number\" value \`\"givenStringInstead\"\` is not assignable to type: \`number\` (Value is not a number).`)
+        }, `[mobx-state-tree] Error while converting \`{\"number\":\"givenStringInstead\"}\` to \`AnonymousModel\`:\n\nat path \"/number\" value \`\"givenStringInstead\"\` is not assignable to type: \`number\` (Value is not a number).`)
         t.throws(() => {
             Factory.create({ number: -4 })
-        }, `[mobx-state-tree] Error while converting \`{\"number\":-4}\` to \`AnonymousModel\`:\nat path "/number" value \`-4\` is not assignable to type: \`number\` (A positive number was expected).`)
+        }, `[mobx-state-tree] Error while converting \`{\"number\":-4}\` to \`AnonymousModel\`:\n\nat path "/number" value \`-4\` is not assignable to type: \`number\` (A positive number was expected).`)
     })
 }

--- a/packages/mobx-state-tree/test/refinement.ts
+++ b/packages/mobx-state-tree/test/refinement.ts
@@ -24,10 +24,10 @@ if (process.env.NODE_ENV === "development") {
         })
         t.throws(() => {
             Factory.create({ number: "givenStringInstead" })
-        }, `[mobx-state-tree] Error while converting \`{\"number\":\"givenStringInstead\"}\` to \`AnonymousModel\`:\n\nat path \"/number\" value \`\"givenStringInstead\"\` is not assignable to type: \`positive number\` (Value is not a number).`)
+        }, `[mobx-state-tree] Error while converting \`{\"number\":\"givenStringInstead\"}\` to \`AnonymousModel\`:\n\n    at path \"/number\" value \`\"givenStringInstead\"\` is not assignable to type: \`positive number\` (Value is not a number).`)
         t.throws(() => {
             Factory.create({ number: -4 })
-        }, `[mobx-state-tree] Error while converting \`{\"number\":-4}\` to \`AnonymousModel\`:\n\nat path \"/number\" value \`-4\` is not assignable to type: \`positive number\` (Value does not respect the refinement predicate).`)
+        }, `[mobx-state-tree] Error while converting \`{\"number\":-4}\` to \`AnonymousModel\`:\n\n    at path \"/number\" value \`-4\` is not assignable to type: \`positive number\` (Value does not respect the refinement predicate).`)
     })
 
     test("it should throw custom error message with failing predicate is given", t => {
@@ -40,9 +40,9 @@ if (process.env.NODE_ENV === "development") {
         })
         t.throws(() => {
             Factory.create({ number: "givenStringInstead" })
-        }, `[mobx-state-tree] Error while converting \`{\"number\":\"givenStringInstead\"}\` to \`AnonymousModel\`:\n\nat path \"/number\" value \`\"givenStringInstead\"\` is not assignable to type: \`number\` (Value is not a number).`)
+        }, `[mobx-state-tree] Error while converting \`{\"number\":\"givenStringInstead\"}\` to \`AnonymousModel\`:\n\n    at path \"/number\" value \`\"givenStringInstead\"\` is not assignable to type: \`number\` (Value is not a number).`)
         t.throws(() => {
             Factory.create({ number: -4 })
-        }, `[mobx-state-tree] Error while converting \`{\"number\":-4}\` to \`AnonymousModel\`:\n\nat path "/number" value \`-4\` is not assignable to type: \`number\` (A positive number was expected).`)
+        }, `[mobx-state-tree] Error while converting \`{\"number\":-4}\` to \`AnonymousModel\`:\n\n    at path "/number" value \`-4\` is not assignable to type: \`number\` (A positive number was expected).`)
     })
 }

--- a/packages/mobx-state-tree/test/type-system.ts
+++ b/packages/mobx-state-tree/test/type-system.ts
@@ -152,7 +152,7 @@ test("#66 - it should pick the correct type of defaulted fields", t => {
     if (process.env.NODE_ENV === "development") {
         t.throws(
             () => (a.name = 3 as any),
-            `[mobx-state-tree] Error while converting \`3\` to \`string\`:\n\nvalue \`3\` is not assignable to type: \`string\` (Value is not a string).`
+            `[mobx-state-tree] Error while converting \`3\` to \`string\`:\n\n    value \`3\` is not assignable to type: \`string\` (Value is not a string).`
         )
     }
 })
@@ -345,7 +345,7 @@ if (process.env.NODE_ENV === "development") {
                 } as any),
             `[mobx-state-tree] Error while converting \`{"todos":{"1":{"title":true,"setTitle":"hello"}},"amount":1,"getAmount":"hello"}\` to \`AnonymousModel\`:
 
-at path "/todos/1/title" value \`true\` is not assignable to type: \`string\` (Value is not a string).`
+    at path "/todos/1/title" value \`true\` is not assignable to type: \`string\` (Value is not a string).`
 
             // MWE: TODO: Ideally (like in MST =< 0.9):
             // at path "/todos/1/setTitle" value \`"hello"\` is not assignable  (Action properties should not be provided in the snapshot).

--- a/packages/mobx-state-tree/test/type-system.ts
+++ b/packages/mobx-state-tree/test/type-system.ts
@@ -152,7 +152,7 @@ test("#66 - it should pick the correct type of defaulted fields", t => {
     if (process.env.NODE_ENV === "development") {
         t.throws(
             () => (a.name = 3 as any),
-            `[mobx-state-tree] Error while converting \`3\` to \`string\`:\nvalue \`3\` is not assignable to type: \`string\` (Value is not a string).`
+            `[mobx-state-tree] Error while converting \`3\` to \`string\`:\n\nvalue \`3\` is not assignable to type: \`string\` (Value is not a string).`
         )
     }
 })
@@ -344,6 +344,7 @@ if (process.env.NODE_ENV === "development") {
                     getAmount: "hello"
                 } as any),
             `[mobx-state-tree] Error while converting \`{"todos":{"1":{"title":true,"setTitle":"hello"}},"amount":1,"getAmount":"hello"}\` to \`AnonymousModel\`:
+
 at path "/todos/1/title" value \`true\` is not assignable to type: \`string\` (Value is not a string).`
 
             // MWE: TODO: Ideally (like in MST =< 0.9):


### PR DESCRIPTION
…er than 280 characters

----

Trying to make some changes to fix https://github.com/mobxjs/mobx-state-tree/issues/560

Changes made:

* added an extra `\n` in error to generate a new line.
* shorten value string in errors, which is longer than 280
* `console.error` to display the original value.
* add `\n` in existing tests.

There are still some concerns:

* `280` might not be the best choice, just it fits my case.
* `console.error()` is too verbose. however I can't use a string since it would be too long to display full value.