### PR TITLE
tryResolve can leave an object node in a bad state

### DIFF
--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -220,22 +220,20 @@ export class ObjectNode implements INode {
         this.assertAlive()
         this._autoUnbox = false
         try {
-            const res = this.type.getChildNode(this, subpath)
+            return this.type.getChildNode(this, subpath)
         } finally {
             this._autoUnbox = true
         }
-        return res
     }
 
     getChildren(): INode[] {
         this.assertAlive()
         this._autoUnbox = false
         try {
-            const res = this.type.getChildren(this)
+            return this.type.getChildren(this)
         } finally {
             this._autoUnbox = true
         }
-        return res
     }
 
     getChildType(key: string): IType<any, any> {

--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -219,16 +219,22 @@ export class ObjectNode implements INode {
     getChildNode(subpath: string): INode {
         this.assertAlive()
         this._autoUnbox = false
-        const res = this.type.getChildNode(this, subpath)
-        this._autoUnbox = true
+        try {
+            const res = this.type.getChildNode(this, subpath)
+        } finally {
+            this._autoUnbox = true
+        }
         return res
     }
 
     getChildren(): INode[] {
         this.assertAlive()
         this._autoUnbox = false
-        const res = this.type.getChildren(this)
-        this._autoUnbox = true
+        try {
+            const res = this.type.getChildren(this)
+        } finally {
+            this._autoUnbox = true
+        }
         return res
     }
 


### PR DESCRIPTION
if you `tryResolve(node, '/path_that_doesnt_exist')`, _autoUnbox is left === false
Doesn't make sense to have any simple `get` operations breaking the tree.
[Code Sandbox](https://mattiamanzati.github.io/mobx-state-tree-playground/#src=import%20React%20from%20%22react%22%0Aimport%20%7B%20types%2C%20tryResolve%20%7D%20from%20%22mobx-state-tree%22%0Aimport%20%7B%20observer%20%7D%20from%20%22mobx-react%22%0Aimport%20%7B%20inspect%2C%20render%20%7D%20from%20%22mobx-state-tree-playground%22%0A%0Aconst%20AppModel%20%3D%20types.model(%7B%0A%20%20item%3A%20types.model(%7B%0A%20%20%20%20count%3A%20types.optional(types.number%2C%201)%20%20%20%20%20%0A%20%20%7D).actions(self%20%3D%3E%20(%7B%0A%20%20%20%20increment()%7B%0A%20%20%20%20%20%20try%20%7B%0A%09console.log(tryResolve(store.item%2C%20'%2Fasd'))%0A%20%20%20%20%20%20%7D%20catch%20(e)%20%7B%0A%09console.log(e)%0A%09console.log(store.item.count)%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20self.count%2B%2B%0A%20%20%20%20%7D%2C%0A%20%20%20%20decrement()%20%7B%0A%20%20%20%20%20%20self.count--%0A%20%20%20%20%7D%0A%20%20%7D))%0A%7D)%0A%0Aconst%20store%20%3D%20AppModel.create(%7B%20item%3A%20%7B%7D%7D)%0A%2F%2Fstore.item.increment()%0A%0Aconst%20App%20%3D%20observer(%0A%20%20props%20%3D%3E%20%3Cdiv%3E%0A%20%20%20%20My%20awesome%20counter%3A%20%0A%20%20%20%20%3Cbutton%20onClick%3D%7B()%20%3D%3E%20props.store.item.decrement()%7D%3E-%3C%2Fbutton%3E%20%0A%20%20%20%20%7Bprops.store.item.count%7D%20%0A%20%20%20%20%3Cbutton%20onClick%3D%7B()%20%3D%3E%20props.store.item.increment()%7D%3E%2B%3C%2Fbutton%3E%20%0A%20%20%20%20%3C%2Fdiv%3E%0A)%0A%0Arender(%3CApp%20store%3D%7Bstore%7D%20%2F%3E)%0A)