### PR TITLE
Added 'getIdentifier' function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,5 @@
 language: node_js
 sudo: required
-before_install: # if "install" is overridden
-  # we don't want the default yarn version
-  - which yarn
-  - sudo rm `which yarn`
-  # Repo for Yarn
-  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn=1.2.1-1
-  - which yarn
-  - yarn --version
 cache:
   yarn: true
 script: yarn run bootstrap && yarn run build && yarn run test && yarn run coverage

--- a/API.md
+++ b/API.md
@@ -347,11 +347,19 @@ Returns **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 Given an object in a model tree, returns the root object of that tree
 
+## getIdentifier(node, property?)
+
+Returns the identifier of the given node. If a property is given returns the identifier of that property. If the node or property
+does not have an identifier, returns null
+
 **Parameters**
 
--   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `node` **IStateTreeNode** 
+-   `property?` **string** 
 
-Returns **any** 
+
+
+Returns **string | null** 
 
 ## getSnapshot
 

--- a/API.md
+++ b/API.md
@@ -347,16 +347,13 @@ Returns **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 Given an object in a model tree, returns the root object of that tree
 
-## getIdentifier(node, property?)
+## getIdentifier(node)
 
-Returns the identifier of the given node. If a property is given returns the identifier of that property. If the node or property
-does not have an identifier, returns null
+Returns the identifier of the given node.
 
 **Parameters**
 
 -   `node` **IStateTreeNode** 
--   `property?` **string** 
-
 
 
 Returns **string | null** 

--- a/README.md
+++ b/README.md
@@ -923,6 +923,7 @@ See the [full API docs](API.md) for more details.
 | [`getPathParts(node)`](API.md#getpathparts) | Returns the path of `node` in the tree, unescaped as separate parts |
 | [`getRelativePath(base, target)`](API.md#getrelativepath) | Returns the short path, which one could use to walk from node `base` to node `target`, assuming they are in the same tree. Up is represented as `../` |
 | [`getRoot(node)`](API.md#getroot) | Returns the root element of the tree containing `node` |
+| [`getIdentifier(node, property?)`](API.md#getidentifier) | Returns the identifier of the given element, or of the given property` |
 | [`getSnapshot(node)`](API.md#getsnapshot) | Returns the snapshot of the `node`. See [snapshots](#snapshots) |
 | [`getType(node)`](API.md#gettype) | Returns the type of `node` |
 | [`hasParent(node, depth=1)`](API.md#hasparent) | Returns `true` if `node` has a parent at `depth` |

--- a/README.md
+++ b/README.md
@@ -923,7 +923,7 @@ See the [full API docs](API.md) for more details.
 | [`getPathParts(node)`](API.md#getpathparts) | Returns the path of `node` in the tree, unescaped as separate parts |
 | [`getRelativePath(base, target)`](API.md#getrelativepath) | Returns the short path, which one could use to walk from node `base` to node `target`, assuming they are in the same tree. Up is represented as `../` |
 | [`getRoot(node)`](API.md#getroot) | Returns the root element of the tree containing `node` |
-| [`getIdentifier(node, property?)`](API.md#getidentifier) | Returns the identifier of the given element, or of the given property` |
+| [`getIdentifier(node)`](API.md#getidentifier) | Returns the identifier of the given element |
 | [`getSnapshot(node)`](API.md#getsnapshot) | Returns the snapshot of the `node`. See [snapshots](#snapshots) |
 | [`getType(node)`](API.md#gettype) | Returns the type of `node` |
 | [`hasParent(node, depth=1)`](API.md#hasparent) | Returns `true` if `node` has a parent at `depth` |

--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -452,18 +452,13 @@ export function resolveIdentifier(
 }
 
 /**
- * Returns the identifier of the target node. If a property is supplied returns the identifier
- * of the property even if it is a reference to a missing object.
+ * Returns the identifier of the target node.
  *
  * @export
  * @param {IStateTreeNode} target
- * @param {string} property
- * @returns {(string | null)}
+  * @returns {(string | null)}
  */
-export function getIdentifier<T extends IStateTreeNode>(
-    target: T,
-    property?: keyof T
-): string | null {
+export function getIdentifier(target: IStateTreeNode): string | null {
     // check all arguments
 
     if (process.env.NODE_ENV !== "production") {
@@ -471,25 +466,7 @@ export function getIdentifier<T extends IStateTreeNode>(
             fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
     }
 
-    if (property === "$treenode") {
-        return null
-    }
-
-    if (!property) {
-        return getStateTreeNode(target).identifier
-    } else {
-        const propertyNode: INode = getStateTreeNode(target).getChildNode(property)
-        if (!isReferenceType(propertyNode.type)) {
-            return null
-        } else {
-            // if mode is 'object' then the value is a node
-            if (propertyNode.storedValue.mode === "identifier") {
-                return propertyNode.storedValue.value
-            } else {
-                return getStateTreeNode(propertyNode.storedValue.value).identifier
-            }
-        }
-    }
+    return getStateTreeNode(target).identifier
 }
 
 /**

--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -460,7 +460,10 @@ export function resolveIdentifier(
  * @param {string} property
  * @returns {(string | null)}
  */
-export function getIdentifier<T>(target: T, property?: keyof T): string | null {
+export function getIdentifier<T extends IStateTreeNode>(
+    target: T,
+    property?: keyof T
+): string | null {
     // check all arguments
 
     if (process.env.NODE_ENV !== "production") {

--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -452,6 +452,44 @@ export function resolveIdentifier(
 }
 
 /**
+ * Returns the identifier of the target node. If a property is supplied returns the identifier
+ * of the property even if it is a reference to a missing object.
+ *
+ * @export
+ * @param {IStateTreeNode} target
+ * @param {string} property
+ * @returns {(string | null)}
+ */
+export function getIdentifier<T>(target: T, property?: keyof T): string | null {
+    // check all arguments
+
+    if (process.env.NODE_ENV !== "production") {
+        if (!isStateTreeNode(target))
+            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+    }
+
+    if (property === "$treenode") {
+        return null
+    }
+
+    if (!property) {
+        return getStateTreeNode(target).identifier
+    } else {
+        const propertyNode: INode = getStateTreeNode(target).getChildNode(property)
+        if (!isReferenceType(propertyNode.type)) {
+            return null
+        } else {
+            // if mode is 'object' then the value is a node
+            if (propertyNode.storedValue.mode === "identifier") {
+                return propertyNode.storedValue.value
+            } else {
+                return getStateTreeNode(propertyNode.storedValue.value).identifier
+            }
+        }
+    }
+}
+
+/**
  *
  *
  * @export
@@ -662,5 +700,6 @@ import {
     IType,
     isType,
     resolveNodeByPath,
-    getRelativePathBetweenNodes
+    getRelativePathBetweenNodes,
+    isReferenceType
 } from "../internal"

--- a/packages/mobx-state-tree/test/api.ts
+++ b/packages/mobx-state-tree/test/api.ts
@@ -21,6 +21,7 @@ const METHODS = [
     "getPathParts",
     "getRelativePath",
     "getRoot",
+    "getIdentifier",
     "getSnapshot",
     "getType",
     "hasParent",

--- a/packages/mobx-state-tree/test/node.ts
+++ b/packages/mobx-state-tree/test/node.ts
@@ -74,55 +74,15 @@ test("it should resolve to the root of an object", t => {
 // getIdentifier
 
 test("it should resolve to the identifier of the object", t => {
-    const Person = types.model("Person", {
+    const Document = types.model("Document", {
         id: types.identifier(types.string)
     })
-    const Document = types.model("Document", {
-        author: types.reference(Person),
-        id: types.identifier(types.string),
-        pageCount: types.number
-    })
     const doc = Document.create({
-        author: "person_1",
-        id: "document_1",
-        pageCount: 32
+        id: "document_1"
     })
-
-    // direct access throws
-    t.throws(() => {
-        const authorId = doc.author
-    })
-
-    // unfortunatly '$treenode' is accepted by the compile-time type checks
-    t.is(getIdentifier(doc, "$treenode"), null)
 
     // get identifier of object
     t.is(getIdentifier(doc), "document_1")
-
-    // get identifier of non-existent reference
-    t.is(getIdentifier(doc, "author"), "person_1")
-
-    // attempt to get identifier of scalar type
-    t.is(getIdentifier(doc, "pageCount"), null)
-
-    const Container = types.model("Container", {
-        person: Person,
-        doc: Document
-    })
-
-    const container = Container.create({
-        doc: Document.create({
-            author: "person_2",
-            id: "document_2",
-            pageCount: 12
-        }),
-        person: Person.create({
-            id: "person_2"
-        })
-    })
-
-    // get identifier of existing reference
-    t.is(getIdentifier(container.doc, "author"), "person_2")
 })
 
 // getPath

--- a/packages/mobx-state-tree/test/node.ts
+++ b/packages/mobx-state-tree/test/node.ts
@@ -4,6 +4,7 @@ import {
     getParent,
     hasParent,
     getRoot,
+    getIdentifier,
     getPathParts,
     isAlive,
     clone,
@@ -69,6 +70,61 @@ test("it should resolve to the root of an object", t => {
     doc.rows.push(row)
     t.is(getRoot(row), doc)
 })
+
+// getIdentifier
+
+test("it should resolve to the identifier of the object", t => {
+    const Person = types.model("Person", {
+        id: types.identifier(types.string)
+    })
+    const Document = types.model("Document", {
+        author: types.reference(Person),
+        id: types.identifier(types.string),
+        pageCount: types.number
+    })
+    const doc = Document.create({
+        author: "person_1",
+        id: "document_1",
+        pageCount: 32
+    })
+
+    // direct access throws
+    t.throws(() => {
+        const authorId = doc.author
+    })
+
+    // unfortunatly '$treenode' is accepted by the compile-time type checks
+    t.is(getIdentifier(doc, "$treenode"), null)
+
+    // get identifier of object
+    t.is(getIdentifier(doc), "document_1")
+
+    // get identifier of non-existent reference
+    t.is(getIdentifier(doc, "author"), "person_1")
+
+    // attempt to get identifier of scalar type
+    t.is(getIdentifier(doc, "pageCount"), null)
+
+    const Container = types.model("Container", {
+        person: Person,
+        doc: Document
+    })
+
+    const container = Container.create({
+        doc: Document.create({
+            author: "person_2",
+            id: "document_2",
+            pageCount: 12
+        }),
+        person: Person.create({
+            id: "person_2"
+        })
+    })
+
+    // get identifier of existing reference
+    t.is(getIdentifier(container.doc, "author"), "person_2")
+})
+
 // getPath
 
 test("it should resolve the path of an object", t => {


### PR DESCRIPTION
Exposes 'getIdentifier' function to resolve #674. 

```javascript
/**
 * Returns the identifier of the target node. If a property is supplied returns the identifier
 * of the property even if it is a reference to a missing object.
 *
 * @export
 * @param {IStateTreeNode} target
 * @param {string} property
 * @returns {(string | null)}
 */
export function getIdentifier<T extends IStateTreeNode>(target: T, property?: keyof T): string | null;
```

