### PR TITLE
warning if snapshot undefined after postProcessSnapshot

### DIFF
--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -381,8 +381,14 @@ export class ModelType<S, T> extends ComplexType<S, T> implements IModelType<S, 
             ;(extras.getAtom(node.storedValue, name) as any).reportObserved()
             res[name] = this.getChildNode(node, name).snapshot
         })
-        if (typeof node.storedValue.postProcessSnapshot === "function")
-            return node.storedValue.postProcessSnapshot.call(null, res)
+        if (typeof node.storedValue.postProcessSnapshot === "function") {
+            const snapshot = node.storedValue.postProcessSnapshot.call(null, res)
+            if (!snapshot && process.env.NODE_ENV !== "production")
+                console.warn(
+                    "It's likely that there is custom middleware attached which doesn't return anything."
+                )
+            return snapshot
+        }
         return res
     }
 


### PR DESCRIPTION
since it's very unlikely someone returns undefined on purpose from within a postProcessSnapshot action, I added this warning since it cost me quite some time today and hope it might help others.