### PR TITLE
Expose Snapshot type in package type declaration.

### DIFF
--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -65,6 +65,7 @@ export {
     ISimpleType,
     IComplexType,
     ISnapshottable,
+    Snapshot,
     typecheckPublic as typecheck,
     escapeJsonPath,
     unescapeJsonPath,


### PR DESCRIPTION
Right now if for some reason you want to type output of types.model(...), you can't because it returns IModelType, but Snapshot is unavailable so this can't work:

```typescript
const myModel = IModelType<Snapshot<T>, T> = types.model<T>('MyModel', {})
```