### PR TITLE
feat(undo-manager): implement methods debounceGroup and throttleGroup

### DIFF
--- a/packages/mst-middlewares/README.md
+++ b/packages/mst-middlewares/README.md
@@ -204,6 +204,8 @@ API:
 * `withoutUndoFlow(fn*)` patches the fn* are not recorded.
 * `startGroup(() => fn)` can be used to start a group, all patches within a group are saved as one history entry.
 * `stopGroup()` can be used to stop the recording of patches for the grouped history entry.
+* `debounceGroup((val?: T) => fn:(val?: T) => any, wait)` can be used to stop the recording of patches by a debounce function.
+* `throttleGroup((val?: T) => fn:(val?: T) => any, wait)` can be used to stop the recording of patches by a throttle function.
 
 Setup and API usage examples:
 
@@ -378,6 +380,30 @@ handleDrag = (mousePosition, { dx, dy }) => {
   );
 }
 ...
+```
+
+DebounceGroup, ThrottleGroup - within an interactive component:
+```js
+import {undoManager} from '../Store';
+
+const debounceTitle = undoManager.debounceGroup(val => {
+  // the group of patches will only be stopped after 5s from the last change.
+  this.saveTitle(val);
+}, 1e3 * 5);
+
+const throttleArticle = undoManager.throttledGroup(val => {
+  // the group of patches will be stopped in every 5s.
+  this.saveArticle(val);
+}, 1e3 * 5);
+...
+
+onTitleChange = val => {
+  debounceTitle(val);
+}
+
+onArticleChange = val => {
+  throttleArticle(val);
+}
 ```
 
 ---

--- a/packages/mst-middlewares/src/undo-manager.ts
+++ b/packages/mst-middlewares/src/undo-manager.ts
@@ -15,11 +15,11 @@ import {
     IJsonPatch
 } from "mobx-state-tree"
 import { IObservableArray } from "mobx"
-interface Debounce<T> {
+export interface Debounce<T> {
     (val?: T): any
     cancel?(): any
 }
-interface Throttle<T> {
+export interface Throttle<T> {
     (val?: T): any
     cancel?(): any
 }

--- a/packages/mst-middlewares/src/undo-manager.ts
+++ b/packages/mst-middlewares/src/undo-manager.ts
@@ -15,12 +15,12 @@ import {
     IJsonPatch
 } from "mobx-state-tree"
 import { IObservableArray } from "mobx"
-interface Debounce {
-    (): any
+interface Debounce<T> {
+    (val?: T): any
     cancel?(): any
 }
-interface Throttle {
-    (): any
+interface Throttle<T> {
+    (val?: T): any
     cancel?(): any
 }
 
@@ -190,16 +190,16 @@ const UndoManager = types
                 ;(self as any).addUndoState(groupRecorder)
                 groupRecorder = { patches: [], inversePatches: [] }
             },
-            debounceGroup(fn: () => any, wait: number) {
+            debounceGroup<T>(fn: (val: T) => any, wait: number) {
                 let timeout: any = 0 // TODO: should the timeout be handled by both number and NodeJS.Timer?
                 function later() {
                     clearTimeout(timeout)
                     ;(self as any).stopGroup()
                     timeout = 0
                 }
-                const debounced: Debounce = function() {
+                const debounced: Debounce<T> = function(val?: T) {
                     if (timeout) clearTimeout(timeout)
-                    ;(self as any).startGroup(fn)
+                    ;(self as any).startGroup(fn.bind(null, val))
                     timeout = setTimeout(later, wait)
                 }
                 debounced.cancel = function() {
@@ -207,15 +207,15 @@ const UndoManager = types
                 }
                 return debounced
             },
-            throttleGroup(fn: () => any, wait: number) {
+            throttleGroup<T>(fn: (val: T) => any, wait: number) {
                 let timeout: any = 0 // TODO: should the timeout be handled by both number and NodeJS.Timer?
                 function later() {
                     clearTimeout(timeout)
                     ;(self as any).stopGroup()
                     timeout = 0
                 }
-                const throttled: Throttle = function() {
-                    ;(self as any).startGroup(fn)
+                const throttled: Throttle<T> = function(val?: T) {
+                    ;(self as any).startGroup(fn.bind(null, val))
                     timeout = timeout || setTimeout(later, wait)
                 }
                 throttled.cancel = function() {

--- a/packages/mst-middlewares/test/UndoManager.ts
+++ b/packages/mst-middlewares/test/UndoManager.ts
@@ -380,8 +380,8 @@ test("on tree - debounce group", async t => {
         .actions(self => {
             _setUndoManagerSameTree(self)
             return {
-                inc() {
-                    self.x += 1
+                inc(n: number) {
+                    self.x += n || 1
                 },
                 addNumber(number) {
                     self.numbers.push(number)
@@ -390,18 +390,18 @@ test("on tree - debounce group", async t => {
         })
     const store = HistoryOnTreeStoreModel.create()
 
-    const debounced = _undoManager.debounceGroup(() => {
-        store.inc()
+    const debounced = _undoManager.debounceGroup(val => {
+        store.inc(val)
     }, 20)
 
     t.is(_undoManager.canUndo, false)
     t.is(_undoManager.canRedo, false)
     t.is(store.x, 1)
 
-    debounced()
+    debounced(2)
 
     await delay(10)
-    t.is(store.x, 2)
+    t.is(store.x, 3)
     t.is(_undoManager.canUndo, false)
     debounced()
 
@@ -453,8 +453,8 @@ test("on tree - throttle group", async t => {
         .actions(self => {
             _setUndoManagerSameTree(self)
             return {
-                inc() {
-                    self.x += 1
+                inc(n: number) {
+                    self.x += n || 1
                 },
                 addNumber(number) {
                     self.numbers.push(number)
@@ -463,28 +463,28 @@ test("on tree - throttle group", async t => {
         })
     const store = HistoryOnTreeStoreModel.create()
 
-    const throttled = _undoManager.throttleGroup(() => {
-        store.inc()
+    const throttled = _undoManager.throttleGroup(val => {
+        store.inc(val)
     }, 30)
 
     t.is(_undoManager.canUndo, false)
     t.is(_undoManager.canRedo, false)
     t.is(store.x, 1)
 
-    throttled()
+    throttled(2)
 
     await delay(10)
-    t.is(store.x, 2)
-    t.is(_undoManager.canUndo, false)
-    throttled()
-
-    await delay(5)
     t.is(store.x, 3)
     t.is(_undoManager.canUndo, false)
     throttled()
 
-    await delay(20)
+    await delay(5)
     t.is(store.x, 4)
+    t.is(_undoManager.canUndo, false)
+    throttled()
+
+    await delay(20)
+    t.is(store.x, 5)
     t.is(_undoManager.canUndo, true)
     t.is(_undoManager.history.length, 1)
     _undoManager.undo()


### PR DESCRIPTION
It's the feature that I want to import to UndoManager.

The method `startGroup` and `stopGroup` are helpful when we are trying to store state batches. They are significant in some cases like dragging on sliders but only track the value when mouse up.

Same to track batched states manually, `debounceGroup` and `throttleGroup` will give us a chance to automatically group states based on time. It is helpful in some cases especially when we want to track editing changes in interactive components(input, text area, editor, etc.)
