### PR TITLE
Fix grammatical error, rename amount to number

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ MST trees have very specific semantics. These semantics purposefully constrain w
 1. Every _node_ tree in a MST tree is a tree in itself. Any operation that can be invoked on the complete tree can also be applied to a sub tree.
 1. A node can only exist exactly _once_ in a tree. This ensures it has a unique, identifiable position.
 2. It is however possible to refer to another object in the _same_ tree by using _references_
-3. There is no limit to the amount of MST trees that live in an application. However, each node can only live in exactly one tree.
+3. There is no limit to the number of MST trees that live in an application. However, each node can only live in exactly one tree.
 4. All _leaves_ in the tree must be serializable; it is not possible to store, for example, functions in a MST.
 6. The only free-form type in MST is frozen; with the requirement that frozen values are immutable and serializable so that the MST semantics can still be upheld.
 7. At any point in the tree it is possible to assign a snapshot to the tree instead of a concrete instance of the expected type. In that case an instance of the correct type, based on the snapshot, will be automatically created for you.
@@ -471,10 +471,10 @@ const UserStore = types
         users: types.array(User)
     })
     .views(self => ({
-        get amountOfChildren() {
+        get numberOfChildren() {
             return self.users.filter(user => user.age < 18).length
         },
-        amountOfPeopleOlderThan(age) {
+        numberOfPeopleOlderThan(age) {
             return self.users.filter(user => user.age > age).length
         }
     }))
@@ -483,10 +483,10 @@ const userStore = UserStore.create(/* */)
 
 // Every time the userStore is updated in a relevant way, log messages will be printed
 autorun(() => {
-    console.log("There are now ", userStore.amountOfChildren, " children")
+    console.log("There are now ", userStore.numberOfChildren, " children")
 })
 autorun(() => {
-    console.log("There are now ", userStore.amountOfPeopleOlderThan(75), " pretty old people")
+    console.log("There are now ", userStore.numberOfPeopleOlderThan(75), " pretty old people")
 })
 ```
 

--- a/packages/mobx-state-tree/test/fixtures/fixture-data.js
+++ b/packages/mobx-state-tree/test/fixtures/fixture-data.js
@@ -59,7 +59,7 @@ function createHeros(count) {
 exports.createHeros = createHeros
 
 /**
- * Creates data with a large amount of fields and data.
+ * Creates data with a large number of fields and data.
  *
  * @param count The number of items to create.
  * @param treasureCount The number of small children to create.

--- a/packages/mobx-state-tree/test/perf/scenarios.js
+++ b/packages/mobx-state-tree/test/perf/scenarios.js
@@ -2,7 +2,7 @@ const { start } = require("./timer")
 const { Treasure, Hero, Monster } = require("../fixtures/fixture-models")
 const { createTreasure, createHeros, createMonsters } = require("../fixtures/fixture-data")
 /**
- * Covers models with a trivial amount of fields.
+ * Covers models with a trivial number of fields.
  *
  * @param count The number of records to create.
  */
@@ -15,7 +15,7 @@ exports.smallScenario = function smallScenario(count) {
     return { count, elapsed, sanity }
 }
 /**
- * Covers models with a moderate amount of fields + 1 computed field.
+ * Covers models with a moderate number of fields + 1 computed field.
  *
  * @param count The number of records to create.
  */
@@ -28,7 +28,7 @@ exports.mediumScenario = function mediumScenario(count) {
     return { count, elapsed, sanity }
 }
 /**
- * Covers models with a large amount of fields.
+ * Covers models with a large number of fields.
  *
  * @param count The number of records to create.
  * @param smallChildren The number of small children contained within.

--- a/packages/mst-example-bookshop/src/stores/CartStore.js
+++ b/packages/mst-example-bookshop/src/stores/CartStore.js
@@ -16,11 +16,11 @@ const CartEntry = types
         }
     }))
     .actions(self => ({
-        increaseQuantity(amount) {
-            self.quantity += amount
+        increaseQuantity(number) {
+            self.quantity += number
         },
-        setQuantity(amount) {
-            self.quantity = amount
+        setQuantity(number) {
+            self.quantity = number
         }
     }))
 

--- a/packages/mst-example-boxes/src/stores/domain-state.js
+++ b/packages/mst-example-boxes/src/stores/domain-state.js
@@ -92,11 +92,11 @@ export default store
 window.store = store // for demo
 
 /**
-    Generate 'amount' new random arrows and boxes
+    Generate 'number' new random arrows and boxes
 */
-export function generateStuff(amount) {
+export function generateStuff(number) {
     runInAction(() => {
-        for (let i = 0; i < amount; i++) {
+        for (let i = 0; i < number; i++) {
             store.addBox(
                 "#" + i,
                 Math.random() * window.innerWidth * 0.5,
@@ -104,7 +104,7 @@ export function generateStuff(amount) {
             )
         }
         const allBoxes = values(store.boxes)
-        for (let i = 0; i < amount; i++) {
+        for (let i = 0; i < number; i++) {
             store.addArrow(
                 allBoxes[Math.floor(Math.random() * allBoxes.length)],
                 allBoxes[Math.floor(Math.random() * allBoxes.length)]


### PR DESCRIPTION
Rename 'amount' to 'number' to fix a grammatical error.

https://github.com/mobxjs/mobx-state-tree/issues/843

https://www.ecenglish.com/learnenglish/lessons/whats-difference-between-amount-and-number