### PR TITLE
middleware callback syntax - abort()

### DIFF
--- a/API.md
+++ b/API.md
@@ -33,6 +33,7 @@ _This reference guide lists all methods exposed by MST. Contributions like lingu
 -   [getSnapshot](#getsnapshot)
 -   [getType](#gettype)
 -   [hasParent](#hasparent)
+-   [hooks](#hooks)
 -   [Identifier](#identifier)
 -   [IdentifierCache](#identifiercache)
 -   [isAlive](#isalive)
@@ -125,7 +126,9 @@ For more details, see the [middleware docs](docs/middleware.md)
 
 -   `target` **IStateTreeNode** 
 -   `middleware`  **IMiddleware**
--   `includeHooks` **([boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean) | any)** indicates whether the hooks should be piped to the middleware. 
+-   `includeHooks` **([boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean) | any)** indicates whether the [hooks](#hooks) should be piped to the middleware.
+
+See [hooks](#hooks) for more information.
 
 
 Returns **IDisposer** 
@@ -386,6 +389,27 @@ Given a model instance, returns `true` if the object has a parent, that is, is p
 -   `depth` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** = 1, how far should we look upward?
 
 Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+## hooks
+
+The current action based LifeCycle hooks for [types.model](#types.model).
+
+```typescript
+enum HookNames {
+    afterCreate = "afterCreate",
+    afterAttach = "afterAttach",
+    postProcessSnapshot = "postProcessSnapshot",
+    beforeDetach = "beforeDetach",
+    beforeDestroy = "beforeDestroy"
+}
+```
+
+Note: 
+Unlike the other hooks, `preProcessSnapshot` is not created as part of the actions initializer, but directly on the type.
+`preProcessSnapshot` is currently not piped to middlewares. 
+
+For more details on middlewares, see the [middleware docs](docs/middleware.md) 
+
 
 ## Identifier
 

--- a/API.md
+++ b/API.md
@@ -124,7 +124,9 @@ For more details, see the [middleware docs](docs/middleware.md)
 **Parameters**
 
 -   `target` **IStateTreeNode** 
--   `middleware`  
+-   `middleware`  **IMiddleware**
+-   `includeHooks` **([boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean) | any)** indicates whether the hooks should be piped to the middleware. 
+
 
 Returns **IDisposer** 
 
@@ -207,7 +209,7 @@ Binds middleware to a specific action
 
 **Parameters**
 
--   `middleware` **IMiddlewareHandler** 
+-   `handler` **IMiddlewareHandler** 
 -   `fn`  
 -   `Function`  } fn
 

--- a/API.md
+++ b/API.md
@@ -116,16 +116,15 @@ const Todo = types.model({
 ```
 
 ## addMiddleware
-
-Middleware can be used to intercept any action is invoked on the subtree where it is attached.
-If a tree is protected (by default), this means that any mutation of the tree will pass through your middleware.
-
+ 
+Middlewares can be used to intercept any action on a subtree.
+ 
 For more details, see the [middleware docs](docs/middleware.md)
-
+ 
 **Parameters**
-
+ 
 -   `target` **IStateTreeNode** 
--   `middleware`  **IMiddleware**
+-   `handler`  **IMiddlewareHandler**
 -   `includeHooks` **([boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean) | any)** indicates whether the [hooks](#hooks) should be piped to the middleware.
 
 See [hooks](#hooks) for more information.

--- a/README.md
+++ b/README.md
@@ -906,13 +906,13 @@ See the [full API docs](API.md) for more details.
 | signature | |
 | ---- | --- |
 | [`addDisposer(node, () => void)`](API.md#adddisposer) | Function to be invoked whenever the target node is to be destroyed |
-| [`addMiddleware(node, middleware: (actionDescription, next) => any)`](API.md#addmiddleware) | Attaches middleware to a node. See [middleware](docs/middleware.md). Returns disposer. |
+| [`addMiddleware(node, middleware: (actionDescription, next) => any, includeHooks)`](API.md#addmiddleware) | Attaches middleware to a node. See [middleware](docs/middleware.md). Returns disposer. |
 | [`applyAction(node, actionDescription)`](API.md#applyaction) | Replays an action on the targeted node |
 | [`applyPatch(node, jsonPatch)`](API.md#applypatch) | Applies a JSON patch, or array of patches, to a node in the tree |
 | [`applySnapshot(node, snapshot)`](API.md#applysnapshot) | Updates a node with the given snapshot |
 | [`createActionTrackingMiddleware`](API.md#createactiontrackingmiddleware) | Utility to make writing middleware that tracks async actions less cumbersome |
 | [`clone(node, keepEnvironment?: true \| false \| newEnvironment)`](API.md#clone) | Creates a full clone of the given node. By default preserves the same environment |
-| [`decorate(middleware, function)`](API.md#decorate) | Attaches middleware to a specific action (or flow) |
+| [`decorate(handler, function)`](API.md#decorate) | Attaches middleware to a specific action (or flow) |
 | [`destroy(node)`](API.md#destroy) | Kills `node`, making it unusable. Removes it from any parent in the process |
 | [`detach(node)`](API.md#detach) | Removes `node` from its current parent, and lets it live on as standalone tree |
 | [`flow(generator)`](API.md#flow) | creates an asynchronous flow based on a generator function |

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -1,23 +1,71 @@
 # Middleware
+Middlewares can be used to intercept any action on a subtree.
 
-MST ships with a small set of [pre-built / example middlewares](../packages/mst-middlewares/README.md)
+It is allowed to attach multiple middlewares to a node.
+The order in which middlewares are invoked is inside-out:
+This means that the middlewares are invoked in the order you attach them.
+The value returned by the action invoked/ the aborted value gets passed through the middleware chain and can be manipulated.
 
-Middleware can be used to intercept any action is invoked on the subtree where it is attached.
-If a tree is protected (by default), this means that any mutation of the tree will pass through your middleware.
 
+MST ships with a small set of [pre-built / example middlewares](../packages/mst-middlewares/README.md).
+
+
+Custom middleware example:
 [SandBox example](https://codesandbox.io/s/mQrqy8j73)
 
-Middleware can be attached by using `addMiddleware(node, handler: (call, next(call) => void, abort(value: any) => any) => void)`
+## Custom Middleware
+Middlewares can be attached by using:
 
-It is allowed to attach multiple middlewares. The order in which middleware is invoked is inside-out:
-local middleware is invoked before parent middleware. On the same object, earlier attached middleware is run before later attached middleware.
+`addMiddleware(target: IStateTreeNode, handler: IMiddlewareHandler, includeHooks: boolean = true) :
+void`
 
-A middleware handler receives three arguments: 1. the description of the the call, 2: a function to invoke the next middleware in the chain. 3: a function to abort the middleware queue and return a value.
-You must either call `next(call)` or `abort(value)` within a middleware. If none is invoked an error will be thrown.
-Before passing the call to the next middleware using `next`, feel free to (clone and) modify the call arguments. Other properties should not be modified
+### target
 
-A call description looks like:
+the middleware will only be attached to actions of the `target` and further sub nodes of such.
 
+### handler
+An example of this is as follows:
+
+```js
+const store = SomeStore.create()
+const disposer = addMiddleWare(store, (call, next, abort) => {
+  console.log(`action ${call.name} was invoked`)
+  // runs the next middleware
+  // or the implementation of the targeted action
+  // if there is no middleware left to run
+
+  // the value returned from the next can be manipulated
+  next(call, value => value + 1);
+});
+```
+```js
+const store = SomeStore.create()
+const disposer = addMiddleWare(store, (call, next, abort) => {
+  console.log(`action ${call.name} was invoked`)
+  // aborts running the middlewares and returns the 'value' instead.
+  // note that the targeted action won't be reached either.
+  return abort('value')  
+})
+```
+
+A middleware handler receives three arguments:
+1. the description of the the call,
+-  a function to invoke the next middleware in the chain and manipulate the returned value from the next middleware in the chain.
+- a function to abort the middleware queue and return a value.
+
+
+
+*Note: You must call either `next(call)` or `abort(value)` within a middleware.*
+
+*Note: If you abort, the action invoked will never be reached.*
+
+*Note: The value from either `abort('value')` or the returned value from the `action` can be manipulated by previous middlewares.*
+
+*Note: It is important to invoke `next(call)` or `abort(value)` synchronously.*
+
+*Note: The value of the `abort(value)` must be a promise in case of aborting a `flow`.*
+
+#### call
 ```javascript
 export type IMiddleWareEvent = {
     type: IMiddlewareEventType
@@ -38,35 +86,6 @@ export type IMiddlewareEventType =
     | "flow_return"
     | "flow_throw"
 ```
-
-A very simple middleware that just logs the invocation of actions will look like:
-
-@example
-```typescript
-const store = SomeStore.create()
-const disposer = addMiddleWare(store, (call, next, abort) => {
-  console.log(`action ${call.name} was invoked`)
-  return next(call) // runs the next middleware (or the implementation of the targeted action if there is no middleware to run left)
-})
-```
-
-@example
-```typescript
-const store = SomeStore.create()
-const disposer = addMiddleWare(store, (call, next, abort) => {
-  console.log(`action ${call.name} was invoked`)
-  return abort('value') // aborts running the middlewares and returns the 'value' instead. Note that the underlying action won't be invoked either.
-})
-```
-
-_Note: for middleware, it is extremely important that `next(action)` is called for asynchronous actions (`call.type !== "action"`), otherwise the generator will remain in an unfinished state forever_
-
-# Built-in middlewares
-
-* [`onAction`](https://github.com/mobxjs/mobx-state-tree/blob/09708ba86d04f433cc23fbcb6d1dc4db170f798e/src/core/action.ts#L174)
-* More will follow soon
-
-## Call attributes
 
 * `name` is the name of the action
 * `context` is the object on which the action was defined & invoked
@@ -93,3 +112,31 @@ A minimal, empty process will fire the following events if started as action:
 2. `flow_spawn`: This is just the notification that a new generator was started
 3. `flow_resume`: This will be emitted when the first "code block" is entered. (So, with zero yields there is one `flow_resume`  still)
 4. `flow_return`: The process has completed
+
+#### next
+use next to call the next middleware.
+
+`next(call: IMiddlewareEvent, callback?: (value: any) => any): void`
+
+- `call` Before passing the call middleware, feel free to (clone and) modify the `call.args`.
+Other properties should not be modified
+
+- `callback` can be used to manipulate values returned by later middlewares or the implementation of the targeted action.
+
+#### abort
+
+use abort if you wan't kill the queue of middlewares and immediately return.
+the implementation of the targeted action won't be reached if you abort the queue.
+
+`abort(value: any) : void`
+
+- `value` is returned instead of the return value from the implementation of the targeted action.
+
+### includeHooks
+set this flag to `false` if you wan't to avoid having hooks passed to the middleware.
+
+## FAQ
+
+- I alter a property and the change does not appear in the middleware.
+
+ - *If you alter a value of an unprotected node, the change won't reach the middleware. Only actions can be intercepted.*

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 		"husky": "^0.13.4",
 		"prettier": "^1.4.4",
 		"lint-staged": "^3.6.1",
-		"cross-env":"^5.1.1"
+		"cross-env": "^5.1.1"
 	},
 	"scripts": {
 		"clean": "lerna clean",

--- a/packages/mobx-state-tree/src/core/action.ts
+++ b/packages/mobx-state-tree/src/core/action.ts
@@ -104,7 +104,7 @@ export function createActionInvoker<T extends Function>(
  */
 export function addMiddleware(
     target: IStateTreeNode,
-    middleware: IMiddlewareHandler,
+    handler: IMiddlewareHandler,
     includeHooks: boolean = true
 ): IDisposer {
     const node = getStateTreeNode(target)
@@ -114,7 +114,7 @@ export function addMiddleware(
                 "It is recommended to protect the state tree before attaching action middleware, as otherwise it cannot be guaranteed that all changes are passed through middleware. See `protect`"
             )
     }
-    return node.addMiddleWare(middleware, includeHooks)
+    return node.addMiddleWare(handler, includeHooks)
 }
 
 export function decorate<T extends Function>(middleware: IMiddlewareHandler, fn: T): T
@@ -201,15 +201,21 @@ function runMiddleWares(node: ObjectNode, baseCall: IMiddlewareEvent, originalFn
                 if (!nextInvoked && !abortInvoked) {
                     const node = getStateTreeNode(call.tree)
                     fail(
-                        `Neither the next() nor the abort() callback within a middleware for the action: "${call.name}" on the node: ${node
-                            .type.name} was invoked.`
+                        `Neither the next() nor the abort() callback within the middleware ${
+                            handler.name
+                        } for the action: "${call.name}" on the node: ${
+                            node.type.name
+                        } was invoked.`
                     )
                 }
-                if (!!nextInvoked && !!abortInvoked) {
+                if (nextInvoked && abortInvoked) {
                     const node = getStateTreeNode(call.tree)
                     fail(
-                        `The next() and abort() callback within a middleware for the action: "${call.name}" on the node: ${node
-                            .type.name} was invoked.`
+                        `The next() and abort() callback within the middleware ${
+                            handler.name
+                        } for the action: "${call.name}" on the node: ${
+                            node.type.name
+                        } were invoked.`
                     )
                 }
             }

--- a/packages/mobx-state-tree/src/core/action.ts
+++ b/packages/mobx-state-tree/src/core/action.ts
@@ -7,7 +7,8 @@ import {
     IDisposer,
     getRoot,
     EMPTY_ARRAY,
-    ObjectNode
+    ObjectNode,
+    HookNames
 } from "../internal"
 
 export type IMiddlewareEventType =
@@ -30,6 +31,10 @@ export type IMiddlewareEvent = {
     args: any[]
 }
 
+export type IMiddleware = {
+    handler: IMiddlewareHandler
+    includeHooks: boolean
+}
 export type IMiddlewareHandler = (
     actionCall: IMiddlewareEvent,
     next: (actionCall: IMiddlewareEvent) => any
@@ -96,7 +101,11 @@ export function createActionInvoker<T extends Function>(
  * @param {(action: IRawActionCall, next: (call: IRawActionCall) => any) => any} middleware
  * @returns {IDisposer}
  */
-export function addMiddleware(target: IStateTreeNode, middleware: IMiddlewareHandler): IDisposer {
+export function addMiddleware(
+    target: IStateTreeNode,
+    middleware: IMiddlewareHandler,
+    includeHooks: boolean = true
+): IDisposer {
     const node = getStateTreeNode(target)
     if (process.env.NODE_ENV !== "production") {
         if (!node.isProtectionEnabled)
@@ -104,7 +113,7 @@ export function addMiddleware(target: IStateTreeNode, middleware: IMiddlewareHan
                 "It is recommended to protect the state tree before attaching action middleware, as otherwise it cannot be guaranteed that all changes are passed through middleware. See `protect`"
             )
     }
-    return node.addMiddleWare(middleware)
+    return node.addMiddleWare(middleware, includeHooks)
 }
 
 export function decorate<T extends Function>(middleware: IMiddlewareHandler, fn: T): T
@@ -126,41 +135,61 @@ export function decorate<T extends Function>(middleware: IMiddlewareHandler, fn:
  *
  * @export
  * @template T
- * @param {IMiddlewareHandler} middleware
+ * @param {IMiddlewareHandler} handler
  * @param Function} fn
  * @returns the original function
  */
-export function decorate<T extends Function>(middleware: IMiddlewareHandler, fn: any) {
+export function decorate<T extends Function>(handler: IMiddlewareHandler, fn: any) {
+    const middleware: IMiddleware = { handler, includeHooks: true }
     if (fn.$mst_middleware) fn.$mst_middleware.push(middleware)
     else fn.$mst_middleware = [middleware]
     return fn
 }
 
-function collectMiddlewareHandlers(
+function collectMiddlewares(
     node: ObjectNode,
     baseCall: IMiddlewareEvent,
     fn: Function
-): IMiddlewareHandler[] {
-    let handlers: IMiddlewareHandler[] = (fn as any).$mst_middleware || EMPTY_ARRAY
+): IMiddleware[] {
+    let middlewares: IMiddleware[] = (fn as any).$mst_middleware || EMPTY_ARRAY
     let n: ObjectNode | null = node
     // Find all middlewares. Optimization: cache this?
     while (n) {
-        if (n.middlewares) handlers = handlers.concat(n.middlewares)
+        if (n.middlewares) middlewares = middlewares.concat(n.middlewares)
         n = n.parent
     }
-    return handlers
+    return middlewares
 }
 
 function runMiddleWares(node: ObjectNode, baseCall: IMiddlewareEvent, originalFn: Function): any {
-    const handlers = collectMiddlewareHandlers(node, baseCall, originalFn)
+    const middlewares = collectMiddlewares(node, baseCall, originalFn)
     // Short circuit
-    if (!handlers.length) return mobxAction(originalFn).apply(null, baseCall.args)
+    if (!middlewares.length) return mobxAction(originalFn).apply(null, baseCall.args)
     let index = 0
 
     function runNextMiddleware(call: IMiddlewareEvent): any {
-        const handler = handlers[index++]
-        if (handler) return handler(call, runNextMiddleware)
-        else return mobxAction(originalFn).apply(null, baseCall.args)
+        const middleware = middlewares[index++]
+        const handler = middleware && middleware.handler
+        const invokeHandler = () => {
+            const next = handler(call, runNextMiddleware)
+            if (!next && index < middlewares.length && process.env.NODE_ENV !== "production") {
+                const node = getStateTreeNode(call.tree)
+                fail(
+                    `The next() callback within a middleware for the action: "${call.name}" on the node: ${node
+                        .type.name} wasn't invoked.`
+                )
+            }
+            return next
+        }
+
+        if (handler && middleware.includeHooks) {
+            return invokeHandler()
+        } else if (handler && !middleware.includeHooks) {
+            if ((HookNames as any)[call.name]) return runNextMiddleware(call)
+            return invokeHandler()
+        } else {
+            return mobxAction(originalFn).apply(null, baseCall.args)
+        }
     }
     return runNextMiddleware(baseCall)
 }

--- a/packages/mobx-state-tree/src/core/action.ts
+++ b/packages/mobx-state-tree/src/core/action.ts
@@ -186,19 +186,21 @@ function runMiddleWares(node: ObjectNode, baseCall: IMiddlewareEvent, originalFn
         }
         const invokeHandler = () => {
             handler(call, next, abort)
-            if (process.env.NODE_ENV !== "production" && !nextInvoked && !abortInvoked) {
-                const node = getStateTreeNode(call.tree)
-                fail(
-                    `Neither the next() nor the abort() callback within a middleware for the action: "${call.name}" on the node: ${node
-                        .type.name} was invoked.`
-                )
-            }
-            if (process.env.NODE_ENV !== "production" && !!nextInvoked && !!abortInvoked) {
-                const node = getStateTreeNode(call.tree)
-                fail(
-                    `The next() and abort() callback within a middleware for the action: "${call.name}" on the node: ${node
-                        .type.name} was invoked.`
-                )
+            if (process.env.NODE_ENV !== "production") {
+                if (!nextInvoked && !abortInvoked) {
+                    const node = getStateTreeNode(call.tree)
+                    fail(
+                        `Neither the next() nor the abort() callback within a middleware for the action: "${call.name}" on the node: ${node
+                            .type.name} was invoked.`
+                    )
+                }
+                if (!!nextInvoked && !!abortInvoked) {
+                    const node = getStateTreeNode(call.tree)
+                    fail(
+                        `The next() and abort() callback within a middleware for the action: "${call.name}" on the node: ${node
+                            .type.name} was invoked.`
+                    )
+                }
             }
             return result
         }

--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -15,6 +15,7 @@ import {
     registerEventHandler,
     addReadOnlyProp,
     walk,
+    IMiddleware,
     IMiddlewareHandler,
     createActionInvoker,
     NodeLifeCycle,
@@ -47,7 +48,7 @@ export class ObjectNode implements INode {
     protected _autoUnbox = true // unboxing is disabled when reading child nodes
     state = NodeLifeCycle.INITIALIZING
 
-    middlewares = EMPTY_ARRAY as IMiddlewareHandler[]
+    middlewares = EMPTY_ARRAY as IMiddleware[]
     private snapshotSubscribers: ((snapshot: any) => void)[]
     private patchSubscribers: ((patch: IJsonPatch, reversePatch: IJsonPatch) => void)[]
     private disposers: (() => void)[]
@@ -404,8 +405,15 @@ export class ObjectNode implements INode {
         this.disposers.unshift(disposer)
     }
 
-    addMiddleWare(handler: IMiddlewareHandler) {
-        return registerEventHandler(this.middlewares, handler)
+    removeMiddleware(handler: IMiddlewareHandler) {
+        this.middlewares = this.middlewares.filter(middleware => middleware.handler !== handler)
+    }
+
+    addMiddleWare(handler: IMiddlewareHandler, includeHooks: boolean = true) {
+        this.middlewares.push({ handler, includeHooks })
+        return () => {
+            this.removeMiddleware(handler)
+        }
     }
 
     applyPatchLocally(subpath: string, patch: IJsonPatch): void {

--- a/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts
+++ b/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts
@@ -35,7 +35,8 @@ export function createActionTrackingMiddleware<T = any>(hooks: {
 }): IMiddlewareHandler {
     return function actionTrackingMiddleware(
         call: IMiddlewareEvent,
-        next: (actionCall: IMiddlewareEvent) => any
+        next: (actionCall: IMiddlewareEvent) => any,
+        abort: (value: any) => any
     ) {
         switch (call.type) {
             case "action": {

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -42,12 +42,12 @@ import {
 
 const PRE_PROCESS_SNAPSHOT = "preProcessSnapshot"
 
-const HOOK_NAMES = {
-    afterCreate: "afterCreate",
-    afterAttach: "afterAttach",
-    postProcessSnapshot: "postProcessSnapshot",
-    beforeDetach: "beforeDetach",
-    beforeDestroy: "beforeDestroy"
+export enum HookNames {
+    afterCreate = "afterCreate",
+    afterAttach = "afterAttach",
+    postProcessSnapshot = "postProcessSnapshot",
+    beforeDetach = "beforeDetach",
+    beforeDestroy = "beforeDestroy"
 }
 
 function objectTypeToString(this: any) {
@@ -72,7 +72,7 @@ function toPropertiesObject<T>(properties: IModelProperties<T>): { [K in keyof T
     return Object.keys(properties).reduce(
         (properties, key) => {
             // warn if user intended a HOOK
-            if (key in HOOK_NAMES)
+            if (key in HookNames)
                 return fail(
                     `Hook '${key}' was defined as property. Hooks should be defined as part of the actions`
                 )
@@ -169,9 +169,9 @@ export class ModelType<S, T> extends ComplexType<S, T> implements IModelType<S, 
             // apply hook composition
             let action = actions[name]
             let baseAction = (self as any)[name]
-            if (name in HOOK_NAMES && baseAction) {
+            if (name in HookNames && baseAction) {
                 let specializedAction = action
-                if (name === HOOK_NAMES.postProcessSnapshot)
+                if (name === HookNames.postProcessSnapshot)
                     action = (snapshot: any) => specializedAction(baseAction(snapshot))
                 else
                     action = function() {
@@ -381,8 +381,9 @@ export class ModelType<S, T> extends ComplexType<S, T> implements IModelType<S, 
             ;(extras.getAtom(node.storedValue, name) as any).reportObserved()
             res[name] = this.getChildNode(node, name).snapshot
         })
-        if (typeof node.storedValue.postProcessSnapshot === "function")
+        if (typeof node.storedValue.postProcessSnapshot === "function") {
             return node.storedValue.postProcessSnapshot.call(null, res)
+        }
         return res
     }
 

--- a/packages/mst-middlewares/README.md
+++ b/packages/mst-middlewares/README.md
@@ -12,7 +12,7 @@ import {MiddlewareName} from "mst-middlewares"
 
 The middlewares serve as example and are supported on a best effort bases. The goal of these middlewares is that if they are critical to your system, you can simply copy paste them and further tailor them towards your specific needs.
 
-For the exact description of all middleware events offered by MST, see the [api docs](../middleware.md)
+For the exact description of all middleware events offered by MST, see the [api docs](../docs/middleware.md)
 
 # Contributing
 

--- a/packages/mst-middlewares/package.json
+++ b/packages/mst-middlewares/package.json
@@ -7,13 +7,15 @@
   "module": "dist/mst-middlewares.module.js",
   "typings": "dist/index.d.ts",
   "scripts": {
-    "test": "tsc -p test/ && ava",
+    "build-tests": "tsc -p test/",
+    "test": "npm run build-tests && cross-env NODE_ENV=development ava && cross-env NODE_ENV=production ava",
     "build": "tsc && cpr lib dist --delete-first --filter=\\\\.js && rollup -c"
   },
   "author": "",
   "license": "MIT",
   "devDependencies": {
     "ava": "^0.22.0",
+    "cross-env": "^5.1.1",
     "mobx": "^3.3.1",
     "mobx-state-tree": "^1.3.1",
     "rollup": "^0.50.0",

--- a/packages/mst-middlewares/src/action-logger.ts
+++ b/packages/mst-middlewares/src/action-logger.ts
@@ -8,5 +8,5 @@ export function actionLogger(call: IMiddlewareEvent, next: any) {
 
     if (!skip)
         console.log(`[MST] #${call.rootId} ${call.type} - ${getPath(call.context)}/${call.name}`)
-    return next(call)
+    next(call)
 }

--- a/packages/mst-middlewares/src/undo-manager.ts
+++ b/packages/mst-middlewares/src/undo-manager.ts
@@ -134,7 +134,7 @@ const UndoManager = types
                     throw new Error(
                         "UndoManager should be created as part of a tree, or with `targetStore` in it's environment"
                     )
-                middlewareDisposer = addMiddleware(targetStore, undoRedoMiddleware)
+                middlewareDisposer = addMiddleware(targetStore, undoRedoMiddleware, false)
             },
             beforeDestroy() {
                 middlewareDisposer()

--- a/packages/mst-middlewares/test/TimeTraveller.ts
+++ b/packages/mst-middlewares/test/TimeTraveller.ts
@@ -1,6 +1,6 @@
 import { test } from "ava"
 import { TimeTraveller } from "../src"
-import { types, addMiddleware, flow, clone } from "mobx-state-tree"
+import { types, flow, clone } from "mobx-state-tree"
 
 const TestModel = types
     .model({

--- a/packages/mst-middlewares/test/custom.ts
+++ b/packages/mst-middlewares/test/custom.ts
@@ -1,6 +1,6 @@
 import { test } from "ava"
 import atomic from "../src/atomic"
-import { types, addMiddleware, getSnapshot } from "mobx-state-tree"
+import { decorate, types, addMiddleware, onSnapshot, flow } from "mobx-state-tree"
 
 let error: any = null
 
@@ -18,6 +18,9 @@ function abortString(call, next, abort) {
 function abortNumeric(call, next, abort) {
     abort(5)
 }
+function abortPromise(call, next, abort) {
+    abort(Promise.resolve(5))
+}
 function nextNoAlter(call, next) {
     next(call)
 }
@@ -27,9 +30,12 @@ function nextAlter(call, next, abort) {
 function nextAlter2(call, next, abort) {
     next(call, value => value + 2)
 }
+function nextAlterAsync(call, next, abort) {
+    next(call, async value => (await value) + 2)
+}
 
 function noHooksMiddleware(call, next, abort) {
-    // thowing errors will lead to the aborting of further middlewares
+    // throwing errors will lead to the aborting of further middlewares
     // => don't throw here but set a global var instead
     if (call.name === "postProcessSnapshot") error = Error("hook in middleware")
     next(call)
@@ -39,12 +45,48 @@ function shouldNeverBeInvoked(call, next, abort) {
     next(call)
 }
 
+function delay(time) {
+    return new Promise(resolve => {
+        setTimeout(resolve, time)
+    })
+}
+
 const TestModel = types
     .model("Test1", {
         z: 1
     })
     .actions(self => {
         return {
+            asyncInc: flow(function*(x) {
+                yield delay(2)
+                self.z += x
+                yield delay(2)
+                return self.z
+            }),
+            asyncIncSuccess: flow(function*(x) {
+                yield (self as any).asyncAbortedPromise() // will return a string instead of a promise.
+                self.z += x
+                return self.z
+            }),
+            asyncIncFailing: flow(function*(x) {
+                yield (self as any).asyncAbortedString() // will return a string instead of a promise.
+                self.z += x
+                return self.z
+            }),
+            asyncAbortedString: decorate(
+                abortString, // this will fail since "Only promises can be yielded" within flows.
+                flow(function*(x) {
+                    yield delay(2)
+                    return 205
+                })
+            ),
+            asyncAbortedPromise: decorate(
+                abortPromise,
+                flow(function*(x) {
+                    yield delay(2)
+                    return 205
+                })
+            ),
             inc(x) {
                 self.z += x
                 return self.z
@@ -55,6 +97,90 @@ const TestModel = types
         }
     })
 
+test("next() middleware queue ", t => {
+    const m = TestModel.create()
+    addMiddleware(m, nextNoAlter) // no alterations
+    const valueFromMiddleware: any = m.inc(1)
+    t.is(valueFromMiddleware, 2)
+})
+
+test("next() middleware queue and alter the action value", t => {
+    const m = TestModel.create()
+    addMiddleware(m, nextAlter) // contains the manipulation + 1
+    addMiddleware(m, nextAlter2) // contains another manipulation + 2
+    const valueFromMiddleware: any = m.inc(1) // value should be 2(inc) + all the maniuplations = 5
+    t.is(valueFromMiddleware, 5)
+})
+
+test("next() middleware queue and alter the async action value", async t => {
+    const m = TestModel.create()
+    addMiddleware(m, nextAlterAsync) // contains another manipulation + 2
+    const valueFromMiddleware: any = await m.asyncInc(1) // value should be 2(inc) + all the maniuplations = 5
+    t.is(valueFromMiddleware, 4)
+})
+
+test("abort() middleware queue", t => {
+    error = null
+    const m = TestModel.create()
+    addMiddleware(m, abortString) // contains abort()
+    addMiddleware(m, shouldNeverBeInvoked) // would contain next() - should never be invoked
+
+    const valueFromMiddleware: any = m.inc(1) // the return value should be the one from the aborting middleware
+    t.is(valueFromMiddleware, "someValue")
+    t.is(error, null) // make sure the cutomMiddleware4 was never invoked
+})
+
+test("abort() middleware queue and alter the abort value", t => {
+    const m = TestModel.create()
+    addMiddleware(m, nextAlter) // contains the manipulation
+    addMiddleware(m, abortNumeric) // does abort with numeric
+
+    const valueFromMiddleware: any = m.inc(1)
+    t.is(valueFromMiddleware, 6)
+})
+
+test("next() middleware queue and alter the async action value", async t => {
+    const m = TestModel.create()
+    addMiddleware(m, nextAlterAsync) // + 2
+    addMiddleware(m, abortPromise) // => 5
+    const valueFromMiddleware: any = await m.asyncInc(1) // => 7
+    t.is(valueFromMiddleware, 7)
+})
+
+test("abort() within nested async actions with string", async t => {
+    const m = TestModel.create()
+    try {
+        const valueFromMiddleware: any = await m.asyncIncFailing(1) // contains 2 delays
+    } catch (e) {
+        // TODO: once we'd change flow to be able to yield more than just a promise
+        // this test must be changed.
+        t.is(!!e, true)
+    }
+})
+
+test("abort() within nested async actions with promise", async t => {
+    const m = TestModel.create()
+    const valueFromMiddleware: any = await m.asyncIncSuccess(1) // should only abort inner.
+    t.is(valueFromMiddleware, 2)
+})
+
+test("middleware should be invoked on hooks", t => {
+    error = null
+    const m = TestModel.create()
+    addMiddleware(m, noHooksMiddleware)
+    m.inc(1)
+    t.is(!!error, true)
+})
+
+test("middleware should not be invoked on hooks", t => {
+    error = null
+    const m = TestModel.create()
+    addMiddleware(m, noHooksMiddleware, false)
+    m.inc(1)
+    t.is(!error, true)
+})
+
+// These tests will leave MST in a bad state since they're throwing. Leave the at the bottom.
 if (process.env.NODE_ENV === "development") {
     test("next()/ abort() omitted within middleware", t => {
         const m = TestModel.create()
@@ -70,7 +196,7 @@ if (process.env.NODE_ENV === "development") {
 }
 
 if (process.env.NODE_ENV === "development") {
-    test.only("abort() and next() invoked within middleware", t => {
+    test("abort() and next() invoked within middleware", t => {
         const m = TestModel.create()
         addMiddleware(m, nextAndAbort)
         let thrownError: any = null
@@ -82,56 +208,3 @@ if (process.env.NODE_ENV === "development") {
         t.is(!!thrownError, true)
     })
 }
-
-test("next() middleware queue ", t => {
-    const m = TestModel.create()
-    addMiddleware(m, nextNoAlter) // no alterations
-    const valueFromMiddleware: any = m.inc(1)
-    t.is(valueFromMiddleware, 2)
-})
-
-test("next() middleware queue and alter the action value", t => {
-    error = null
-    const m = TestModel.create()
-    addMiddleware(m, nextAlter) // contains the manipulation + 1
-    addMiddleware(m, nextAlter2) // contains another manipulation + 2
-    const valueFromMiddleware: any = m.inc(1) // value should be 2(inc) + all the maniuplations = 5
-    t.is(valueFromMiddleware, 5)
-})
-
-test("abort() middleware queue", t => {
-    error = null
-    const m = TestModel.create()
-    addMiddleware(m, abortString) // contains abort()
-    addMiddleware(m, shouldNeverBeInvoked) // would contain next() - should never be invoked
-
-    const valueFromMiddleware: any = m.inc(1) // the return value should be the one from the aborting middleware
-    t.is(valueFromMiddleware, "someValue")
-    t.is(error, null) // make sure the cutomMiddleware4 was never invoked
-})
-
-test("abort() middleware queue and alter the abort value", t => {
-    error = null
-    const m = TestModel.create()
-    addMiddleware(m, nextAlter) // contains the manipulation
-    addMiddleware(m, abortNumeric) // does abort with numeric
-
-    const valueFromMiddleware: any = m.inc(1)
-    t.is(valueFromMiddleware, 6)
-})
-
-test("middleware should be invoked on hooks", t => {
-    error = null
-    const m = TestModel.create()
-    addMiddleware(m, noHooksMiddleware, true)
-    m.inc(1)
-    t.is(!!error, true)
-})
-
-test("middleware should not be invoked on hooks", t => {
-    const m = TestModel.create()
-    error = null
-    addMiddleware(m, noHooksMiddleware, false)
-    m.inc(1)
-    t.is(!error, true)
-})

--- a/packages/mst-middlewares/test/custom.ts
+++ b/packages/mst-middlewares/test/custom.ts
@@ -1,0 +1,65 @@
+import { test } from "ava"
+import atomic from "../src/atomic"
+import { types, addMiddleware, getSnapshot } from "mobx-state-tree"
+
+let error: any = null
+
+function customMiddleware1(call, next) {
+    // omit next() when there are more middlewares in the queue
+    //return next(call)
+}
+function customMiddleware2(call, next) {
+    return next(call)
+}
+
+function noHooksMiddleware(call, next) {
+    // thowing errors will lead to the aborting of further middlewares
+    // => don't throw here but set a global var instead
+    if (call.name === "postProcessSnapshot") error = Error("hook in middleware")
+    return next(call)
+}
+
+const TestModel = types
+    .model("Test1", {
+        z: 1
+    })
+    .actions(self => {
+        return {
+            inc(x) {
+                self.z += x
+                return self.z
+            },
+            postProcessSnapshot(snapshot) {
+                return snapshot
+            }
+        }
+    })
+
+test("next() omitted within middleware", t => {
+    const m = TestModel.create()
+    addMiddleware(m, customMiddleware1)
+    addMiddleware(m, customMiddleware2)
+    let thrownError: any = null
+    try {
+        m.inc(1)
+    } catch (e) {
+        thrownError = e
+    }
+    t.is(!!thrownError, true)
+})
+
+test("middleware should be invoked on hooks", t => {
+    const m = TestModel.create()
+    error = null
+    addMiddleware(m, noHooksMiddleware)
+    m.inc(1)
+    t.is(!!error, true)
+})
+
+test("middleware should not be invoked on hooks", t => {
+    const m = TestModel.create()
+    error = null
+    addMiddleware(m, noHooksMiddleware, false)
+    m.inc(1)
+    t.is(!error, true)
+})


### PR DESCRIPTION
introduces `abort()`

```js
function customMiddleware1(call, next, abort) {
    console.log(call.name)
    next(call, (value) => value + 1) // no return needed, value can be manipulated
}

function customMiddleware2(call, next, abort) {
    console.log(call.name)
    abort('someValue') // 'someValue' will be returned instead of value from the actual action
}

addMiddleware(store, customMiddleware1)
addMiddleware(store, customMiddleware2)

const valueFromAction = store.someAction()  // someValue1
```

because of the syntax change - we can

- check whether at least one of the callbacks was invoked.
- check if accidentally both were invoked.
- eliminate the current problems where one missed to return / didn't call next(call)

TODO: 
- [x] add callback fn within next `next(call, (value) => value)` as a second param to overwrite the return value

TBD: 
- [ ] should abort values also be manipulated? (currently they are)