### PR TITLE
Fix issue #792 - Allow resuming to `flow` when node destroyed while waiting the async operation.

### DIFF
--- a/packages/mobx-state-tree/src/core/action.ts
+++ b/packages/mobx-state-tree/src/core/action.ts
@@ -52,7 +52,11 @@ export function runWithActionContext(context: IMiddlewareEvent, fn: Function) {
     const node = getStateTreeNode(context.context)
     const baseIsRunningAction = node._isRunningAction
     const prevContext = currentActionContext
-    node.assertAlive()
+
+    if (context.type === "action") {
+        node.assertAlive()
+    }
+
     node._isRunningAction = true
     currentActionContext = context
     try {


### PR DESCRIPTION
Allow resuming to `flow` when node destroyed while waiting the async operation.