### PR TITLE
Fix to typedefs for Typescript 2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
 	"private": true,
 	"dependencies": {
-		"lerna": "^2.4.0",
+		"cross-env": "^5.1.1",
 		"husky": "^0.13.4",
-		"prettier": "^1.4.4",
+		"lerna": "^2.4.0",
 		"lint-staged": "^3.6.1",
-		"cross-env":"^5.1.1"
+		"prettier": "^1.4.4"
 	},
 	"scripts": {
 		"clean": "lerna clean",

--- a/packages/mobx-state-tree/package.json
+++ b/packages/mobx-state-tree/package.json
@@ -55,7 +55,7 @@
     "tape": "^4.6.0",
     "tslib": "^1.7.1",
     "tslint": "^3.15.1",
-    "typescript": "^2.4.2"
+    "typescript": "^2.7.1"
   },
   "peerDependencies": {
     "mobx": "^3.1.15"

--- a/packages/mobx-state-tree/src/utils.ts
+++ b/packages/mobx-state-tree/src/utils.ts
@@ -51,8 +51,8 @@ export function extendKeepGetter(a: any, ...b: any[]) {
     for (let i = 0; i < b.length; i++) {
         const current = b[i]
         for (let key in current) {
-            const descriptor = Object.getOwnPropertyDescriptor(current, key)
-            if ("get" in descriptor) {
+            const descriptor = Object.getOwnPropertyDescriptor(current, key) || {}
+            if (descriptor && "get" in descriptor) {
                 Object.defineProperty(a, key, { ...descriptor, configurable: true })
                 continue
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10503,6 +10503,10 @@ typescript@^2.4.2:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
 
+typescript@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
+
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"


### PR DESCRIPTION
Related to #629 and #635.

These changes compile using the latest typescript (using`npm run quick-build`) but I don't know enough to know if they're correct or if a there's a better alternative.