### PR TITLE
Do not spoil snapshots during 'create'

### DIFF
--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -277,7 +277,7 @@ export function isType(value: any): value is IAnyType {
 function cloneSnapshotIfNeeded(snapshot: any): any {
     if (snapshot) {
         if (isStateTreeNode(snapshot)) return snapshot
-        else if (isArray(snapshot)) return Array.from(snapshot)
+        else if (isArray(snapshot)) return (snapshot as Array<any>).slice()
         else if (isMutable(snapshot)) return Object.assign({}, snapshot)
     }
     return snapshot

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -18,7 +18,8 @@ import {
     ObjectNode,
     IChildNodesMap,
     ModelPrimitive,
-    IReferenceType
+    IReferenceType,
+    isArray
 } from "../../internal"
 
 export enum TypeFlags {
@@ -111,7 +112,7 @@ export abstract class ComplexType<C, S, T> implements IType<C, S, T> {
     @action
     create(snapshot: C = this.getDefaultSnapshot(), environment?: any) {
         typecheck(this, snapshot)
-        return this.instantiate(null, "", environment, snapshot).value
+        return this.instantiate(null, "", environment, cloneSnapshotIfNeeded(snapshot)).value
     }
     initializeChildNodes(node: INode, snapshot: any): IChildNodesMap | null {
         return null
@@ -271,4 +272,13 @@ export abstract class Type<C, S, T> extends ComplexType<C, S, T> implements ITyp
 
 export function isType(value: any): value is IAnyType {
     return typeof value === "object" && value && value.isType === true
+}
+
+function cloneSnapshotIfNeeded(snapshot: any): any {
+    if (snapshot) {
+        if (isStateTreeNode(snapshot)) return snapshot
+        else if (isArray(snapshot)) return Array.from(snapshot)
+        else if (isMutable(snapshot)) return Object.assign({}, snapshot)
+    }
+    return snapshot
 }

--- a/packages/mobx-state-tree/test/object.ts
+++ b/packages/mobx-state-tree/test/object.ts
@@ -652,6 +652,15 @@ test("782, TS + compose", () => {
     const user = User.create({ id: "someId" })
 })
 
+test("961 - model creating should not change snapshot", () => {
+    const M = types.model({ foo: 1 })
+    const o = {}
+
+    const m = M.create(o)
+    expect(o).toEqual({})
+    expect(getSnapshot(m)).toEqual({ foo: 1 })
+})
+
 if (process.env.NODE_ENV === "development")
     test("beautiful errors", () => {
         expect(() => {

--- a/packages/mobx-state-tree/test/union.ts
+++ b/packages/mobx-state-tree/test/union.ts
@@ -1,4 +1,4 @@
-import { types, hasParent, tryResolve, getSnapshot } from "../src"
+import { types, hasParent, tryResolve, getSnapshot, applySnapshot } from "../src"
 const createTestFactories = () => {
     const Box = types.model("Box", {
         width: types.number,
@@ -159,4 +159,13 @@ test("dispatch", () => {
             )
         }).toThrow("First argument to types.union should either be a type")
     }
+})
+
+test("961 - apply snapshot to union should not throw when union keeps models with different properties and snapshot is got by getSnapshot", () => {
+    const Foo = types.model({ foo: 1 })
+    const Bar = types.model({ bar: 1 })
+    const U = types.union(Foo, Bar)
+
+    const u = U.create({ foo: 1 })
+    applySnapshot(u, getSnapshot(Bar.create()))
 })


### PR DESCRIPTION
FIxes [#961](https://github.com/mobxjs/mobx-state-tree/issues/961)
- Clone mutable snapshots in .create()
- Apply optional values only for initialSnapshot (also happened during typecheck)