### PR TITLE
WIP: Changes the default targetStore of UndoManager to getParent instead of getRoot

### DIFF
--- a/packages/mst-middlewares/src/undo-manager.ts
+++ b/packages/mst-middlewares/src/undo-manager.ts
@@ -5,7 +5,7 @@ import {
     recordPatches,
     addMiddleware,
     applyPatch,
-    getRoot,
+    getParent,
     createActionTrackingMiddleware,
     IStateTreeNode,
     IModelType,
@@ -55,7 +55,7 @@ const UndoManager = types
             const actionId = call.name + recordingActionLevel
             recordingActionId = actionId
             return {
-                recorder: recordPatches(call.tree),
+                recorder: recordPatches(call.context),
                 actionId
             }
         }
@@ -129,7 +129,7 @@ const UndoManager = types
                 self.undoIdx = self.history.length
             },
             afterCreate() {
-                targetStore = getEnv(self).targetStore ? getEnv(self).targetStore : getRoot(self)
+                targetStore = getEnv(self).targetStore ? getEnv(self).targetStore : getParent(self)
                 if (!targetStore || targetStore === self)
                     throw new Error(
                         "UndoManager should be created as part of a tree, or with `targetStore` in it's environment"


### PR DESCRIPTION
Fixes issue #832. I think that for more flexibility the targetStore should default to the parent not the root. This allows you to have undo managers on child object, for example a separate undo history for each note in a note-taking app.

Tests pass.
```
lerna success run Ran npm script 'test' in packages:
lerna success - mobx-state-tree
lerna success - mst-example-bookshop
lerna success - mst-example-boxes
lerna success - mst-example-redux-todomvc
lerna success - mst-example-todomvc
lerna success - mst-middlewares
✨  Done in 28.53s.
```