### PR TITLE
fix(type): parameter 'fn' in undoManager.stopGroup should be optional

### DIFF
--- a/packages/mst-middlewares/src/undo-manager.ts
+++ b/packages/mst-middlewares/src/undo-manager.ts
@@ -176,7 +176,7 @@ const UndoManager = types
                 grouping = true
                 return fn()
             },
-            stopGroup(fn: () => any) {
+            stopGroup(fn?: () => any) {
                 if (fn) fn()
                 grouping = false
                 ;(self as any).addUndoState(groupRecorder)


### PR DESCRIPTION
As the usage described in https://github.com/mobxjs/mobx-state-tree/blame/master/packages/mst-middlewares/README.md#L369 and the condition in https://github.com/mobxjs/mobx-state-tree/blob/878d7f312d03276304d20af9dc055837666dbc6f/packages/mst-middlewares/src/undo-manager.ts#L180, the type of the parameter 'fn' here should be optional.