### PR TITLE
getSnapshot without postProcess

### DIFF
--- a/API.md
+++ b/API.md
@@ -391,10 +391,12 @@ Returns **any**
 
 Calculates a snapshot from the given model instance. The snapshot will always reflect the latest state but use
 structural sharing where possible. Doesn't require MobX transactions to be completed.
+By default postProcessSnapshot hooks are applied to the snapshot.
 
 **Parameters**
 
 -   `target` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `applyPostProcess` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **any** 
 

--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ If you want to share volatile state between views and actions, use `.extend` ins
 <i><a style="color: white; background:cornflowerblue;padding:5px;margin:5px;border-radius:2px" href="https://egghead.io/lessons/react-automatically-send-changes-to-the-server-by-using-onsnapshot">egghead.io lesson 16: Automatically Send Changes to the Server by Using onSnapshot</a></i>
 
 Snapshots are the immutable serialization, in plain objects, of a tree at a specific point in time.
-Snapshots can be inspected through `getSnapshot(node)`.
+Snapshots can be inspected through `getSnapshot(node, applyPostProcess)`.
 Snapshots don't contain any type information and are stripped from all actions etc, so they are perfectly suitable for transportation.
 Requesting a snapshot is cheap, as MST always maintains a snapshot of each node in the background, and uses structural sharing
 
@@ -519,7 +519,7 @@ Some interesting properties of snapshots:
 
 Useful methods:
 
--   `getSnapshot(model)`: returns a snapshot representing the current state of the model
+-   `getSnapshot(model, applyPostProcess)`: returns a snapshot representing the current state of the model
 -   `onSnapshot(model, callback)`: creates a listener that fires whenever a new snapshot is available (but only one per MobX transaction).
 -   `applySnapshot(model, snapshot)`: updates the state of the model and all its descendants to the state represented by the snapshot
 
@@ -962,7 +962,7 @@ See the [full API docs](API.md) for more details.
 | [`getRelativePath(base, target)`](API.md#getrelativepath) | Returns the short path, which one could use to walk from node `base` to node `target`, assuming they are in the same tree. Up is represented as `../` |
 | [`getRoot(node)`](API.md#getroot) | Returns the root element of the tree containing `node` |
 | [`getIdentifier(node)`](API.md#getidentifier) | Returns the identifier of the given element |
-| [`getSnapshot(node)`](API.md#getsnapshot) | Returns the snapshot of the `node`. See [snapshots](#snapshots) |
+| [`getSnapshot(node, applyPostProcess)`](API.md#getsnapshot) | Returns the snapshot of the `node`. See [snapshots](#snapshots) |
 | [`getType(node)`](API.md#gettype) | Returns the type of `node` |
 | [`hasParent(node, depth=1)`](API.md#hasparent) | Returns `true` if `node` has a parent at `depth` |
 | [`isAlive(node)`](API.md#isalive) | Returns `true` if `node` is alive |
@@ -1009,7 +1009,7 @@ The following service can generate MST models based on JSON: https://transform.n
 
 ### `toJSON()` for debugging
 
-For debugging you might want to use `getSnapshot(model)` to print the state of a model. But if you didn't import `getSnapshot` while debugging in some debugger; don't worry, `model.toJSON()` will produce the same snapshot. (For API consistency, this feature is not part of the typed API)
+For debugging you might want to use `getSnapshot(model, applyPostProcess)` to print the state of a model. But if you didn't import `getSnapshot` while debugging in some debugger; don't worry, `model.toJSON()` will produce the same snapshot. (For API consistency, this feature is not part of the typed API)
 
 ### Handle circular dependencies between files using `late`
 

--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -281,8 +281,7 @@ export function getSnapshot<S>(target: ISnapshottable<S>, applyPostProcess = tru
     const node = getStateTreeNode(target)
     if (applyPostProcess) return node.snapshot
 
-    const snapshot = freeze(node.type.getSnapshot(node, false))
-    return snapshot
+    return freeze(node.type.getSnapshot(node, false))
 }
 
 /**

--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -279,8 +279,10 @@ export function getSnapshot<S>(target: ISnapshottable<S>, applyPostProcess = tru
             fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
     }
     const node = getStateTreeNode(target)
-    node._applyPostProcess = applyPostProcess
-    return node.snapshot
+    if (applyPostProcess) return node.snapshot
+
+    const snapshot = freeze(node.type.getSnapshot(node, false))
+    return snapshot
 }
 
 /**
@@ -742,5 +744,6 @@ import {
     isType,
     resolveNodeByPath,
     getRelativePathBetweenNodes,
-    ModelType
+    ModelType,
+    freeze
 } from "../internal"

--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -262,22 +262,25 @@ export function getSnapshot<K extends string | number, V>(
     target: ObservableMap<K, V>
 ): { [key: string]: V }
 export function getSnapshot<S>(target: IObservableArray<S>): S[]
-export function getSnapshot<S = any>(target: ISnapshottable<S>): S
+export function getSnapshot<S = any>(target: ISnapshottable<S>, applyPostProcess?: boolean): S
 /**
  * Calculates a snapshot from the given model instance. The snapshot will always reflect the latest state but use
  * structural sharing where possible. Doesn't require MobX transactions to be completed.
  *
  * @export
  * @param {Object} target
+ * @param {boolean} applyPostProcess = true, by default the postProcessSnapshot gets applied
  * @returns {*}
  */
-export function getSnapshot<S>(target: ISnapshottable<S>): S {
+export function getSnapshot<S>(target: ISnapshottable<S>, applyPostProcess = true): S {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
             fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
     }
-    return getStateTreeNode(target).snapshot
+    const node = getStateTreeNode(target)
+    node._applyPostProcess = applyPostProcess
+    return node.snapshot
 }
 
 /**

--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -44,6 +44,7 @@ export class ObjectNode implements INode {
     _environment: any = undefined
     protected _autoUnbox = true // unboxing is disabled when reading child nodes
     state = NodeLifeCycle.INITIALIZING
+    @observable _applyPostProcess = true // needs to be an observable since the computed snapshots must recompute upon a change
 
     middlewares = EMPTY_ARRAY as IMiddleware[]
     private snapshotSubscribers: ((snapshot: any) => void)[]

--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -44,7 +44,6 @@ export class ObjectNode implements INode {
     _environment: any = undefined
     protected _autoUnbox = true // unboxing is disabled when reading child nodes
     state = NodeLifeCycle.INITIALIZING
-    @observable _applyPostProcess = true // needs to be an observable since the computed snapshots must recompute upon a change
 
     middlewares = EMPTY_ARRAY as IMiddleware[]
     private snapshotSubscribers: ((snapshot: any) => void)[]

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -55,7 +55,7 @@ export interface IType<S, T> {
     instantiate(parent: INode | null, subpath: string, environment: any, initialValue?: any): INode
     reconcile(current: INode, newValue: any): INode
     getValue(node: INode): T
-    getSnapshot(node: INode): S
+    getSnapshot(node: INode, applyPostProcess?: boolean): S
     applySnapshot(node: INode, snapshot: S): void
     applyPatchLocally(node: INode, subpath: string, patch: IJsonPatch): void
     getChildren(node: INode): ReadonlyArray<INode>
@@ -104,7 +104,7 @@ export abstract class ComplexType<S, T> implements IType<S, T> {
     abstract getChildren(node: INode): ReadonlyArray<INode>
     abstract getChildNode(node: INode, key: string): INode
     abstract getValue(node: INode): T
-    abstract getSnapshot(node: INode): any
+    abstract getSnapshot(node: INode, applyPostProcess?: boolean): any
     abstract applyPatchLocally(node: INode, subpath: string, patch: IJsonPatch): void
     abstract getChildType(key: string): IType<any, any>
     abstract removeChild(node: INode, subpath: string): void

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -398,7 +398,7 @@ export class ModelType<S, T> extends ComplexType<S, T> implements IModelType<S, 
             ;(getAtom(node.storedValue, name) as any).reportObserved()
             res[name] = this.getChildNode(node, name).snapshot
         })
-        if (typeof node.storedValue.postProcessSnapshot === "function") {
+        if (typeof node.storedValue.postProcessSnapshot === "function" && node._applyPostProcess) {
             return node.storedValue.postProcessSnapshot.call(null, res)
         }
         return res

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -391,14 +391,14 @@ export class ModelType<S, T> extends ComplexType<S, T> implements IModelType<S, 
         return node.storedValue
     }
 
-    getSnapshot(node: ObjectNode): any {
+    getSnapshot(node: ObjectNode, applyPostProcess = true): any {
         const res = {} as any
         this.forAllProps((name, type) => {
             // TODO: FIXME, make sure the observable ref is used!
             ;(getAtom(node.storedValue, name) as any).reportObserved()
             res[name] = this.getChildNode(node, name).snapshot
         })
-        if (typeof node.storedValue.postProcessSnapshot === "function" && node._applyPostProcess) {
+        if (typeof node.storedValue.postProcessSnapshot === "function" && applyPostProcess) {
             return node.storedValue.postProcessSnapshot.call(null, res)
         }
         return res

--- a/packages/mobx-state-tree/test/hooks.ts
+++ b/packages/mobx-state-tree/test/hooks.ts
@@ -132,6 +132,13 @@ test("it should postprocess snapshots when generating snapshot", () => {
     expect(car.id).toBe(2)
     expect(getSnapshot(car)).toEqual({ id: "1" })
 })
+test("it should be possible to overwrite the application of the postProcessor", () => {
+    const car = Car.create({ id: "1" })
+    expect(getSnapshot(car)).toEqual({ id: "1" })
+    expect(getSnapshot(car, false)).toEqual({ id: 2 })
+    // test again if snapshot gets recomputed
+    expect(getSnapshot(car)).toEqual({ id: "1" })
+})
 test("it should preprocess snapshots when creating as property type", () => {
     const f = Factory.create({
         car: { id: "1" }

--- a/packages/mobx-state-tree/test/hooks.ts
+++ b/packages/mobx-state-tree/test/hooks.ts
@@ -1,4 +1,13 @@
-import { addDisposer, destroy, detach, types, unprotect, getSnapshot, applySnapshot } from "../src"
+import {
+    addDisposer,
+    destroy,
+    detach,
+    types,
+    unprotect,
+    getSnapshot,
+    applySnapshot,
+    onSnapshot
+} from "../src"
 function createTestStore(listener) {
     const Todo = types
         .model("Todo", {
@@ -132,12 +141,15 @@ test("it should postprocess snapshots when generating snapshot", () => {
     expect(car.id).toBe(2)
     expect(getSnapshot(car)).toEqual({ id: "1" })
 })
-test("it should be possible to overwrite the application of the postProcessor", () => {
+test("it should not apply postprocessor to snapshot on getSnapshot", () => {
     const car = Car.create({ id: "1" })
+    let error: any = false
+    onSnapshot(car, snapshot => {
+        error = true
+    })
     expect(getSnapshot(car)).toEqual({ id: "1" })
     expect(getSnapshot(car, false)).toEqual({ id: 2 })
-    // test again if snapshot gets recomputed
-    expect(getSnapshot(car)).toEqual({ id: "1" })
+    expect(error).toBeFalsy()
 })
 test("it should preprocess snapshots when creating as property type", () => {
     const f = Factory.create({


### PR DESCRIPTION
introduce a flag to optionally disable the postProcessSnapshot.

```
getSnapshot(node, applyPostProcess)
```