### PR TITLE
fix for getParent and getRoot defs so they support both typeof AnyType and typeof AnyType.Type

### DIFF
--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -1,6 +1,12 @@
 import { isComputedProp, isObservableProp } from "mobx"
 import { ExtractS, ExtractT, IAnyStateTreeNode, ExtractC } from "../internal"
 
+export type TypeOrStateTreeNodeToStateTreeNode<
+    T extends IAnyType | IAnyStateTreeNode
+> = T extends IAnyStateTreeNode
+    ? T
+    : T extends IAnyType ? ExtractIStateTreeNode<T, ExtractC<T>, ExtractS<T>, ExtractT<T>> : never
+
 /**
  * Returns the _actual_ type of the given tree node. (Or throws)
  *
@@ -313,10 +319,10 @@ export function hasParent(target: IAnyStateTreeNode, depth: number = 1): boolean
  * @param {number} depth = 1, how far should we look upward?
  * @returns {*}
  */
-export function getParent<IT extends IAnyType>(
+export function getParent<IT extends IAnyStateTreeNode | IAnyType>(
     target: IAnyStateTreeNode,
     depth = 1
-): ExtractIStateTreeNode<IT, ExtractC<IT>, ExtractS<IT>, ExtractT<IT>> {
+): TypeOrStateTreeNodeToStateTreeNode<IT> {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
@@ -397,9 +403,9 @@ export function getParentOfType<IT extends IAnyType>(
  * @param {Object} target
  * @returns {*}
  */
-export function getRoot<IT extends IAnyType>(
+export function getRoot<IT extends IAnyType | IAnyStateTreeNode>(
     target: IAnyStateTreeNode
-): ExtractIStateTreeNode<IT, ExtractC<IT>, ExtractS<IT>, ExtractT<IT>> {
+): TypeOrStateTreeNodeToStateTreeNode<IT> {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
@@ -804,3 +810,4 @@ import {
     ExtractIStateTreeNode,
     IMSTArray
 } from "../internal"
+import { ModelPrimitive } from "../types/complex-types/model"

--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -1,11 +1,11 @@
 import { isComputedProp, isObservableProp } from "mobx"
-import { ExtractS, ExtractT, IAnyStateTreeNode, ExtractC } from "../internal"
+import { ExtractS, ExtractT, IAnyStateTreeNode, ExtractC, IType } from "../internal"
 
 export type TypeOrStateTreeNodeToStateTreeNode<
     T extends IAnyType | IAnyStateTreeNode
 > = T extends IAnyStateTreeNode
     ? T
-    : T extends IAnyType ? ExtractIStateTreeNode<T, ExtractC<T>, ExtractS<T>, ExtractT<T>> : never
+    : T extends IType<infer TC, infer TS, infer TT> ? ExtractIStateTreeNode<T, TC, TS, TT> : never
 
 /**
  * Returns the _actual_ type of the given tree node. (Or throws)

--- a/packages/mobx-state-tree/src/types/primitives.ts
+++ b/packages/mobx-state-tree/src/types/primitives.ts
@@ -195,8 +195,11 @@ export function isPrimitiveType<S = any, T = any>(type: IAnyType): type is CoreT
     return (
         isType(type) &&
         (type.flags &
-            (TypeFlags.String | TypeFlags.Number | TypeFlags.Integer,
-            TypeFlags.Boolean | TypeFlags.Date)) >
+            (TypeFlags.String |
+                TypeFlags.Number |
+                TypeFlags.Integer |
+                TypeFlags.Boolean |
+                TypeFlags.Date)) >
             0
     )
 }

--- a/packages/mobx-state-tree/test/boxes-store.ts
+++ b/packages/mobx-state-tree/test/boxes-store.ts
@@ -16,7 +16,7 @@ export const Box = types
         },
         get isSelected() {
             if (!hasParent(self)) return false
-            return getParent(getParent(self)).selection === self
+            return getParent<typeof Store>(getParent(self)).selection === self
         }
     }))
     .actions(self => {

--- a/packages/mobx-state-tree/test/parent-properties.ts
+++ b/packages/mobx-state-tree/test/parent-properties.ts
@@ -8,7 +8,7 @@ const ChildModel = types
     .views(self => {
         return {
             get parent() {
-                return getParent(self)
+                return getParent<typeof ParentModel>(self)
             }
         }
     })

--- a/packages/mobx-state-tree/test/protect.ts
+++ b/packages/mobx-state-tree/test/protect.ts
@@ -109,7 +109,7 @@ test("action cannot modify parent", () => {
         })
         .actions(self => ({
             setParentX() {
-                getParent(self).x += 1
+                getParent<typeof self>(self).x += 1
             }
         }))
     const Parent = types.model("Parent", {

--- a/packages/mobx-state-tree/test/reference-custom.ts
+++ b/packages/mobx-state-tree/test/reference-custom.ts
@@ -60,7 +60,7 @@ test("it should support custom references - adv", () => {
     const NameReference = types.reference(User, {
         get(identifier, parent) {
             if (identifier === null) return null
-            const users = values(getRoot(parent!).users)
+            const users = values(getRoot<any>(parent!).users)
             return users.filter((u: typeof User.Type) => u.name === identifier)[0] || null
         },
         set(value) {

--- a/packages/mobx-state-tree/test/type-system.ts
+++ b/packages/mobx-state-tree/test/type-system.ts
@@ -1,4 +1,4 @@
-import { types, getSnapshot, unprotect, IType } from "../src"
+import { types, getSnapshot, unprotect, IType, getRoot, getParent } from "../src"
 const createTestFactories = () => {
     const Box = types.model({
         width: 0,
@@ -553,4 +553,48 @@ test("#923", () => {
     })
 
     types.optional(types.map(Bar), {}) // Should have no compile error!
+})
+
+test("#951", () => {
+    const C = types.model({ a: 123 })
+
+    // model as root
+    const ModelWithC = types.model({ c: C })
+    const modelInstance = ModelWithC.create({ c: C.create() })
+
+    // getRoot
+    const modelRoot1 = getRoot<typeof ModelWithC>(modelInstance.c)
+    const modelCR1: typeof C.Type = modelRoot1.c
+    const modelRoot2 = getRoot<typeof ModelWithC.Type>(modelInstance.c)
+    const modelCR2: typeof C.Type = modelRoot2.c
+
+    // getParent
+    const modelParent1 = getParent<typeof ModelWithC>(modelInstance.c)
+    const modelCP1: typeof ModelWithC.Type = modelParent1
+    const modelParent2 = getParent<typeof ModelWithC.Type>(modelInstance.c)
+    const modelCP2: typeof ModelWithC.Type = modelParent2
+
+    // array as root
+    const ArrayOfC = types.array(C)
+    const arrayInstance = ArrayOfC.create([C.create()])
+
+    // getRoot
+    const arrayRoot1 = getRoot<typeof ArrayOfC>(arrayInstance[0])
+    const arrayCR1: typeof C.Type = arrayRoot1[0]
+
+    // getParent
+    const arrayParent1 = getParent<typeof ArrayOfC>(arrayInstance[0])
+    const arrayCP1: typeof ArrayOfC.Type = arrayParent1
+
+    // map as root
+    const MapOfC = types.map(C)
+    const mapInstance = MapOfC.create({ a: C.create() })
+
+    // getRoot
+    const mapRoot1 = getRoot<typeof MapOfC>(mapInstance.get("a")!)
+    const mapC1: typeof C.Type = mapRoot1.get("a")!
+
+    // getParent
+    const mapParent1 = getRoot<typeof MapOfC>(mapInstance.get("a")!)
+    const mapCP1: typeof MapOfC.Type = mapParent1
 })


### PR DESCRIPTION
Fixes #951

already included in PR 952