### PR TITLE
Expose Snapshot type

### DIFF
--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -81,7 +81,8 @@ export {
     IActionRecorder,
     ISerializedActionCall,
     recordActions,
-    createActionTrackingMiddleware
+    createActionTrackingMiddleware,
+    Snapshot
 } from "./internal"
 
 export * from "./core/mst-operations"


### PR DESCRIPTION
Tiny PR for exposing Snapshot type which comes handy when wrapping model's creation to a function. It allows me to write.

```ts
function mockSomeModel(props: Snapshot<typeof SomeModel.Type>) {
  return SomeModel.create(props)
}
```

**Update**
Later I've realized that it doesn't work that well if there are some actions on the model. Is there some better way of getting a type of properties of a model without splitting those manually? I was trying this, but it messes up more then it gives.

```tsx
interface IModelProps {
  foo: string
}

const MyModel = types.model<IModelProps>({
  foo: types.string
})
```