### PR TITLE
WIP - Feature/eager union

### DIFF
--- a/packages/mobx-state-tree/src/types/utility-types/union.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/union.ts
@@ -16,6 +16,7 @@ export type ITypeDispatcher = (snapshot: any) => IType<any, any>
 
 export class Union extends Type<any, any> {
     readonly dispatcher: ITypeDispatcher | null = null
+    readonly eager: Boolean = true
     readonly types: IType<any, any>[]
 
     get flags() {
@@ -62,7 +63,11 @@ export class Union extends Type<any, any> {
 
         // find the most accomodating type
         const applicableTypes = this.types.filter(type => type.is(value))
-        if (applicableTypes.length > 1)
+        if (applicableTypes.length > 1) {
+            debugger
+            console.log(this.types)
+        }
+        if (!this.eager && applicableTypes.length > 1)
             return fail(
                 `Ambiguos snapshot ${JSON.stringify(value)} for union ${this
                     .name}. Please provide a dispatch in the union declaration.`
@@ -79,7 +84,7 @@ export class Union extends Type<any, any> {
         const errors = this.types.map(type => type.validate(value, context))
         const applicableTypes = errors.filter(errorArray => errorArray.length === 0)
 
-        if (applicableTypes.length > 1) {
+        if (!this.eager && applicableTypes.length > 1) {
             return typeCheckFailure(
                 context,
                 value,
@@ -322,7 +327,7 @@ export function union(
     ...otherTypes: IType<any, any>[]
 ): IType<any, any> {
     const dispatcher = isType(dispatchOrType) ? null : dispatchOrType
-    const types = isType(dispatchOrType) ? otherTypes.concat(dispatchOrType) : otherTypes
+    const types = isType(dispatchOrType) ? [dispatchOrType, ...otherTypes] : otherTypes
     const name = "(" + types.map(type => type.name).join(" | ") + ")"
 
     // check all options

--- a/packages/mobx-state-tree/test/action.ts
+++ b/packages/mobx-state-tree/test/action.ts
@@ -149,8 +149,8 @@ if (process.env.NODE_ENV !== "production") {
         expect(() => {
             store.orders[0].setCustomer(store.orders[0])
         }).toThrowError(
-            "[mobx-state-tree] Error while converting <Order@/orders/0> to `(reference(Customer) | null)`:\n\n    " +
-                "value of type Order: <Order@/orders/0> is not assignable to type: `(reference(Customer) | null)`, expected an instance of `(reference(Customer) | null)` or a snapshot like `(reference(Customer) | null?)` instead."
+            "[mobx-state-tree] Error while converting <Order@/orders/0> to `(null | reference(Customer))`:\n\n    " +
+                "value of type Order: <Order@/orders/0> is not assignable to type: `(null | reference(Customer))`, expected an instance of `(null | reference(Customer))` or a snapshot like `(null? | reference(Customer))` instead."
         ) // wrong type!
     })
 }

--- a/packages/mobx-state-tree/test/enum.ts
+++ b/packages/mobx-state-tree/test/enum.ts
@@ -11,7 +11,7 @@ test("should support enums", () => {
     })
     unprotect(l)
     l.color = "Red"
-    expect(TrafficLight.describe()).toBe('{ color: ("Orange" | "Green" | "Red") }')
+    expect(TrafficLight.describe()).toBe('{ color: ("Red" | "Orange" | "Green") }')
     // Note, any cast needed, compiler should correctly error otherwise
     if (process.env.NODE_ENV !== "production") {
         expect(() => (l.color = "Blue" as any)).toThrowError(
@@ -28,11 +28,11 @@ test("should support anonymous enums", () => {
     })
     unprotect(l)
     l.color = "Red"
-    expect(TrafficLight.describe()).toBe('{ color: ("Orange" | "Green" | "Red") }')
+    expect(TrafficLight.describe()).toBe('{ color: ("Red" | "Orange" | "Green") }')
     // Note, any cast needed, compiler should correctly error otherwise
     if (process.env.NODE_ENV !== "production") {
         expect(() => (l.color = "Blue" as any)).toThrowError(
-            /Error while converting `"Blue"` to `"Orange" | "Green" | "Red"`/
+            /Error while converting `"Blue"` to `"Red" | "Orange" | "Green"`/
         )
     }
 })

--- a/packages/mobx-state-tree/test/reference.ts
+++ b/packages/mobx-state-tree/test/reference.ts
@@ -294,7 +294,7 @@ test("it should fail when reference snapshot is ambiguous", () => {
     expect(() => {
         store.selected // store.boxes[1] // throws because it can't know if you mean a box or an arrow!
     }).toThrowError(
-        "[mobx-state-tree] Cannot resolve a reference to type '(Arrow | Box)' with id: '2' unambigously, there are multiple candidates: /boxes/1, /arrows/0"
+        "[mobx-state-tree] Cannot resolve a reference to type '(Box | Arrow)' with id: '2' unambigously, there are multiple candidates: /boxes/1, /arrows/0"
     )
     unprotect(store)
     // first update the reference, than create a new matching item! Ref becomes ambigous now...
@@ -309,7 +309,7 @@ test("it should fail when reference snapshot is ambiguous", () => {
     expect(store.selected).toBe(store.boxes[0]) // unambigous identifier
     store.arrows.push({ id: 1, name: "oops" })
     expect(err.message).toBe(
-        "[mobx-state-tree] Cannot resolve a reference to type '(Arrow | Box)' with id: '1' unambigously, there are multiple candidates: /boxes/0, /arrows/1"
+        "[mobx-state-tree] Cannot resolve a reference to type '(Box | Arrow)' with id: '1' unambigously, there are multiple candidates: /boxes/0, /arrows/1"
     )
 })
 test("it should support array of references", () => {
@@ -488,7 +488,7 @@ test("References are described properly", () => {
         maybeRef: types.maybe(types.reference(Todo))
     })
     expect(Store.describe()).toBe(
-        "{ todo: ({ id: identifier(number) } | null?); ref: reference(AnonymousModel); maybeRef: (reference(AnonymousModel) | null?) }"
+        "{ todo: (null? | { id: identifier(number) }); ref: reference(AnonymousModel); maybeRef: (null? | reference(AnonymousModel)) }"
     )
 })
 test("References in recursive structures", () => {

--- a/packages/mobx-state-tree/test/union.ts
+++ b/packages/mobx-state-tree/test/union.ts
@@ -24,6 +24,13 @@ const createTestFactories = () => {
     })
     return { Box, Square, Cube, Plane, DispatchPlane, Heighed, Block }
 }
+const createLiteralTestFactories = () => {
+    const Man = types.model("Man", { type: types.literal("M") })
+    const Woman = types.model("Woman", { type: types.literal("W") })
+    const All = types.model("All", { type: types.identifier(types.string) })
+    const ManWomanOrAll = types.union(Man, Woman, All)
+    return { Man, Woman, All, ManWomanOrAll }
+}
 if (process.env.NODE_ENV !== "production") {
     test("it should complain about multiple applicable types no dispatch method", () => {
         const { Box, Plane, Square } = createTestFactories()
@@ -89,4 +96,16 @@ test("it should use dispatch to discriminate", () => {
     const { Box, DispatchPlane, Square } = createTestFactories()
     const a = DispatchPlane.create({ width: 3 })
     expect(getSnapshot(a)).toEqual({ width: 3 })
+})
+test("it should eagerly match by ambiguos value", () => {
+    const { ManWomanOrAll, All, Man } = createLiteralTestFactories()
+    const person = ManWomanOrAll.create({ type: "Z" })
+    expect(All.is(person)).toEqual(true)
+    expect(Man.is(person)).toEqual(false)
+})
+test("it should eagerly match by value literal", () => {
+    const { ManWomanOrAll, All, Man } = createLiteralTestFactories()
+    const person = ManWomanOrAll.create({ type: "M" })
+    expect(All.is(person)).toEqual(false)
+    expect(Man.is(person)).toEqual(true)
 })

--- a/packages/mobx-state-tree/test/union.ts
+++ b/packages/mobx-state-tree/test/union.ts
@@ -33,9 +33,12 @@ const createLiteralTestFactories = () => {
 }
 if (process.env.NODE_ENV !== "production") {
     test("it should complain about multiple applicable types no dispatch method", () => {
-        const { Box, Plane, Square } = createTestFactories()
+        const { Box, Square } = createTestFactories()
+        const PlaneNotEager = types.union(Square, Box, {
+            eager: false
+        })
         expect(() => {
-            Plane.create({ width: 2, height: 2 })
+            PlaneNotEager.create({ width: 2, height: 2 })
         }).toThrow(/Error while converting/)
     })
 }


### PR DESCRIPTION
This change enables eager unions by default.  One of the most impactful changes is the proper sorting on union types.  Currently Union will take the first param and check if it's a dispatch function.  If it's a Type it will be appended to the end of the types array.  I've moved it back to the front. 

I'm having a hard time pop-ing the options off the array of types.  In addition, I don't have a clue if I'm approaching the UnionOptions TS the correct way.  I tried to follow reference.ts as an example. 


