### PR TITLE
fix: enhance types for modelType in Typescript 2.7.1

### DIFF
--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -191,7 +191,7 @@ export class ModelType<S, T> extends ComplexType<S, T> implements IModelType<S, 
 
     props<SP, TP>(
         properties: { [K in keyof TP]: IType<any, TP[K]> } & { [K in keyof SP]: IType<SP[K], any> }
-    ): IModelType<S & SP, T & TP> {
+    ): IModelType<S & SP & Snapshot<SP>, T & TP> {
         return this.cloneAndEnhance({ properties } as any)
     }
 


### PR DESCRIPTION
Today I also met the same problem #629  when I upgrade to Typescript 2.7.1
Maybe Typescript do more strict type checking to the instances.  

Actually I don't know the history or context of `ModelType`. I try to do something that fits to Typescript type checking.