### PR TITLE
WIP: disposer fuction returned from addDisposer

### DIFF
--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -407,6 +407,11 @@ export class ObjectNode implements INode {
         this.disposers.unshift(disposer)
     }
 
+    removeDisposer(disposer: () => void) {
+        disposer()
+        this.disposers = this.disposers.filter(storedDisposer => storedDisposer !== disposer)
+    }
+
     removeMiddleware(handler: IMiddlewareHandler) {
         this.middlewares = this.middlewares.filter(middleware => middleware.handler !== handler)
     }

--- a/packages/mobx-state-tree/test/hooks.ts
+++ b/packages/mobx-state-tree/test/hooks.ts
@@ -1,4 +1,5 @@
 import { addDisposer, destroy, detach, types, unprotect, getSnapshot, applySnapshot } from "../src"
+const disposers: any = []
 function createTestStore(listener) {
     const Todo = types
         .model("Todo", {
@@ -38,9 +39,11 @@ function createTestStore(listener) {
             function afterCreate() {
                 unprotect(self)
                 listener("new store: " + self.todos.length)
-                addDisposer(self, () => {
-                    listener("custom disposer for store")
-                })
+                disposers.push(
+                    addDisposer(self, () => {
+                        listener("custom disposer for store")
+                    })
+                )
             }
             function beforeDestroy() {
                 listener("destroy store: " + self.todos.length)
@@ -87,13 +90,13 @@ test("it should trigger lifecycle hooks", () => {
         "new todo: add sugar",
         "attach todo: add sugar",
         "---",
+        "custom disposer for store",
         "custom disposer 2 for Get coffee",
         "custom disposer 1 for Get coffee",
         "destroy todo: Get coffee",
         "custom disposer 2 for add sugar",
         "custom disposer 1 for add sugar",
         "destroy todo: add sugar",
-        "custom disposer for store",
         "destroy store: 2",
         "custom disposer 2 for Give talk",
         "custom disposer 1 for Give talk",

--- a/packages/mobx-state-tree/test/hooks.ts
+++ b/packages/mobx-state-tree/test/hooks.ts
@@ -71,6 +71,7 @@ test("it should trigger lifecycle hooks", () => {
     const sugar = Todo.create({ title: "add sugar" })
     store.todos.push(sugar)
     events.push("---")
+    disposers.forEach(disposer => disposer())
     destroy(store)
     destroy(talk)
     expect(events).toEqual([


### PR DESCRIPTION
```js
const disposer = addDisposer(reaction(
  addDisposer(self, autoSaveDisposer)
    () => getSnapshot(self),
    snapshot => sendSnapshotToServerSomehow(snapshot)
))
```

makes reactions abort-able within view components (e.g. unmount) and on node destruction at the same time.