### PR TITLE
Do not initialize store twice

### DIFF
--- a/packages/mst-example-todomvc/src/index.js
+++ b/packages/mst-example-todomvc/src/index.js
@@ -27,7 +27,7 @@ const initialState = localStorage.getItem(localStorageKey)
           ]
       }
 
-let store = TodoStore.create(initialState)
+let store
 let snapshotListener
 
 function createTodoStore(snapshot) {


### PR DESCRIPTION
In the MST example TodoMVC the store was initialized twice, once here and once in the `createTodoStore` function.