### PR TITLE
Ts2p8 upgrade

### DIFF
--- a/packages/mst-middlewares/src/time-traveller.ts
+++ b/packages/mst-middlewares/src/time-traveller.ts
@@ -9,6 +9,7 @@ import {
     ISnapshottable,
     IModelType
 } from "mobx-state-tree"
+import { IObservableArray } from "mobx"
 
 const TimeTraveller = types
     .model("TimeTraveller", {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10740,8 +10740,8 @@ ts-jest@^22.4.1:
     yargs "^11.0.0"
 
 tslib@^1.7.1:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.0.tgz#dc604ebad64bcbf696d613da6c954aa0e7ea1eb6"
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
 tslint@^3.15.1:
   version "3.15.1"
@@ -10795,8 +10795,8 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 typescript@^2.7.0, typescript@^2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
Simply upgrade typescript to 2.8
First step toward improving types using 2.8 features
ref #705