### PR TITLE
[Internal] Cleanup 'createNode' and related codepaths

### DIFF
--- a/packages/mobx-state-tree/src/core/node/node-utils.ts
+++ b/packages/mobx-state-tree/src/core/node/node-utils.ts
@@ -69,6 +69,10 @@ export function getStateTreeNode(value: IAnyStateTreeNode): ObjectNode {
     else return fail(`Value ${value} is no MST Node`)
 }
 
+export function getStateTreeNodeSafe(value: IAnyStateTreeNode): ObjectNode {
+    return (value && value.$treenode) || null
+}
+
 export function canAttachNode(value: any) {
     return (
         value &&

--- a/packages/mobx-state-tree/src/core/node/scalar-node.ts
+++ b/packages/mobx-state-tree/src/core/node/scalar-node.ts
@@ -30,7 +30,7 @@ export class ScalarNode implements INode {
 
         let sawException = true
         try {
-            this.storedValue = type.initializeInstance(this, {}, initialSnapshot)
+            this.storedValue = type.createNewInstance(this, {}, initialSnapshot)
             this.state = NodeLifeCycle.CREATED
             sawException = false
         } finally {

--- a/packages/mobx-state-tree/src/core/node/scalar-node.ts
+++ b/packages/mobx-state-tree/src/core/node/scalar-node.ts
@@ -4,7 +4,6 @@ import {
     fail,
     freeze,
     NodeLifeCycle,
-    noop,
     ObjectNode,
     IAnyType
 } from "../../internal"
@@ -23,19 +22,15 @@ export class ScalarNode implements INode {
         parent: ObjectNode | null,
         subpath: string,
         environment: any,
-        initialSnapshot: any,
-        createNewInstance: (initialValue: any) => any,
-        finalizeNewInstance: (node: INode, initialValue: any) => void = noop
+        initialSnapshot: any
     ) {
         this.type = type
         this.parent = parent
         this.subpath = subpath
 
-        this.storedValue = createNewInstance(initialSnapshot)
         let sawException = true
         try {
-            finalizeNewInstance(this, initialSnapshot)
-
+            this.storedValue = type.initializeInstance(this, {}, initialSnapshot)
             this.state = NodeLifeCycle.CREATED
             sawException = false
         } finally {

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -56,7 +56,8 @@ export interface IType<C, S, T> {
 
     // Internal api's
     instantiate(parent: INode | null, subpath: string, environment: any, initialValue?: any): INode
-    initializeChildNodes(node: INode, snapshot: any): IChildNodesMap | null
+    initializeChildNodes(node: INode, snapshot: any): IChildNodesMap
+    initializeInstance(node: INode, childNodes: IChildNodesMap, snapshot: any): any
     reconcile(current: INode, newValue: any): INode
     getValue(node: INode): T
     getSnapshot(node: INode, applyPostProcess?: boolean): S
@@ -113,8 +114,12 @@ export abstract class ComplexType<C, S, T> implements IType<C, S, T> {
         typecheck(this, snapshot)
         return this.instantiate(null, "", environment, snapshot).value
     }
-    initializeChildNodes(node: INode, snapshot: any): IChildNodesMap | null {
-        return null
+    initializeChildNodes(node: INode, snapshot: any): IChildNodesMap {
+        return {}
+    }
+
+    initializeInstance(node: INode, childNodes: IChildNodesMap, snapshot: any): any {
+        return snapshot
     }
 
     abstract instantiate(

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -57,7 +57,8 @@ export interface IType<C, S, T> {
     // Internal api's
     instantiate(parent: INode | null, subpath: string, environment: any, initialValue?: any): INode
     initializeChildNodes(node: INode, snapshot: any): IChildNodesMap
-    initializeInstance(node: INode, childNodes: IChildNodesMap, snapshot: any): any
+    createNewInstance(node: INode, childNodes: IChildNodesMap, snapshot: any): any
+    finalizeNewInstance(node: INode, instance: any): void
     reconcile(current: INode, newValue: any): INode
     getValue(node: INode): T
     getSnapshot(node: INode, applyPostProcess?: boolean): S
@@ -118,9 +119,11 @@ export abstract class ComplexType<C, S, T> implements IType<C, S, T> {
         return {}
     }
 
-    initializeInstance(node: INode, childNodes: IChildNodesMap, snapshot: any): any {
+    createNewInstance(node: INode, childNodes: IChildNodesMap, snapshot: any): any {
         return snapshot
     }
+
+    finalizeNewInstance(node: INode, instance: any) {}
 
     abstract instantiate(
         parent: INode | null,

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -18,8 +18,7 @@ import {
     ObjectNode,
     IChildNodesMap,
     ModelPrimitive,
-    IReferenceType,
-    isArray
+    IReferenceType
 } from "../../internal"
 
 export enum TypeFlags {

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -72,14 +72,17 @@ export class ArrayType<C, S, T> extends ComplexType<C[] | undefined, S[], IMSTAr
         return result
     }
 
-    initializeInstance(node: INode, childNodes: IChildNodesMap, snapshot: any): any {
-        const instance = observable.array(convertChildNodesToArray(childNodes), mobxShallow)
-
-        _getAdministration(instance).dehancer = (node as ObjectNode).unbox
+    createNewInstance(
+        node: ObjectNode,
+        childNodes: IChildNodesMap,
+        snapshot: any
+    ): IObservableArray<any> {
+        return observable.array(convertChildNodesToArray(childNodes), mobxShallow)
+    }
+    finalizeNewInstance(node: ObjectNode, instance: IObservableArray<any>): void {
+        _getAdministration(instance).dehancer = node.unbox
         intercept(instance, this.willChange as any)
         observe(instance, this.didChange)
-
-        return instance
     }
 
     describe() {

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -40,7 +40,6 @@ import {
     typeCheckFailure,
     TypeFlags
 } from "../../internal"
-import { ModelType } from "./model"
 
 export interface IMSTArray<C, S, T> extends IObservableArray<T> {}
 export interface IArrayType<C, S, T>

--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -231,14 +231,18 @@ export class MapType<C, S, T> extends ComplexType<
         return result
     }
 
-    initializeInstance(node: INode, childNodes: IChildNodesMap, snapshot: any): any {
-        const instance = new MSTMap(childNodes)
+    createNewInstance(
+        node: INode,
+        childNodes: IChildNodesMap,
+        snapshot: any
+    ): IMSTMap<any, any, any> {
+        return (new MSTMap(childNodes) as any) as IMSTMap<any, any, any>
+    }
 
-        _interceptReads(instance, (node as ObjectNode).unbox)
+    finalizeNewInstance(node: ObjectNode, instance: any) {
+        _interceptReads(instance, node.unbox)
         intercept(instance, this.willChange)
         observe(instance, this.didChange)
-
-        return instance
     }
 
     describe() {

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -3,10 +3,10 @@ import {
     _interceptReads,
     action,
     computed,
-    extendObservable,
     getAtom,
     intercept,
     IObjectWillChange,
+    IObservableObject,
     isComputedProp,
     observable,
     observe,
@@ -459,20 +459,19 @@ export class ModelType<S extends ModelProperties, T> extends ComplexType<any, an
         return result
     }
 
-    initializeInstance(node: INode, childNodes: IChildNodesMap, snapshot: any): any {
-        const instance = observable.object(EMPTY_OBJECT, EMPTY_OBJECT, mobxShallow)
+    createNewInstance(node: ObjectNode, childNodes: IChildNodesMap, snapshot: any): any {
+        return observable.object(childNodes, EMPTY_OBJECT, mobxShallow)
+    }
+    finalizeNewInstance(node: ObjectNode, instance: IObservableObject): void {
         addHiddenFinalProp(instance, "toString", objectTypeToString)
 
-        extendObservable(instance, childNodes, EMPTY_OBJECT, mobxShallow)
         this.forAllProps(name => {
-            _interceptReads(instance, name, (node as ObjectNode).unbox)
+            _interceptReads(instance, name, node.unbox)
         })
 
         this.initializers.reduce((self, fn) => fn(self), instance)
         intercept(instance, this.willChange)
         observe(instance, this.didChange)
-
-        return instance
     }
 
     willChange(change: any): IObjectWillChange | null {

--- a/packages/mobx-state-tree/src/types/primitives.ts
+++ b/packages/mobx-state-tree/src/types/primitives.ts
@@ -1,4 +1,3 @@
-import { isInteger } from "./../utils"
 import {
     Type,
     isPrimitive,
@@ -16,7 +15,8 @@ import {
     isType,
     ObjectNode,
     IAnyType,
-    IChildNodesMap
+    IChildNodesMap,
+    isInteger
 } from "../internal"
 
 // TODO: implement CoreType using types.custom ?
@@ -46,7 +46,7 @@ export class CoreType<S, T> extends Type<S, S, T> {
         return createNode(this, parent, subpath, environment, snapshot)
     }
 
-    initializeInstance(node: INode, childNodes: IChildNodesMap, snapshot: any): any {
+    createNewInstance(node: INode, childNodes: IChildNodesMap, snapshot: any): any {
         return this.initializer(snapshot)
     }
 

--- a/packages/mobx-state-tree/src/types/primitives.ts
+++ b/packages/mobx-state-tree/src/types/primitives.ts
@@ -15,7 +15,8 @@ import {
     typeCheckFailure,
     isType,
     ObjectNode,
-    IAnyType
+    IAnyType,
+    IChildNodesMap
 } from "../internal"
 
 // TODO: implement CoreType using types.custom ?
@@ -42,7 +43,11 @@ export class CoreType<S, T> extends Type<S, S, T> {
     }
 
     instantiate(parent: ObjectNode | null, subpath: string, environment: any, snapshot: T): INode {
-        return createNode(this, parent, subpath, environment, snapshot, this.initializer)
+        return createNode(this, parent, subpath, environment, snapshot)
+    }
+
+    initializeInstance(node: INode, childNodes: IChildNodesMap, snapshot: any): any {
+        return this.initializer(snapshot)
     }
 
     isValidSnapshot(value: any, context: IContext): IValidationResult {


### PR DESCRIPTION
This PR is purely internal. 
~~Basically it replaces ```createNewInstance``` + ```finalizeNewInstance``` combo with just one ```initializeInstance``` call.~~
Another step to make code cleaner was to remove ```createNewInstance```/```finalizeNewInstance``` from ```createNode```'s arguments, as those were taken from type anyway (inside ```type.instantiate```). As we have type inside ```ObjectNode```/```ScalarNode``` there is not need to pass those two methods 3 calls deep separately.
As a side effect this makes ```createNode``` and Node's constructor's calls less polymorphic and slightly reduces subsequent calls time.