### PR TITLE
Fix TypeScript example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,7 +1145,7 @@ const TodoState = types.model({
     });
 
 type ITodoStateType = typeof TodoState.Type;
-interface ITodoState extends ITodoType {}
+interface ITodoState extends ITodoStateType {}
 
 const Todo = TodoState
     .actions(self: ITodoState  => ({


### PR DESCRIPTION
Fix example related to TypeScript types. Former code would have produced TypeScript compile-time error when using ITodoState.title (in the same example few lines bellow from the ITodoState declaration):
```
type ITodoStateType = typeof TodoState.Type;
interface ITodoState extends ITodoType {}

const Todo = TodoState
    .actions(self: ITodoState  => ({
        setTitle(v: string) {
            self.title = v
                  ^^^ error TS2339: Property 'title' does not exist on type 'ITodoState'.
        }
    }))
```