### PR TITLE
feat(applyAction): returns Promise from the result of applyAction

### DIFF
--- a/API.md
+++ b/API.md
@@ -142,8 +142,8 @@ Returns **IDisposer**
 
 ## applyAction
 
-Applies an action or a series of actions in a single MobX transaction.
-Does not return any value
+Applies an action(no matter it's sync or async action) or a series of actions in a single MobX transaction.
+It will return a Promise which resolves an array(Promise<any[]>).
 Takes an action description as produced by the `onAction` middleware.
 
 **Parameters**
@@ -612,7 +612,7 @@ export interface IActionRecorder {
      // stop recording actions
      stop(): any
      // apply all the recorded actions on the given object
-     replay(target: IStateTreeNode): any
+     replay(target: IStateTreeNode): Promise<any[]>
 }
 ```
 

--- a/packages/mobx-state-tree/src/middlewares/on-action.ts
+++ b/packages/mobx-state-tree/src/middlewares/on-action.ts
@@ -31,7 +31,7 @@ export type ISerializedActionCall = {
 export interface IActionRecorder {
     actions: ReadonlyArray<ISerializedActionCall>
     stop(): any
-    replay(target: IStateTreeNode): any
+    replay(target: IStateTreeNode): Promise<any[]>
 }
 
 function serializeArgument(node: INode, actionName: string, index: number, arg: any): any {
@@ -144,7 +144,7 @@ function baseApplyAction(target: IStateTreeNode, action: ISerializedActionCall):
  *      // stop recording actions
  *      stop(): any
  *      // apply all the recorded actions on the given object
- *      replay(target: IStateTreeNode): any
+ *      replay(target: IStateTreeNode): Promise<any[]>
  * }
  *
  * @export


### PR DESCRIPTION
Implemented #439 
There are two things may need us to be careful:
* `IActionRecorder.replay` will return Promise<any[]>(same as the result of applyAction) instead of void/undefined.
* Some docs or code that keep in other packages(e.g. mst-middlewares) haven't been updated yet, because they use mst from node modules.