### PR TITLE
#634 fix optional frozen to return default value if undefined

### DIFF
--- a/packages/mobx-state-tree/src/types/utility-types/optional.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/optional.ts
@@ -52,7 +52,7 @@ export class OptionalValue<S, T> extends Type<S, T> {
     reconcile(current: INode, newValue: any): INode {
         return this.type.reconcile(
             current,
-            this.type.is(newValue) ? newValue : this.getDefaultValue()
+            this.type.is(newValue) && newValue !== undefined ? newValue : this.getDefaultValue()
         )
     }
 

--- a/packages/mobx-state-tree/test/optional.ts
+++ b/packages/mobx-state-tree/test/optional.ts
@@ -1,4 +1,4 @@
-import { getSnapshot, types, unprotect } from "../src"
+import { getSnapshot, types, unprotect, applySnapshot } from "../src"
 test("it should provide a default value, if no snapshot is provided", () => {
     const Row = types.model({
         name: "",
@@ -66,7 +66,8 @@ test("Values should reset to default if omitted in snapshot", () => {
         todo: types.model({
             id: types.identifier(),
             done: false,
-            title: "test"
+            title: "test",
+            thing: types.optional(types.frozen, {})
         })
     })
     const store = Store.create({ todo: { id: "2" } })
@@ -77,6 +78,21 @@ test("Values should reset to default if omitted in snapshot", () => {
     expect(store.todo.title).toBe("stuff")
     expect(store.todo.done).toBe(false)
 })
+
+test("optional frozen should fallback to default value if snapshot is undefined", () => {
+    const Store = types.model({
+        thing: types.optional(types.frozen, {})
+    })
+    const store = Store.create({
+        thing: null
+    })
+
+    expect(store.thing).toBeNull()
+    applySnapshot(store, {})
+    expect(store.thing).toBeDefined()
+    expect(store.thing).toEqual({})
+})
+
 test("a model is a valid default value, snapshot will be used", () => {
     const Row = types.model({
         name: "",


### PR DESCRIPTION
Fixes #634, optional frozen were undefined after applySnapshot()

Issue was the undefined is a valid type for frozen so was accepted as it by optional type and not falling back to the default value.