### PR TITLE
Update Jest configs

### DIFF
--- a/packages/mobx-state-tree/package.json
+++ b/packages/mobx-state-tree/package.json
@@ -9,13 +9,14 @@
   "scripts": {
     "build": "tsc && cpr lib dist --delete-first --filter=\\\\.js && yarn rollup",
     "rollup": "rollup -c",
-    "test": "cross-env NODE_ENV=development jest --ci && cross-env NODE_ENV=production jest --ci && yarn run test:cyclic && yarn run test:mobx4",
-    "test:perf": "yarn build && yarn jest --testRegex 'test/perf/fixture*' && TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' /usr/bin/time node --expose-gc --require ts-node/register test/perf/report.ts",
+    "jest": "jest --projects='test'",
+    "jest:perf": "jest --projects='test/perf'",
+    "test": "cross-env NODE_ENV=development yarn jest --ci && cross-env NODE_ENV=production yarn jest --ci && yarn run test:cyclic && yarn run test:mobx4",
+    "test:perf": "yarn build && yarn jest:perf && TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' /usr/bin/time node --expose-gc --require ts-node/register test/perf/report.ts",
     "test:cyclic": "yarn run build && node -e \"require('.')\"",
-    "test:mobx4": "yarn add -D mobx@4.3.1 && yarn build && jest --ci && git checkout package.json ../../yarn.lock && yarn install",
-    "watch": "jest --watch",
+    "test:mobx4": "yarn add -D mobx@4.3.1 && yarn build && yarn jest --ci && git checkout package.json ../../yarn.lock && yarn install",
     "_prepublish": "yarn run build && yarn run build-docs",
-    "coverage": "jest --coverage",
+    "coverage": "yarn jest --coverage",
     "build-docs": "tsc && documentation build lib/index.js --sort-order alpha -f md -o ../../API.md.tmp && concat -o ../../API.md ../../docs/API_header.md ../../API.md.tmp && rm ../../API.md.tmp",
     "lint": "tslint -c tslint.json 'src/**/*.ts'"
   },
@@ -67,26 +68,5 @@
     "frp",
     "functional-reactive-programming",
     "state management"
-  ],
-  "jest": {
-    "transform": {
-      "^.+\\.tsx?$": "ts-jest",
-      "^.+\\.jsx?$": "babel-jest"
-    },
-    "testRegex": "test/(?!perf).*\\.(t|j)sx?$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/src/",
-      "/dist/",
-      "/test/perf/fixtures",
-      "/\\./"
-    ]
-  }
+  ]
 }

--- a/packages/mobx-state-tree/test/jest.config.js
+++ b/packages/mobx-state-tree/test/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+    displayName: "test",
+    transform: {
+        "^.+\\.tsx?$": "ts-jest",
+        "^.+\\.jsx?$": "babel-jest"
+    },
+    testRegex: ".*\\.ts?$",
+    moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
+    testPathIgnorePatterns: [
+        "/node_modules/",
+        "/src/",
+        "/dist/",
+        "/test/jest.config.js",
+        "/test/perf/",
+        "/\\./"
+    ]
+}

--- a/packages/mobx-state-tree/test/perf/jest.config.js
+++ b/packages/mobx-state-tree/test/perf/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+    displayName: "perf",
+    transform: {
+        "^.+\\.tsx?$": "ts-jest",
+        "^.+\\.jsx?$": "babel-jest"
+    },
+    testRegex: ".*\\.ts?$",
+    moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
+    testPathIgnorePatterns: [
+        "/node_modules/",
+        "/src/",
+        "/dist/",
+        "/test/perf/fixtures",
+        "/test/perf/scenarios.ts",
+        "/test/perf/report.ts",
+        "/test/perf/timer.ts",
+        "/test/perf/jest.config.js",
+        "/\\./"
+    ]
+}


### PR DESCRIPTION
## Overview

This PR updates the Jest configs to make it easier to run regular tests vs performance tests

![](http://dp.hanlon.io/1C2z3R3c1029/Screen%20Recording%202018-07-26%20at%2001.01%20PM.gif)

## Details
- Creates two jest projects: "test" and "test/perf"
- Adds `yarn jest` which runs the normal tests
- Adds `yarn jest:perf` which runs the performance tests
- Removes `yarn watch` since it's preferred to do `yarn jest --watch`

