### PR TITLE
use interfaces wherever possible, they compile/parse faster

### DIFF
--- a/packages/mobx-state-tree/package.json
+++ b/packages/mobx-state-tree/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@types/jest": "^22.2.0",
     "@types/node": "^8.0.19",
+    "@types/sinon": "^5.0.1",
     "concat": "^1.0.3",
     "concurrently": "^3.1.0",
     "coveralls": "^2.11.4",

--- a/packages/mobx-state-tree/src/core/json-patch.ts
+++ b/packages/mobx-state-tree/src/core/json-patch.ts
@@ -3,13 +3,13 @@ import { fail } from "../internal"
 // https://tools.ietf.org/html/rfc6902
 // http://jsonpatch.com/
 
-export type IJsonPatch = {
+export interface IJsonPatch {
     op: "replace" | "add" | "remove"
     path: string
     value?: any
 }
 
-export type IReversibleJsonPatch = IJsonPatch & {
+export interface IReversibleJsonPatch extends IJsonPatch {
     oldValue: any // This goes beyond JSON-patch, but makes sure each patch can be inverse applied
 }
 

--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -77,7 +77,9 @@ export {
     IAnyType,
     IModelType,
     IMSTMap,
+    IMapType,
     IMSTArray,
+    IArrayType,
     IType,
     ISimpleType,
     IComplexType,
@@ -87,6 +89,7 @@ export {
     joinJsonPath,
     splitJsonPath,
     IJsonPatch,
+    IReversibleJsonPatch,
     decorate,
     addMiddleware,
     IMiddlewareEvent,
@@ -109,7 +112,14 @@ export {
     ModelSnapshotType,
     ModelCreationType,
     ModelInstanceType,
-    ModelPropertiesDeclarationToProperties
+    ModelPropertiesDeclarationToProperties,
+    ModelProperties,
+    ModelPropertiesDeclaration,
+    OptionalPropertyTypes,
+    ModelActions,
+    ModelTypeConfig,
+    CustomTypeOptions,
+    UnionOptions
 } from "./internal"
 
 export * from "./core/mst-operations"

--- a/packages/mobx-state-tree/src/middlewares/on-action.ts
+++ b/packages/mobx-state-tree/src/middlewares/on-action.ts
@@ -21,7 +21,7 @@ import {
     IAnyStateTreeNode
 } from "../internal"
 
-export type ISerializedActionCall = {
+export interface ISerializedActionCall {
     name: string
     path?: string
     args?: any[]

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -42,7 +42,8 @@ import {
 } from "../../internal"
 
 export interface IMSTArray<C, S, T> extends IObservableArray<T> {}
-export type IArrayType<C, S, T> = IComplexType<C[] | undefined, S[], IMSTArray<C, S, T>> & {
+export interface IArrayType<C, S, T>
+    extends IComplexType<C[] | undefined, S[], IMSTArray<C, S, T>> {
     flags: TypeFlags.Optional
 }
 

--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -43,11 +43,10 @@ import {
     IAnyStateTreeNode
 } from "../../internal"
 
-export type IMapType<C, S, T> = IComplexType<
-    IKeyValueMap<C> | undefined,
-    IKeyValueMap<S>,
-    IMSTMap<C, S, T>
-> & { flags: TypeFlags.Optional }
+export interface IMapType<C, S, T>
+    extends IComplexType<IKeyValueMap<C> | undefined, IKeyValueMap<S>, IMSTMap<C, S, T>> {
+    flags: TypeFlags.Optional
+}
 
 export interface IMSTMap<C, S, T> {
     // bases on ObservableMap, but fine tuned to the auto snapshot conversion of MST

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -63,13 +63,13 @@ export enum HookNames {
     beforeDestroy = "beforeDestroy"
 }
 
-export type ModelProperties = {
+export interface ModelProperties {
     [key: string]: IAnyType
 }
 
 export type ModelPrimitive = string | number | boolean | Date
 
-export type ModelPropertiesDeclaration = {
+export interface ModelPropertiesDeclaration {
     [key: string]: ModelPrimitive | IAnyType
 }
 
@@ -90,7 +90,9 @@ export type ModelPropertiesDeclarationToProperties<T extends ModelPropertiesDecl
                     : T[K] extends IAnyType ? T[K] : never
 }
 
-export type OptionalPropertyTypes = { flags: TypeFlags.Optional }
+export interface OptionalPropertyTypes {
+    flags: TypeFlags.Optional
+}
 
 export type RequiredPropNames<T> = {
     [K in keyof T]: T[K] extends OptionalPropertyTypes ? never : K
@@ -122,7 +124,7 @@ export type ModelInstanceType<T extends ModelPropertiesDeclarationToProperties<a
     O &
     IStateTreeNode<C, S>
 
-export type ModelActions = {
+export interface ModelActions {
     [key: string]: Function
 }
 
@@ -162,7 +164,7 @@ function objectTypeToString(this: any) {
     return getStateTreeNode(this).toString()
 }
 
-export type ModelTypeConfig = {
+export interface ModelTypeConfig {
     name?: string
     properties?: ModelProperties
     initializers?: ReadonlyArray<((instance: any) => any)>

--- a/packages/mobx-state-tree/src/types/utility-types/custom.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/custom.ts
@@ -12,7 +12,7 @@ import {
     IAnyType
 } from "../../internal"
 
-export type CustomTypeOptions<S, T> = {
+export interface CustomTypeOptions<S, T> {
     // Friendly name
     name: string
     // given a serialized value, how to turn it into the target type
@@ -33,7 +33,7 @@ export type CustomTypeOptions<S, T> = {
  * The signature of the options is:
  *
  * ```javascript
- * export type CustomTypeOptions<S, T> = {
+ * export interface CustomTypeOptions<S, T> {
  *     // Friendly name
  *     name: string
  *     // given a serialized value, how to turn it into the target type

--- a/packages/mobx-state-tree/src/types/utility-types/union.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/union.ts
@@ -19,7 +19,10 @@ import {
 
 export type ITypeDispatcher = (snapshot: any) => IAnyType
 
-export type UnionOptions = { eager?: boolean; dispatcher?: ITypeDispatcher }
+export interface UnionOptions {
+    eager?: boolean
+    dispatcher?: ITypeDispatcher
+}
 
 export class Union extends Type<any, any, any> {
     readonly dispatcher?: ITypeDispatcher

--- a/packages/mobx-state-tree/test/deprecated.ts
+++ b/packages/mobx-state-tree/test/deprecated.ts
@@ -2,6 +2,7 @@ import { spy } from "sinon"
 import { deprecated } from "../src/utils"
 import { flow, createFlowSpawner } from "../src/core/flow"
 import { process as mstProcess, createProcessSpawner } from "../src/core/process"
+
 function createDeprecationListener() {
     // clear previous deprecation dedupe keys
     deprecated.ids = {}

--- a/packages/mobx-state-tree/test/fixture-models.ts
+++ b/packages/mobx-state-tree/test/fixture-models.ts
@@ -1,5 +1,6 @@
-import { Hero, Monster, Treasure } from "./fixtures/fixture-models.js"
+import { Hero, Monster, Treasure } from "./fixtures/fixture-models"
 import { unprotect } from "../src"
+
 const SAMPLE_HERO = {
     id: 1,
     name: "jimmy",
@@ -29,7 +30,8 @@ test("Monster computed fields", () => {
         hasFangs: true,
         hasClaws: true,
         hasWings: true,
-        hasGrowl: true
+        hasGrowl: true,
+        freestyle: null
     })
     expect(monster.isAlive).toBe(true)
     expect(monster.isFlashingRed).toBe(true)

--- a/packages/mobx-state-tree/test/fixtures/fixture-data.ts
+++ b/packages/mobx-state-tree/test/fixtures/fixture-data.ts
@@ -1,26 +1,25 @@
-const { HeroRoles } = require("./fixture-models")
+import { HeroRoles } from "./fixture-models"
+
 /**
  * Creates data containing very few fields.
  *
  * @param count The number of items to create.
  */
-function createTreasure(count) {
+export function createTreasure(count: number) {
     const data = []
     let i = 0
     do {
         data.push({
             trapped: i % 2 === 0,
-            gold: (count % 10 + 1) * 10
+            gold: ((count % 10) + 1) * 10
         })
         i++
     } while (i < count)
     return data
 }
-exports.createTreasure = createTreasure
 
 // why yes i DID graduate high school, why do you ask?
-const rando = () => (Math.random() > 0.5 ? 1 : 0)
-exports.rando = rando
+export const rando = () => (Math.random() > 0.5 ? 1 : 0)
 
 const titles = ["Sir", "Lady", "Baron von", "Baroness", "Captain", "Dread", "Fancy"].sort(rando)
 const givenNames = ["Abe", "Beth", "Chuck", "Dora", "Ernie", "Fran", "Gary", "Haily"].sort(rando)
@@ -33,7 +32,7 @@ const wtf = `Daenerys Stormborn of the House Targaryen, First of Her Name, the U
  *
  * @param count The number of items to create.
  */
-function createHeros(count) {
+export function createHeros(count: number) {
     const data = []
     let i = 0
     let even = true
@@ -47,7 +46,7 @@ function createHeros(count) {
         data.push({
             id: i,
             name: `${n1} ${n2} the ${n3}`,
-            level: count % 100 + 1,
+            level: (count % 100) + 1,
             role: HeroRoles[i % HeroRoles.length],
             description: `${wtf} ${wtf} ${wtf}`
         })
@@ -56,7 +55,6 @@ function createHeros(count) {
     } while (i < count)
     return data
 }
-exports.createHeros = createHeros
 
 /**
  * Creates data with a large number of fields and data.
@@ -65,7 +63,7 @@ exports.createHeros = createHeros
  * @param treasureCount The number of small children to create.
  * @param heroCount The number of medium children to create.
  */
-function createMonsters(count, treasureCount, heroCount) {
+export function createMonsters(count: number, treasureCount: number, heroCount: number) {
     const data = []
     let i = 0
     let even = true
@@ -75,7 +73,7 @@ function createMonsters(count, treasureCount, heroCount) {
         data.push({
             id: `omg-${i}-run!`,
             freestyle: `${wtf} ${wtf} ${wtf}${wtf} ${wtf} ${wtf}`,
-            level: count % 100 + 1,
+            level: (count % 100) + 1,
             hp: i % 2 === 0 ? 1 : 5 * i,
             maxHp: 5 * i,
             warning: "!!!!!!",
@@ -99,4 +97,3 @@ function createMonsters(count, treasureCount, heroCount) {
     } while (i < count)
     return data
 }
-exports.createMonsters = createMonsters

--- a/packages/mobx-state-tree/test/fixtures/fixture-models.ts
+++ b/packages/mobx-state-tree/test/fixtures/fixture-models.ts
@@ -1,12 +1,13 @@
-const { types } = require("../../src")
+import { types } from "../../src"
+
 // tiny
-exports.Treasure = types.model("Treasure", {
+export const Treasure = types.model("Treasure", {
     trapped: types.boolean,
     gold: types.optional(types.number, 0)
 })
 // medium
-exports.HeroRoles = ["warrior", "wizard", "cleric", "thief"]
-exports.Hero = types
+export const HeroRoles = ["warrior", "wizard", "cleric", "thief"]
+export const Hero = types
     .model("Hero", {
         id: types.identifierNumber,
         name: types.string,
@@ -20,7 +21,7 @@ exports.Hero = types
         }
     }))
 // large
-exports.Monster = types
+export const Monster = types
     .model("Monster", {
         id: types.identifier,
         freestyle: types.frozen(),

--- a/packages/mobx-state-tree/test/perf.ts
+++ b/packages/mobx-state-tree/test/perf.ts
@@ -1,5 +1,6 @@
 import { smallScenario, mediumScenario, largeScenario } from "./perf/scenarios"
 import { start } from "./perf/timer"
+
 // TODO: Not sure how this should work. This feels super fragile.
 const TOO_SLOW_MS = 10000
 test("performs well on small scenario", () => {

--- a/packages/mobx-state-tree/test/perf/report.ts
+++ b/packages/mobx-state-tree/test/perf/report.ts
@@ -1,4 +1,5 @@
-const { smallScenario, mediumScenario, largeScenario } = require("./scenarios")
+import { smallScenario, mediumScenario, largeScenario } from "./scenarios"
+
 // here's what we'll be testing
 const plan = [
     "-----------",
@@ -52,7 +53,7 @@ smallScenario(1000)
 mediumScenario(500)
 largeScenario(100, 10, 10)
 // remember when this broke the internet?
-function leftPad(value, length, char = " ") {
+function leftPad(value: string, length: number, char = " "): string {
     return value.toString().length < length ? leftPad(char + value, length) : value
 }
 // let's start

--- a/packages/mobx-state-tree/test/perf/scenarios.ts
+++ b/packages/mobx-state-tree/test/perf/scenarios.ts
@@ -1,12 +1,13 @@
-const { start } = require("./timer")
-const { Treasure, Hero, Monster } = require("../fixtures/fixture-models")
-const { createTreasure, createHeros, createMonsters } = require("../fixtures/fixture-data")
+import { start } from "./timer"
+import { Treasure, Hero, Monster } from "../fixtures/fixture-models"
+import { createTreasure, createHeros, createMonsters } from "../fixtures/fixture-data"
+
 /**
  * Covers models with a trivial number of fields.
  *
  * @param count The number of records to create.
  */
-exports.smallScenario = function smallScenario(count) {
+export const smallScenario = function smallScenario(count: number) {
     const data = createTreasure(count) // ready?
     const time = start()
     const converted = data.map(d => Treasure.create(d)) // go
@@ -19,7 +20,7 @@ exports.smallScenario = function smallScenario(count) {
  *
  * @param count The number of records to create.
  */
-exports.mediumScenario = function mediumScenario(count) {
+export const mediumScenario = function mediumScenario(count: number) {
     const data = createHeros(count) // ready?
     const time = start()
     const converted = data.map(d => Hero.create(d)) // go
@@ -34,7 +35,11 @@ exports.mediumScenario = function mediumScenario(count) {
  * @param smallChildren The number of small children contained within.
  * @param mediumChildren The number of medium children contained within.
  */
-exports.largeScenario = function largeScenario(count, smallChildren, mediumChildren) {
+export const largeScenario = function largeScenario(
+    count: number,
+    smallChildren: number,
+    mediumChildren: number
+) {
     const data = createMonsters(count, smallChildren, mediumChildren) // ready?
     const time = start()
     const converted = data.map(d => Monster.create(d)) // go

--- a/packages/mobx-state-tree/test/perf/timer.ts
+++ b/packages/mobx-state-tree/test/perf/timer.ts
@@ -14,9 +14,9 @@
  * time(true) // 1.00
  * ```
  */
-exports.start = () => {
+export const start = () => {
     const started = process.hrtime()
-    let last = [started[0], started[1]]
+    let last: [number, number] = [started[0], started[1]]
     return (lapTime = false) => {
         const final = process.hrtime(lapTime ? last : started)
         return Math.round((final[0] * 1e9 + final[1]) / 1e6)

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,6 +66,10 @@
   version "8.0.47"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.47.tgz#968e596f91acd59069054558a00708c445ca30c2"
 
+"@types/sinon@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-5.0.1.tgz#a15b36ec42f1f53166617491feabd1734cb03e21"
+
 JSONStream@^1.0.3, JSONStream@^1.0.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"


### PR DESCRIPTION
this small pull request is to change some types to interfaces wherever possible, since they are compiled/parsed faster by TS