### PR TITLE
fix issue on map with number identifier that must be cast as string

### DIFF
--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -39,7 +39,7 @@ interface IMapFactoryConfig {
     isMapFactory: true
 }
 
-export interface IExtendedObservableMap<T> extends ObservableMap<string, T> {
+export interface IExtendedObservableMap<T> extends ObservableMap<string | number, T> {
     put(value: T | any): this // downtype to any, again, because we cannot type the snapshot, see
 }
 
@@ -114,6 +114,8 @@ export class MapType<S, T> extends ComplexType<{ [key: string]: S }, IExtendedOb
         // const identifierAttr = getIdentifierAttribute(this.subType)
         const map = observable.map({}, mobxShallow)
         addHiddenFinalProp(map, "put", put)
+        const _get = map.get
+        addHiddenFinalProp(map, "get", (key: string | number) => _get.call(map, "" + key))
         addHiddenFinalProp(map, "toString", mapToString)
         return map
     }

--- a/packages/mobx-state-tree/test/map.ts
+++ b/packages/mobx-state-tree/test/map.ts
@@ -294,3 +294,31 @@ test("map expects regular identifiers", () => {
         "[mobx-state-tree] The objects in a map should all have the same identifier attribute, expected 'a', but child of type 'B' declared attribute 'b' as identifier"
     )
 })
+
+test("get should return value when key is a number", () => {
+    const Todo = types.model("Todo", {
+        todo_id: types.identifier(types.number),
+        title: types.string
+    })
+    const TodoStore = types
+        .model("TodoStore", {
+            todos: types.optional(types.map(Todo), {})
+        })
+        .actions(self => {
+            function addTodo(todo) {
+                self.todos.put(todo)
+            }
+            return {
+                addTodo
+            }
+        })
+    const todoStore = TodoStore.create({})
+
+    const todo = {
+        todo_id: 1,
+        title: "Test"
+    }
+
+    todoStore.addTodo(todo)
+    expect(todoStore.todos.get(1)).toEqual(todo)
+})


### PR DESCRIPTION
Hello,

When using map with a model that has a number identifier, the identifier must be cast as string when using 'get' function.

As identifiers can be number, map should accept number too.

In this PR, the key type is changed from string to string | number.
The get function is also changed to force a string comparison when getting a value.
I've also added a test for this case.