### PR TITLE
fixes for typescript 2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
 	"private": true,
 	"dependencies": {
-		"lerna": "^2.4.0",
+		"cross-env": "^5.1.1",
 		"husky": "^0.13.4",
-		"prettier": "^1.4.4",
+		"lerna": "^2.4.0",
 		"lint-staged": "^3.6.1",
-		"cross-env":"^5.1.1"
+		"prettier": "^1.4.4"
 	},
 	"scripts": {
 		"clean": "lerna clean",

--- a/packages/mobx-state-tree/package.json
+++ b/packages/mobx-state-tree/package.json
@@ -55,7 +55,7 @@
     "tape": "^4.6.0",
     "tslib": "^1.7.1",
     "tslint": "^3.15.1",
-    "typescript": "^2.4.2"
+    "typescript": "^2.7.0"
   },
   "peerDependencies": {
     "mobx": "^3.1.15"

--- a/packages/mobx-state-tree/src/core/type/type-checker.ts
+++ b/packages/mobx-state-tree/src/core/type/type-checker.ts
@@ -124,7 +124,7 @@ export function typecheckPublic(type: IType<any, any>, value: any): void {
     const errors = type.validate(value, [{ path: "", type }])
 
     if (errors.length > 0) {
-        console.error("Failed to create `${type.name}` from:", value)
+        console.error(`Failed to create "${type.name}" from:`, value)
         fail(
             `Error while converting ${shortenPrintValue(
                 prettyPrintValue(value)

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -61,11 +61,12 @@ export class ArrayType<S, T> extends ComplexType<S[], IObservableArray<T>> {
         return array
     }
 
-    finalizeNewInstance = (node: ObjectNode, snapshot: any) => {
-        const instance = node.storedValue as IObservableArray<any>
-        extras.getAdministration(instance).dehancer = node.unbox
+    finalizeNewInstance = (node: INode, snapshot: any) => {
+        const objNode = node as ObjectNode
+        const instance = objNode.storedValue as IObservableArray<any>
+        extras.getAdministration(instance).dehancer = objNode.unbox
         intercept(instance, change => this.willChange(change) as any)
-        node.applySnapshot(snapshot)
+        objNode.applySnapshot(snapshot)
         observe(instance, this.didChange)
     }
 

--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -100,11 +100,12 @@ export class MapType<S, T> extends ComplexType<{ [key: string]: S }, IExtendedOb
         return map
     }
 
-    finalizeNewInstance = (node: ObjectNode, snapshot: any) => {
-        const instance = node.storedValue as ObservableMap<any>
-        extras.interceptReads(instance, node.unbox)
+    finalizeNewInstance = (node: INode, snapshot: any) => {
+        const objNode = node as ObjectNode
+        const instance = objNode.storedValue as ObservableMap<any>
+        extras.interceptReads(instance, objNode.unbox)
         intercept(instance, c => this.willChange(c))
-        node.applySnapshot(snapshot)
+        objNode.applySnapshot(snapshot)
         observe(instance, this.didChange)
     }
 

--- a/packages/mobx-state-tree/src/utils.ts
+++ b/packages/mobx-state-tree/src/utils.ts
@@ -51,7 +51,7 @@ export function extendKeepGetter(a: any, ...b: any[]) {
     for (let i = 0; i < b.length; i++) {
         const current = b[i]
         for (let key in current) {
-            const descriptor = Object.getOwnPropertyDescriptor(current, key)
+            const descriptor = Object.getOwnPropertyDescriptor(current, key)!
             if ("get" in descriptor) {
                 Object.defineProperty(a, key, { ...descriptor, configurable: true })
                 continue

--- a/packages/mobx-state-tree/test/action.ts
+++ b/packages/mobx-state-tree/test/action.ts
@@ -258,7 +258,7 @@ test("snapshot should be available and updated during an action", t => {
     const a = Model.create({ x: 2 })
     t.is(a.inc(), 3)
     t.is(a.x, 4)
-    t.is(getSnapshot(a).x, 4)
+    t.is(getSnapshot<typeof Model.SnapshotType>(a).x, 4)
 })
 
 test("indirectly called private functions should be able to modify state", t => {

--- a/packages/mobx-state-tree/test/hooks.ts
+++ b/packages/mobx-state-tree/test/hooks.ts
@@ -242,5 +242,5 @@ test("snapshot processors can be composed", t => {
         }))
     const x = X.create({ x: 25 })
     t.is(x.x, 2)
-    t.is(getSnapshot(x).x, 25)
+    t.is(getSnapshot<typeof X.SnapshotType>(x).x, 25)
 })

--- a/packages/mobx-state-tree/test/optimizations.ts
+++ b/packages/mobx-state-tree/test/optimizations.ts
@@ -24,7 +24,7 @@ test("it should avoid processing patch if is exactly the current one in reconcil
     })
     const store = RootModel.create({ a: { a: 1, b: "hello" } })
     unprotect(store)
-    const snapshot = getSnapshot(store)
+    const snapshot = getSnapshot<typeof Model.SnapshotType>(store)
     store.a = snapshot.a
     t.is(getSnapshot(store.a), snapshot.a)
     t.deepEqual(getSnapshot(store), snapshot)

--- a/packages/mobx-state-tree/test/primitives.ts
+++ b/packages/mobx-state-tree/test/primitives.ts
@@ -46,5 +46,5 @@ test("Date can be rehydrated using unix timestamp", t => {
     t.is(store.date.getTime(), time.getTime())
     applySnapshot(store, { date: newTime })
     t.is(store.date.getTime(), newTime)
-    t.is(getSnapshot(store).date, newTime)
+    t.is(getSnapshot<typeof Factory.SnapshotType>(store).date, newTime)
 })

--- a/packages/mobx-state-tree/tsconfig.json
+++ b/packages/mobx-state-tree/tsconfig.json
@@ -10,6 +10,8 @@
         "noImplicitAny": true,
         "moduleResolution": "node",
         "experimentalDecorators": true,
+        "strict": true,
+        "strictPropertyInitialization": false,
         "strictNullChecks": true,
         "noFallthroughCasesInSwitch": true,
         "noImplicitReturns": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10503,6 +10503,10 @@ typescript@^2.4.2:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
 
+typescript@^2.7.0:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
+
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"


### PR DESCRIPTION
Basic fixes for Typescript 2.7, tests passing.

The only problem seems to be with getSnapshot (and other stuff that uses ISnapshottable), which for new versions have to be manually typecasted to typeof Model.SnapshotType (e.g. ```getSnapshot<typeof Model.SnapshotType>(node)```)

This is basically because of this: https://github.com/Microsoft/TypeScript/pull/19513
ISnapshottable is basically now "merged" and lost into the new types, quoting:
```
When inferring multiple object literal types for a type parameter, the object literal types are normalized into a single inferred union type.
```
Since ISnapshottable is basically an empty interface it eventually gets lost. Probably there could be a way around this by adding some info that makes the interface unique, such as:
```
const snapshottableSymbol = Symbol();
export interface ISnapshottable {
  readonly [snapshottableSymbol]: true;
}
```
And while that made the type be applied again and not be lost, it couldn't be inferred on this check: ```export function getSnapshot<S>(target: ISnapshottable<S>): S```, probably due to this:
```
When checking a type relationship between a source type S and a target type T, if T is an object literal type, any excess properties in S are required to have type undefined (normally such excess properties are permitted to have any type).
```

On the good side the changes don't change how old versions of TS behave.