### PR TITLE
performance actionTrackingMiddleware

### DIFF
--- a/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts
+++ b/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts
@@ -22,6 +22,9 @@ import { IMiddlewareEvent, IMiddlewareHandler } from "../internal"
  * }} hooks
  * @returns {IMiddlewareHandler}
  */
+
+const runningActions = new Map<number, { async: boolean; call: IMiddlewareEvent; context: any }>()
+
 export function createActionTrackingMiddleware<T = any>(hooks: {
     filter?: (call: IMiddlewareEvent) => boolean
     onStart: (call: IMiddlewareEvent) => T
@@ -30,8 +33,6 @@ export function createActionTrackingMiddleware<T = any>(hooks: {
     onSuccess: (call: IMiddlewareEvent, context: T, result: any) => void
     onFail: (call: IMiddlewareEvent, context: T, error: any) => void
 }): IMiddlewareHandler {
-    const runningActions = new Map<number, { async: boolean; call: IMiddlewareEvent; context: T }>()
-
     return function actionTrackingMiddleware(
         call: IMiddlewareEvent,
         next: (actionCall: IMiddlewareEvent) => any
@@ -50,10 +51,12 @@ export function createActionTrackingMiddleware<T = any>(hooks: {
                         const res = next(call)
                         hooks.onSuspend(call, context)
                         if (runningActions.get(call.id)!.async === false) {
+                            runningActions.delete(call.id)
                             hooks.onSuccess(call, context, res)
                         }
                         return res
                     } catch (e) {
+                        runningActions.delete(call.id)
                         hooks.onFail(call, context, e)
                         throw e
                     }


### PR DESCRIPTION
reduce memory allocation (delete of recording entries)
and reduce gc collecting interval (by lifting the var) - noticeable for example when zooming

