### PR TITLE
fix for map of map

### DIFF
--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -294,7 +294,7 @@ export class MapType<S, T> extends ComplexType<{ [key: string]: S }, IExtendedOb
  */
 export function map<S, T>(
     subtype: IComplexType<S, T>
-): IComplexType<{ [key: string]: S }, IExtendedObservableMap<T>>;
+): IComplexType<{ [key: string]: S }, IExtendedObservableMap<T>>
 export function map<S, T>(
     subtype: IType<S, T>
 ): IComplexType<{ [key: string]: S }, IExtendedObservableMap<T>> {

--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -293,6 +293,9 @@ export class MapType<S, T> extends ComplexType<{ [key: string]: S }, IExtendedOb
  * @returns {IComplexType<S[], IObservableArray<T>>}
  */
 export function map<S, T>(
+    subtype: IComplexType<S, T>
+): IComplexType<{ [key: string]: S }, IExtendedObservableMap<T>>;
+export function map<S, T>(
     subtype: IType<S, T>
 ): IComplexType<{ [key: string]: S }, IExtendedObservableMap<T>> {
     return new MapType<S, T>(`map<string, ${subtype.name}>`, subtype)


### PR DESCRIPTION
fixes types.map(types.map(types.map(types.boolean))

how? I have no clue, but apparently putting an overload that takes IComplexType before IType works :)

Fixes #703 