### PR TITLE
Fix MST-boxes example

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"private": true,
-	"dependencies": {},
+	"dependencies": {
+	},
 	"scripts": {
 		"clean": "lerna clean",
 		"build": "lerna run build",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
 	"private": true,
-	"dependencies": {
-	},
+	"dependencies": {},
 	"scripts": {
 		"clean": "lerna clean",
 		"build": "lerna run build",

--- a/packages/mst-example-boxes/package.json
+++ b/packages/mst-example-boxes/package.json
@@ -25,27 +25,27 @@
   },
   "homepage": "http://mobxjs.github.com/mobx",
   "devDependencies": {
-    "babel-core": "^6.17.0",
+    "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-preset-es2015": "^6.16.0",
-    "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "jest": "^21.2.1",
-    "react-hot-loader": "^4.0.1",
-    "webpack": "^4.5.0",
-    "webpack-dev-server": "^3.1.1"
+    "babel-plugin-transform-decorators-legacy": "^1.3.5",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
+    "jest": "^23.1.0",
+    "react-hot-loader": "^4.2.0",
+    "webpack": "^4.10.2",
+    "webpack-dev-server": "^3.1.4"
   },
   "dependencies": {
-    "mobx": "^4.0.2",
-    "mobx-react": "^5.0.0",
+    "mobx": "^4.3.0",
+    "mobx-react": "^5.1.2",
     "mobx-react-devtools": "^5.0.1",
     "mobx-state-tree": "^2.0.5",
-    "node-uuid": "^1.4.3",
-    "react": "^16.3.1",
-    "react-dom": "^16.3.1",
-    "react-draggable": "1.3.7",
+    "node-uuid": "^1.4.8",
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0",
+    "react-draggable": "3.0.5",
     "remotedev": "^0.2.7",
-    "ws": "^1.1.1"
+    "ws": "^5.2.0"
   }
 }

--- a/packages/mst-example-boxes/package.json
+++ b/packages/mst-example-boxes/package.json
@@ -25,27 +25,27 @@
   },
   "homepage": "http://mobxjs.github.com/mobx",
   "devDependencies": {
-    "babel-core": "^6.26.3",
+    "babel-core": "^6.17.0",
     "babel-loader": "^7.1.4",
-    "babel-plugin-transform-decorators-legacy": "^1.3.5",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
-    "jest": "^23.1.0",
-    "react-hot-loader": "^4.2.0",
-    "webpack": "^4.10.2",
-    "webpack-dev-server": "^3.1.4"
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-preset-es2015": "^6.16.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-0": "^6.16.0",
+    "jest": "^21.2.1",
+    "react-hot-loader": "^4.0.1",
+    "webpack": "^4.5.0",
+    "webpack-dev-server": "^3.1.1"
   },
   "dependencies": {
-    "mobx": "^4.3.0",
-    "mobx-react": "^5.1.2",
+    "mobx": "^4.0.2",
+    "mobx-react": "^5.0.0",
     "mobx-react-devtools": "^5.0.1",
     "mobx-state-tree": "^2.0.5",
-    "node-uuid": "^1.4.8",
+    "node-uuid": "^1.4.3",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-draggable": "3.0.5",
     "remotedev": "^0.2.7",
-    "ws": "^5.2.0"
+    "ws": "^1.1.1"
   }
 }

--- a/packages/mst-example-boxes/src/components/box-view.js
+++ b/packages/mst-example-boxes/src/components/box-view.js
@@ -28,7 +28,7 @@ class BoxView extends Component {
     }
 
     handleDrag = (e, dragInfo) => {
-        this.props.box.move(dragInfo.position.deltaX, dragInfo.position.deltaY)
+        this.props.box.move(dragInfo.deltaX, dragInfo.deltaY)
     }
 }
 

--- a/packages/mst-example-boxes/style.css
+++ b/packages/mst-example-boxes/style.css
@@ -53,7 +53,7 @@ body {
 }
 
 .canvas path {
-    fill: '#000000';
+    fill: #000000;
 }
 
 .sidebar {


### PR DESCRIPTION
`react-draggable` was not working correctly with latest React, so I updated its version. Then I decided to update all the packages altogether :) Everything works as expected so far.