### PR TITLE
add Typeflags to exports

### DIFF
--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -93,7 +93,8 @@ export {
     recordActions,
     createActionTrackingMiddleware,
     setLivelynessChecking,
-    LivelynessMode
+    LivelynessMode,
+    TypeFlags
 } from "./internal"
 
 export * from "./core/mst-operations"


### PR DESCRIPTION
Some of the code being generated for .d.ts seems to be using (for example)
```typescript
flags: TypeFlags.Optional;
```
but it's not being exported so that's causing some errors