### PR TITLE
Mst3 optimizations

### DIFF
--- a/packages/mobx-state-tree/.vscode/launch.json
+++ b/packages/mobx-state-tree/.vscode/launch.json
@@ -5,7 +5,7 @@
             "type": "node",
             "request": "launch",
             "name": "debug unit test",
-            "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
+            "program": "${workspaceRoot}/node_modules/.bin/jest",
             "args": ["-i", "${file}"],
         }
     ]

--- a/packages/mobx-state-tree/package.json
+++ b/packages/mobx-state-tree/package.json
@@ -10,7 +10,7 @@
     "build": "tsc && cpr lib dist --delete-first --filter=\\\\.js && yarn rollup",
     "rollup": "rollup -c",
     "test": "cross-env NODE_ENV=development jest --ci && cross-env NODE_ENV=production jest --ci && yarn run test-cyclic && yarn run test-mobx4",
-    "speedtest": "yarn build && node --expose-gc test/perf/report.js",
+    "speedtest": "yarn build && /usr/bin/time node --expose-gc test/perf/report.js",
     "test-cyclic": "yarn run build && node -e \"require('.')\"",
     "test-mobx4": "yarn add -D mobx@4.3.1 && yarn build && jest --ci && git checkout package.json ../../yarn.lock && yarn install",
     "watch": "jest --watch",

--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -237,11 +237,11 @@ export class ObjectNode implements INode {
         return this._value
     }
 
-    @computed
     private get _value(): any {
         if (!this.isAlive) return undefined
         return this.type.getValue(this)
     }
+
     // advantage of using computed for a snapshot is that nicely respects transactions etc.
     @computed
     public get snapshot(): any {

--- a/packages/mobx-state-tree/src/core/node/scalar-node.ts
+++ b/packages/mobx-state-tree/src/core/node/scalar-node.ts
@@ -1,4 +1,3 @@
-import { computed } from "mobx"
 import {
     INode,
     escapeJsonPath,
@@ -7,7 +6,6 @@ import {
     NodeLifeCycle,
     noop,
     ObjectNode,
-    invalidateComputed,
     IAnyType
 } from "../../internal"
 
@@ -15,8 +13,7 @@ export class ScalarNode implements INode {
     readonly type: IAnyType
     readonly storedValue: any
     readonly parent: ObjectNode | null
-
-    subpath: string = ""
+    readonly subpath: string = ""
 
     private state = NodeLifeCycle.INITIALIZING
     _environment: any = undefined
@@ -52,9 +49,8 @@ export class ScalarNode implements INode {
     /*
      * Returnes (escaped) path representation as string
      */
-    @computed
     public get path(): string {
-        if (!this.parent) return ""
+        if (!this.parent) return this.subpath
         return this.parent.path + "/" + escapeJsonPath(this.subpath)
     }
 
@@ -69,10 +65,7 @@ export class ScalarNode implements INode {
     }
 
     setParent(newParent: INode | null, subpath: string | null = null) {
-        if (this.parent !== newParent) fail(`Cannot change parent of immutable node`)
-        if (this.subpath === subpath) return
-        this.subpath = subpath || ""
-        invalidateComputed(this, "path")
+        fail("setParent is not supposed to be called on scalar nodes")
     }
 
     public get value(): any {

--- a/packages/mobx-state-tree/src/core/node/scalar-node.ts
+++ b/packages/mobx-state-tree/src/core/node/scalar-node.ts
@@ -50,7 +50,7 @@ export class ScalarNode implements INode {
      * Returnes (escaped) path representation as string
      */
     public get path(): string {
-        if (!this.parent) return this.subpath
+        if (!this.parent) return ""
         return this.parent.path + "/" + escapeJsonPath(this.subpath)
     }
 

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -8,7 +8,9 @@ import {
     observable,
     _interceptReads,
     _getAdministration,
-    isComputedProp
+    isComputedProp,
+    computed,
+    set
 } from "mobx"
 import {
     fail,
@@ -363,8 +365,7 @@ export class ModelType<S extends ModelProperties, T> extends ComplexType<any, an
         // check views return
         if (!isPlainObject(state))
             fail(`volatile state initializer should return a plain object containing state`)
-        // TODO: typecheck & namecheck members of state?
-        extendObservable(self, state, EMPTY_OBJECT, mobxShallow)
+        set(self, state)
     }
 
     extend(fn: (self: any) => any): any {
@@ -411,13 +412,8 @@ export class ModelType<S extends ModelProperties, T> extends ComplexType<any, an
                             descriptor.set
                         )
                 } else {
-                    const tmp = {}
-                    Object.defineProperty(tmp, key, {
-                        get: descriptor.get,
-                        set: descriptor.set,
-                        enumerable: true
-                    })
-                    extendObservable(self, tmp, EMPTY_OBJECT, mobxShallow)
+                    // use internal api as shortcut
+                    ;(computed as any)(self, key, descriptor, true)
                 }
             } else if (typeof value === "function") {
                 // this is a view function, merge as is!

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -490,8 +490,7 @@ export class ModelType<S extends ModelProperties, T> extends ComplexType<any, an
         const type = objNode.type as ModelType<any, any>
         const instance = objNode.storedValue as IStateTreeNode
 
-        extendObservable(instance, EMPTY_OBJECT, EMPTY_OBJECT, mobxShallow)
-        set(instance, childNodes)
+        extendObservable(instance, childNodes, EMPTY_OBJECT, mobxShallow)
         type.forAllProps(name => {
             _interceptReads(instance, name, objNode.unbox)
         })

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -490,15 +490,9 @@ export class ModelType<S extends ModelProperties, T> extends ComplexType<any, an
         const type = objNode.type as ModelType<any, any>
         const instance = objNode.storedValue as IStateTreeNode
 
+        extendObservable(instance, EMPTY_OBJECT, EMPTY_OBJECT, mobxShallow)
+        set(instance, childNodes)
         type.forAllProps(name => {
-            extendObservable(
-                instance,
-                {
-                    [name]: childNodes[name]
-                },
-                EMPTY_OBJECT,
-                mobxShallow
-            )
             _interceptReads(instance, name, objNode.unbox)
         })
 

--- a/packages/mobx-state-tree/test/env.ts
+++ b/packages/mobx-state-tree/test/env.ts
@@ -54,14 +54,16 @@ test("it is possible to assign instance with the same environment as the parent 
     expect(getEnv(todo) === getEnv(store.todos[0])).toBe(true)
 })
 test("it is not possible to assign instance with a different environment than the parent to a tree", () => {
-    const env1 = createEnvironment()
-    const env2 = createEnvironment()
-    const store = Store.create({ todos: [] }, env1)
-    const todo = Todo.create({}, env2)
-    unprotect(store)
-    expect(() => store.todos.push(todo)).toThrowError(
-        "[mobx-state-tree] A state tree cannot be made part of another state tree as long as their environments are different."
-    )
+    if (process.env.NODE_ENV !== "production") {
+        const env1 = createEnvironment()
+        const env2 = createEnvironment()
+        const store = Store.create({ todos: [] }, env1)
+        const todo = Todo.create({}, env2)
+        unprotect(store)
+        expect(() => store.todos.push(todo)).toThrowError(
+            "[mobx-state-tree] A state tree cannot be made part of another state tree as long as their environments are different."
+        )
+    }
 })
 test("it is possible to set a value inside a map of a map when using the same environment", () => {
     const env = createEnvironment()

--- a/packages/mobx-state-tree/test/map.ts
+++ b/packages/mobx-state-tree/test/map.ts
@@ -34,7 +34,7 @@ test("it should restore the state from the snapshot", () => {
     const { Factory } = createTestFactories()
     const instance = Factory.create({ hello: { to: "world" } })
     expect(getSnapshot(instance)).toEqual({ hello: { to: "world" } })
-    expect("" + instance).toBe("ObservableMap@18[{ hello: AnonymousModel@/hello }]") // default toString
+    expect("" + instance).toBe("ObservableMap@16[{ hello: AnonymousModel@/hello }]") // default toString
 })
 // === SNAPSHOT TESTS ===
 test("it should emit snapshots", () => {

--- a/packages/mobx-state-tree/test/map.ts
+++ b/packages/mobx-state-tree/test/map.ts
@@ -34,7 +34,9 @@ test("it should restore the state from the snapshot", () => {
     const { Factory } = createTestFactories()
     const instance = Factory.create({ hello: { to: "world" } })
     expect(getSnapshot(instance)).toEqual({ hello: { to: "world" } })
-    expect("" + instance).toBe("ObservableMap@16[{ hello: AnonymousModel@/hello }]") // default toString
+    expect(("" + instance).replace(/@\d+/, "@xx")).toBe(
+        "ObservableMap@xx[{ hello: AnonymousModel@/hello }]"
+    ) // default toString
 })
 // === SNAPSHOT TESTS ===
 test("it should emit snapshots", () => {

--- a/packages/mobx-state-tree/test/map.ts
+++ b/packages/mobx-state-tree/test/map.ts
@@ -34,7 +34,7 @@ test("it should restore the state from the snapshot", () => {
     const { Factory } = createTestFactories()
     const instance = Factory.create({ hello: { to: "world" } })
     expect(getSnapshot(instance)).toEqual({ hello: { to: "world" } })
-    expect("" + instance).toBe("ObservableMap@18[{ hello: AnonymousModel@/hello }]") // default toString
+    expect("" + instance).toBe("ObservableMap@26[{ hello: AnonymousModel@/hello }]") // default toString
 })
 // === SNAPSHOT TESTS ===
 test("it should emit snapshots", () => {

--- a/packages/mobx-state-tree/test/map.ts
+++ b/packages/mobx-state-tree/test/map.ts
@@ -34,7 +34,7 @@ test("it should restore the state from the snapshot", () => {
     const { Factory } = createTestFactories()
     const instance = Factory.create({ hello: { to: "world" } })
     expect(getSnapshot(instance)).toEqual({ hello: { to: "world" } })
-    expect("" + instance).toBe("ObservableMap@26[{ hello: AnonymousModel@/hello }]") // default toString
+    expect("" + instance).toBe("ObservableMap@18[{ hello: AnonymousModel@/hello }]") // default toString
 })
 // === SNAPSHOT TESTS ===
 test("it should emit snapshots", () => {


### PR DESCRIPTION
@k-g-a while testing the optimizations, I discovered that paths didn't always correctly propagate there changes (see the added unit test in node.ts). 

So I reverted that to being an observable, but created a lowlevel atom instead, which is a bit cheaper. Also found out that the observables used in scalar-node only slowed things down. (Scalar nodes are not reconciled, so their own subpath / direct parent will never change)

Numbers on the speedtest:

```
Master:      24.6 sec / 352 MB
MST base:    10.8 sec   / 179 MB
this branch: 10.6 sec / 182 MB
```

Would you mind reviewing? I think the numbers are very acceptable and this doesn't include the snapshot disposer optimization yet
