### PR TITLE
cast method + making official the tree kind of types

### DIFF
--- a/API.md
+++ b/API.md
@@ -13,6 +13,7 @@ _This reference guide lists all methods exposed by MST. Contributions like lingu
 -   [applySnapshot](#applysnapshot)
 -   [BaseReferenceType](#basereferencetype)
 -   [BaseReferenceType](#basereferencetype-1)
+-   [cast](#cast)
 -   [clone](#clone)
 -   [ComplexType](#complextype)
 -   [ComplexType](#complextype-1)
@@ -180,6 +181,41 @@ Applies a snapshot to a given model instances. Patch and snapshot listeners will
 ## BaseReferenceType
 
 ## BaseReferenceType
+
+## cast
+
+Casts a node snapshot or instance type to an instance type so it can be assigned to a type instance.
+Note that this is just a cast for the type system, this is, it won't actually convert a snapshot to an instance,
+but just fool typescript into thinking so.
+Casting only works on assignation operations, it won't work (compile) stand-alone.
+Technically it is not required for instances, but it is provided for consistency reasons.
+
+**Parameters**
+
+-   `snapshotOrInstance` **CastedType&lt;T>** 
+
+**Examples**
+
+```javascript
+const ModelA = types.model({
+  n: types.number
+}).actions(self => ({
+  setN(aNumber: number) {
+    self.n = aNumber
+  }
+}))
+
+const ModelB = types.model({
+  innerModel: ModelA
+}).actions(self => ({
+  someAction() {
+    // this will allow the compiler to assign an snapshot to the property
+    self.innerModel = cast({ a: 5 })
+  }
+}))
+```
+
+Returns **T** 
 
 ## clone
 

--- a/README.md
+++ b/README.md
@@ -1202,11 +1202,11 @@ const Todo = types.model({
         }
     }))
 
-type ITodo = Instance<typeof Todo> // => ITodo is now a valid TypeScript type with { title: string; setTitle: (v: string) => void }
+type ITodo = Instance<typeof Todo> // => { title: string; setTitle: (v: string) => void }
 
-type ITodoInSnapshot = InSnapshot<typeof Todo> // => ITodoSnapshot is now a valid TypeScript type with { title?: string }
+type ITodoInSnapshot = InSnapshot<typeof Todo> // => { title?: string }
 
-type ITodoOutSnapshot = OutSnapshot<typeof Todo> // => ITodoSnapshot is now a valid TypeScript type with { title: string }
+type ITodoOutSnapshot = OutSnapshot<typeof Todo> // => { title: string }
 ```
 
 Due to the way typeof operator works, when working with big and deep models trees, it might make your IDE/ts server takes a lot of CPU time and freeze vscode (or others)

--- a/README.md
+++ b/README.md
@@ -962,6 +962,7 @@ See the [full API docs](API.md) for more details.
 | [`addMiddleware(node, middleware: (actionDescription, next) => any, includeHooks)`](API.md#addmiddleware) | Attaches middleware to a node. See [middleware](docs/middleware.md). Returns disposer. |
 | [`applyAction(node, actionDescription)`](API.md#applyaction) | Replays an action on the targeted node |
 | [`applyPatch(node, jsonPatch)`](API.md#applypatch) | Applies a JSON patch, or array of patches, to a node in the tree |
+| [`cast(nodeOrSnapshot)`](API.md#cast) | Cast a node instance or snapshot to a node so it can be used in assignment operations |
 | [`applySnapshot(node, snapshot)`](API.md#applysnapshot) | Updates a node with the given snapshot |
 | [`createActionTrackingMiddleware`](API.md#createactiontrackingmiddleware) | Utility to make writing middleware that tracks async actions less cumbersome |
 | [`clone(node, keepEnvironment?: true \| false \| newEnvironment)`](API.md#clone) | Creates a full clone of the given node. By default preserves the same environment |

--- a/README.md
+++ b/README.md
@@ -1343,7 +1343,7 @@ const Store = types.model({
 })
 
 const s = Store.create({ tasks: [] })
-// `{}` is a valid snapshot of Task, and hence a valid task, MST allows this, but TS doesn't, so need to use 'cast'
+// `{}` is a valid snapshot of Task, and hence a valid task, MST allows this, but TS doesn't, so we need to use 'cast'
 s.tasks.push(cast({}))
 s.selection = cast({})
 ```
@@ -1360,14 +1360,10 @@ const Task = types.model({
 const Store = types.model({
     tasks: types.array(Task)
 }).actions(self => ({
-    addTask(
-        task: SnapshotOrInstance<typeof Task>
-    ) {
+    addTask(task: SnapshotOrInstance<typeof Task>) {
         self.tasks.push(cast(task))
     },
-    replaceTasks(
-        tasks: SnapshotOrInstance<typeof self.tasks>
-    ) {
+    replaceTasks(tasks: SnapshotOrInstance<typeof self.tasks>) {
         self.tasks = cast(tasks)
     }
 }))

--- a/README.md
+++ b/README.md
@@ -1361,13 +1361,11 @@ const Store = types.model({
     tasks: types.array(Task)
 }).actions(self => ({
     addTask(
-        // equivalent to typeof Task.Type | typeof Task.CreationType
         task: SnapshotOrInstance<typeof Task>
     ) {
         self.tasks.push(cast(task))
     },
     replaceTasks(
-        // equivalent to typeof typeof (types.array(Task)).Type | typeof (types.array(Task)).CreationType
         tasks: SnapshotOrInstance<typeof self.tasks>
     ) {
         self.tasks = cast(tasks)

--- a/README.md
+++ b/README.md
@@ -28,49 +28,50 @@ Introduction blog post [The curious case of MobX state tree](https://medium.com/
 MobX state tree is a community driven project, but is looking for active maintainers! See [#700](https://github.com/mobxjs/mobx-state-tree/issues/700)
 
 ---
+
 # Contents
 
-* [Installation](#installation)
-* [Getting Started](docs/getting-started.md)
-* [Talks & blogs](#talks--blogs)
-* [Philosophy & Overview](#philosophy--overview)
-* [Examples](#examples)
-* [Concepts](#concepts)
-  * [Trees, types and state](#trees-types-and-state)
-  * [Creating models](#creating-models)
-  * [Tree semantics in detail](#tree-semantics-in-detail)
-  * [Composing trees](#composing-trees)
-  * [Actions](#actions)
-  * [Views](#views)
-  * [Snapshots](#snapshots)
-  * [Patches](#patches)
-  * [References and identifiers](#references-and-identifiers)
-  * [Listening to observables, snapshots, patches or actions](#listening-to-observables-snapshots-patches-or-actions)
-  * [Volatile state](#volatile-state)
-  * [Dependency injection](#dependency-injection)
-* [Types overview](#types-overview)
-  * [Lifecycle hooks](#lifecycle-hooks-for-typesmodel)
-* [Api overview](#api-overview)
-* [Tips](#tips)
-* [FAQ](#faq)
-* [Full Api Docs](API.md)
-* [Built-in / example middlewares](packages/mst-middlewares/README.md)
-* [Changelog](changelog.md)
+-   [Installation](#installation)
+-   [Getting Started](docs/getting-started.md)
+-   [Talks & blogs](#talks--blogs)
+-   [Philosophy & Overview](#philosophy--overview)
+-   [Examples](#examples)
+-   [Concepts](#concepts)
+    -   [Trees, types and state](#trees-types-and-state)
+    -   [Creating models](#creating-models)
+    -   [Tree semantics in detail](#tree-semantics-in-detail)
+    -   [Composing trees](#composing-trees)
+    -   [Actions](#actions)
+    -   [Views](#views)
+    -   [Snapshots](#snapshots)
+    -   [Patches](#patches)
+    -   [References and identifiers](#references-and-identifiers)
+    -   [Listening to observables, snapshots, patches or actions](#listening-to-observables-snapshots-patches-or-actions)
+    -   [Volatile state](#volatile-state)
+    -   [Dependency injection](#dependency-injection)
+-   [Types overview](#types-overview)
+    -   [Lifecycle hooks](#lifecycle-hooks-for-typesmodel)
+-   [Api overview](#api-overview)
+-   [Tips](#tips)
+-   [FAQ](#faq)
+-   [Full Api Docs](API.md)
+-   [Built-in / example middlewares](packages/mst-middlewares/README.md)
+-   [Changelog](changelog.md)
 
 # Installation
 
-* NPM: `npm install mobx mobx-state-tree --save` (use `mobx@3` for MST 1.x)
-* Yarn: `yarn add mobx mobx-state-tree`
-* CDN: https://unpkg.com/mobx-state-tree@1.1.0/dist/mobx-state-tree.umd.js (exposed as `window.mobxStateTree`)
-* Playground: [https://mattiamanzati.github.io/mobx-state-tree-playground/](https://mattiamanzati.github.io/mobx-state-tree-playground/) (with React UI, snapshots, patches and actions display)
-* CodeSandbox [TodoList demo](https://codesandbox.io/s/nZ26kGMD) fork for testing and bug reporting
+-   NPM: `npm install mobx mobx-state-tree --save` (use `mobx@3` for MST 1.x)
+-   Yarn: `yarn add mobx mobx-state-tree`
+-   CDN: https://unpkg.com/mobx-state-tree@1.1.0/dist/mobx-state-tree.umd.js (exposed as `window.mobxStateTree`)
+-   Playground: [https://mattiamanzati.github.io/mobx-state-tree-playground/](https://mattiamanzati.github.io/mobx-state-tree-playground/) (with React UI, snapshots, patches and actions display)
+-   CodeSandbox [TodoList demo](https://codesandbox.io/s/nZ26kGMD) fork for testing and bug reporting
 
 Typescript typings are included in the packages. Use `module: "commonjs"` or `moduleResolution: "node"` to make sure they are picked up automatically in any consuming project.
 
 Supported browsers:
- * MobX-state-tree runs on any ES5 environment
- * However, for MobX version 4 or 5 can be used. MobX 4 will run on any environment, MobX 5 only on modern browsers. See for more details the [MobX readme](https://github.com/mobxjs/mobx#browser-support)
 
+-   MobX-state-tree runs on any ES5 environment
+-   However, for MobX version 4 or 5 can be used. MobX 4 will run on any environment, MobX 5 only on modern browsers. See for more details the [MobX readme](https://github.com/mobxjs/mobx#browser-support)
 
 # Getting started
 
@@ -78,12 +79,12 @@ See the [Getting started](https://github.com/mobxjs/mobx-state-tree/blob/master/
 
 # Talks & blogs
 
-* Talk React Europe 2017: [Next generation state management](https://www.youtube.com/watch?v=rwqwwn_46kA)
-* Talk ReactNext 2017: [React, but for Data](https://www.youtube.com/watch?v=xfC_xEA8Z1M&index=6&list=PLMYVq3z1QxSqq6D7jxVdqttOX7H_Brq8Z) ([slides](http://react-next-2017-slides.surge.sh/#1), [demo](https://codesandbox.io/s/8y4p23j32j))
-* Talk ReactJSDay Verona 2017: [Immutable or immutable? Both!](https://www.youtube.com/watch?v=zdtwaa5Rmb8&index=9&list=PLWK9j6ps_unl293VhhN4RYMCISxye3xH9) ([slides](https://mweststrate.github.io/reactjsday2017-presentation/index.html#1), [demo](https://github.com/mweststrate/reatjsday2017-demo))
-* Talk React Alicante 2017: [Mutable or Immutable? Let's do both!](https://www.youtube.com/watch?v=DgnL3uij9ec&list=PLd7nkr8mN0sWvBH_s0foCE6eZTX8BmLUM&index=9) ([slides](https://mattiamanzati.github.io/slides-react-alicante-2017/#2))
-* Talk ReactiveConf 2016: [Immer-mutable state management](https://www.youtube.com/watch?v=Ql8KUUUOHNc&list=PLa2ZZ09WYepMCRRGCRPhTYuTCat4TiDlX&index=30)
-* Talk FrontendLove 2018: [MobX State Tree + React: pure reactivity served](https://www.youtube.com/watch?v=HS9revHrNRI) by [Luca Mezzalira](https://lucamezzalira.com/) ([slides](https://docs.google.com/presentation/d/1f18RhN9hz1GPAdY4binWVNZDKm3k7EfNvV48lWnzdjQ/edit#slide=id.g35f391192_00)).
+-   Talk React Europe 2017: [Next generation state management](https://www.youtube.com/watch?v=rwqwwn_46kA)
+-   Talk ReactNext 2017: [React, but for Data](https://www.youtube.com/watch?v=xfC_xEA8Z1M&index=6&list=PLMYVq3z1QxSqq6D7jxVdqttOX7H_Brq8Z) ([slides](http://react-next-2017-slides.surge.sh/#1), [demo](https://codesandbox.io/s/8y4p23j32j))
+-   Talk ReactJSDay Verona 2017: [Immutable or immutable? Both!](https://www.youtube.com/watch?v=zdtwaa5Rmb8&index=9&list=PLWK9j6ps_unl293VhhN4RYMCISxye3xH9) ([slides](https://mweststrate.github.io/reactjsday2017-presentation/index.html#1), [demo](https://github.com/mweststrate/reatjsday2017-demo))
+-   Talk React Alicante 2017: [Mutable or Immutable? Let's do both!](https://www.youtube.com/watch?v=DgnL3uij9ec&list=PLd7nkr8mN0sWvBH_s0foCE6eZTX8BmLUM&index=9) ([slides](https://mattiamanzati.github.io/slides-react-alicante-2017/#2))
+-   Talk ReactiveConf 2016: [Immer-mutable state management](https://www.youtube.com/watch?v=Ql8KUUUOHNc&list=PLa2ZZ09WYepMCRRGCRPhTYuTCat4TiDlX&index=30)
+-   Talk FrontendLove 2018: [MobX State Tree + React: pure reactivity served](https://www.youtube.com/watch?v=HS9revHrNRI) by [Luca Mezzalira](https://lucamezzalira.com/) ([slides](https://docs.google.com/presentation/d/1f18RhN9hz1GPAdY4binWVNZDKm3k7EfNvV48lWnzdjQ/edit#slide=id.g35f391192_00)).
 
 # Philosophy & Overview
 
@@ -93,32 +94,38 @@ Simply put, mobx-state-tree tries to combine the best features of both immutabil
 Unlike MobX itself, mobx-state-tree is very opinionated on how data should be structured and updated.
 This makes it possible to solve many common problems out of the box.
 
-Central in MST (mobx-state-tree) is the concept of a *living tree*. The tree consists of mutable, but strictly protected objects enriched with _runtime type information_. In other words; each tree has a _shape_ (type information) and _state_ (data).
+Central in MST (mobx-state-tree) is the concept of a _living tree_. The tree consists of mutable, but strictly protected objects enriched with _runtime type information_. In other words; each tree has a _shape_ (type information) and _state_ (data).
 From this living tree, immutable, structurally shared, snapshots are generated automatically.
 
 ```javascript
 import { types, onSnapshot } from "mobx-state-tree"
 
-const Todo = types.model("Todo", {
-    title: types.string,
-    done: false
-}).actions(self => ({
-    toggle() {
-        self.done = !self.done
-    }
-}))
+const Todo = types
+    .model("Todo", {
+        title: types.string,
+        done: false
+    })
+    .actions(self => ({
+        toggle() {
+            self.done = !self.done
+        }
+    }))
 
 const Store = types.model("Store", {
     todos: types.array(Todo)
 })
 
 // create an instance from a snapshot
-const store = Store.create({ todos: [{
-    title: "Get coffee"
-}]})
+const store = Store.create({
+    todos: [
+        {
+            title: "Get coffee"
+        }
+    ]
+})
 
 // listen to new snapshots
-onSnapshot(store, (snapshot) => {
+onSnapshot(store, snapshot => {
     console.dir(snapshot)
 })
 
@@ -169,10 +176,7 @@ const oldTodo = store.todos[0]
 store.removeTodo(0)
 
 function logTodo(todo) {
-    setTimeout(
-        () => console.log(todo.title),
-        1000
-    )
+    setTimeout(() => console.log(todo.title), 1000)
 }
 
 logTodo(store.todos[0])
@@ -180,13 +184,12 @@ store.removeTodo(0)
 // throws exception in one second for using an stale object!
 ```
 
-
 Despite all that, you will see that the [API](API.md) is pretty straightforward!
 
 ---
 
 Another way to look at mobx-state-tree is to consider it, as argued by Daniel Earwicker, to be ["React, but for data"](http://danielearwicker.github.io/json_mobx_Like_React_but_for_Data_Part_2_.html).
-Like React, MST consists of composable components, called *models*, which captures a small piece of state. They are instantiated from props (snapshots) and after that manage and protect their own internal state (using actions). Moreover, when applying snapshots, tree nodes are reconciled as much as possible. There is even a context-like mechanism, called environments, to pass information to deep descendants.
+Like React, MST consists of composable components, called _models_, which captures a small piece of state. They are instantiated from props (snapshots) and after that manage and protect their own internal state (using actions). Moreover, when applying snapshots, tree nodes are reconciled as much as possible. There is even a context-like mechanism, called environments, to pass information to deep descendants.
 
 An introduction to the philosophy can be watched [here](https://youtu.be/ta8QKmNRXZM?t=21m52s). [Slides](https://immer-mutable-state.surge.sh/). Or, as [markdown](https://github.com/mweststrate/reactive2016-slides/blob/master/slides.md) to read it quickly.
 
@@ -195,14 +198,15 @@ mobx-state-tree "immutable trees" and "graph model" features talk, ["Next Genera
 # Examples
 
 To run the examples:
-1. clone this repository
-2. navigate to the example folder (e.g. `packages/mst-example-bookshop`)
-3. run `yarn install` and `yarn start`
 
-* [Bookshop](https://github.com/mobxjs/mobx-state-tree/tree/master/packages/mst-example-bookshop) Example webshop application with references, identifiers, routing, testing etc.
-* [Boxes](https://github.com/mobxjs/mobx-state-tree/tree/master/packages/mst-example-boxes) Example app where one can draw, drag, and drop boxes. With time-travelling and multi-client synchronization over websockets.
-* [TodoMVC](https://github.com/mobxjs/mobx-state-tree/tree/master/packages/mst-example-todomvc) Classic example app using React and MST.
-* [Redux TodoMVC](https://github.com/mobxjs/mobx-state-tree/tree/master/packages/mst-example-redux-todomvc) Redux TodoMVC application, except that the reducers are replaced with a MST. Tip: open the Redux devtools; they will work!
+1.  clone this repository
+2.  navigate to the example folder (e.g. `packages/mst-example-bookshop`)
+3.  run `yarn install` and `yarn start`
+
+-   [Bookshop](https://github.com/mobxjs/mobx-state-tree/tree/master/packages/mst-example-bookshop) Example webshop application with references, identifiers, routing, testing etc.
+-   [Boxes](https://github.com/mobxjs/mobx-state-tree/tree/master/packages/mst-example-boxes) Example app where one can draw, drag, and drop boxes. With time-travelling and multi-client synchronization over websockets.
+-   [TodoMVC](https://github.com/mobxjs/mobx-state-tree/tree/master/packages/mst-example-todomvc) Classic example app using React and MST.
+-   [Redux TodoMVC](https://github.com/mobxjs/mobx-state-tree/tree/master/packages/mst-example-redux-todomvc) Redux TodoMVC application, except that the reducers are replaced with a MST. Tip: open the Redux devtools; they will work!
 
 # Concepts
 
@@ -215,7 +219,7 @@ Each **node** in the tree is described by two things: Its **type** (the shape of
 The simplest tree possible:
 
 ```javascript
-import {types} from "mobx-state-tree"
+import { types } from "mobx-state-tree"
 
 // declaring the shape of a node with the type `Todo`
 const Todo = types.model({
@@ -231,7 +235,6 @@ const coffeeTodo = Todo.create({
 The `types.model` type declaration is used to describe the shape of an object.
 Other built-in types include arrays, maps, primitives etc. See the [types overview](#types-overview).
 The type information will be used for both.
-
 
 ### Creating models
 
@@ -275,32 +278,36 @@ A model takes additionally object argument defining the properties.
 
 The _properties_ argument is a key-value set where each key indicates the introduction of a property, and the value its type. The following types are acceptable:
 
-1. A type. This can be a simple primitive type like `types.boolean`, see `// 2`, or a complex, possibly pre-defined type (`// 4`)
-2. A primitive. Using a primitive as type is syntactic sugar for introducing a property with a default value. See `// 3`, `endpoint: "http://localhost"` is the same as `endpoint: types.optional(types.string, "http://localhost")`. The primitive type is inferred from the default value. Properties with a default value can be omitted in snapshots.
-3. A [computed property](https://mobx.js.org/refguide/computed-decorator.html), see `// 6`. Computed properties are tracked and memoized by MobX. Computed properties will not be stored in snapshots or emit patch events. It is possible to provide a setter for a computed property as well. A setter should always invoke an action.
-4. A view function (see `// 7`). A view function can, unlike computed properties, take arbitrary arguments. It won't be memoized, but its value can be tracked by MobX nonetheless. View functions are not allowed to change the model, but should rather be used to retrieve information from the model.
+1.  A type. This can be a simple primitive type like `types.boolean`, see `// 2`, or a complex, possibly pre-defined type (`// 4`)
+2.  A primitive. Using a primitive as type is syntactic sugar for introducing a property with a default value. See `// 3`, `endpoint: "http://localhost"` is the same as `endpoint: types.optional(types.string, "http://localhost")`. The primitive type is inferred from the default value. Properties with a default value can be omitted in snapshots.
+3.  A [computed property](https://mobx.js.org/refguide/computed-decorator.html), see `// 6`. Computed properties are tracked and memoized by MobX. Computed properties will not be stored in snapshots or emit patch events. It is possible to provide a setter for a computed property as well. A setter should always invoke an action.
+4.  A view function (see `// 7`). A view function can, unlike computed properties, take arbitrary arguments. It won't be memoized, but its value can be tracked by MobX nonetheless. View functions are not allowed to change the model, but should rather be used to retrieve information from the model.
 
 _Tip: `(self) => ({ action1() { }, action2() { }})` is ES6 syntax for `function (self) { return { action1: function() { }, action2: function() { } }}`, in other words; it's short way of directly returning an object literal.
 For that reason a comma between each member of a model is mandatory, unlike classes which are syntactically a totally different concept._
 
 `types.model` creates a chainable model type, where each chained method produces a new type:
-* `.named(name)` clones the current type, but gives it a new name
-* `.props(props)` produces a new type, based on the current one, and adds / overrides the specified properties
-* `.actions(self => object literal with actions)` produces a new type, based on the current one, and adds / overrides the specified actions
-* `.views(self => object literal with view functions)` produces a new type, based on the current one, and adds / overrides the specified view functions
-* `.preProcessSnapshot(snapshot => snapshot)` can be used to pre-process the raw JSON before instantiating a new model. See [Lifecycle hooks](#lifecycle-hooks-for-typesmodel)
+
+-   `.named(name)` clones the current type, but gives it a new name
+-   `.props(props)` produces a new type, based on the current one, and adds / overrides the specified properties
+-   `.actions(self => object literal with actions)` produces a new type, based on the current one, and adds / overrides the specified actions
+-   `.views(self => object literal with view functions)` produces a new type, based on the current one, and adds / overrides the specified view functions
+-   `.preProcessSnapshot(snapshot => snapshot)` can be used to pre-process the raw JSON before instantiating a new model. See [Lifecycle hooks](#lifecycle-hooks-for-typesmodel)
 
 Note that `views` and `actions` don't define actions and views directly, but rather they should be given a function.
 The function will be invoked when a new model instance is created. The instance will be passed in as the first and only argument. Typically called `self`.
 This has two advantages:
-1. All methods will always be bound correctly, and won't suffer from an unbound `this`
-2. The closure can be used to store private state or methods of the instance. See also [actions](#actions) and [volatile state](#volatile-state).
+
+1.  All methods will always be bound correctly, and won't suffer from an unbound `this`
+2.  The closure can be used to store private state or methods of the instance. See also [actions](#actions) and [volatile state](#volatile-state).
 
 Quick example:
 
 ```javascript
 const TodoStore = types
-    .model("TodoStore", { /* props */ })
+    .model("TodoStore", {
+        /* props */
+    })
     .actions(self => {
         const instantiationTime = Date.now()
 
@@ -324,18 +331,18 @@ It is also possible to define lifecycle hooks in the _actions_ object, these are
 
 MST trees have very specific semantics. These semantics purposefully constrain what you can do with MST. The reward for that is all kinds of generic features out of the box like snapshots, replayability, etc... If these constraints don't suit your app, you are probably better of using plain mobx with your own model classes. Which is perfectly fine as well.
 
-1. Each object in a MST tree is considered a _node_. Each primitive (and frozen) value is considered a _leaf_.
-1. MST has only three types of nodes; _model_, _array_, and _map_.
-1. Every _node_ tree in a MST tree is a tree in itself. Any operation that can be invoked on the complete tree can also be applied to a sub tree.
-1. A node can only exist exactly _once_ in a tree. This ensures it has a unique, identifiable position.
-2. It is however possible to refer to another object in the _same_ tree by using _references_
-3. There is no limit to the number of MST trees that live in an application. However, each node can only live in exactly one tree.
-4. All _leaves_ in the tree must be serializable; it is not possible to store, for example, functions in a MST.
-6. The only free-form type in MST is frozen; with the requirement that frozen values are immutable and serializable so that the MST semantics can still be upheld.
-7. At any point in the tree it is possible to assign a snapshot to the tree instead of a concrete instance of the expected type. In that case an instance of the correct type, based on the snapshot, will be automatically created for you.
-8. Nodes in the MST tree will be reconciled (the exact same instance will be reused) when updating the tree by any means, based on their _identifier_ property. If there is no identifier property, instances won't be reconciled.
-9. If a node in the tree is replaced by another node, the original node will die and become unusable. This makes sure you are not accidentally holding on to stale objects anywhere in your application.
-10. If you want to create a new node based on an existing node in a tree, you can either `detach` that node, or `clone` it.
+1.  Each object in a MST tree is considered a _node_. Each primitive (and frozen) value is considered a _leaf_.
+1.  MST has only three types of nodes; _model_, _array_, and _map_.
+1.  Every _node_ tree in a MST tree is a tree in itself. Any operation that can be invoked on the complete tree can also be applied to a sub tree.
+1.  A node can only exist exactly _once_ in a tree. This ensures it has a unique, identifiable position.
+1.  It is however possible to refer to another object in the _same_ tree by using _references_
+1.  There is no limit to the number of MST trees that live in an application. However, each node can only live in exactly one tree.
+1.  All _leaves_ in the tree must be serializable; it is not possible to store, for example, functions in a MST.
+1.  The only free-form type in MST is frozen; with the requirement that frozen values are immutable and serializable so that the MST semantics can still be upheld.
+1.  At any point in the tree it is possible to assign a snapshot to the tree instead of a concrete instance of the expected type. In that case an instance of the correct type, based on the snapshot, will be automatically created for you.
+1.  Nodes in the MST tree will be reconciled (the exact same instance will be reused) when updating the tree by any means, based on their _identifier_ property. If there is no identifier property, instances won't be reconciled.
+1.  If a node in the tree is replaced by another node, the original node will die and become unusable. This makes sure you are not accidentally holding on to stale objects anywhere in your application.
+1.  If you want to create a new node based on an existing node in a tree, you can either `detach` that node, or `clone` it.
 
 These egghead.io lessons nicely leverage the specific semantics of MST trees:
 
@@ -354,9 +361,11 @@ const TodoStore = types.model({
 })
 
 const storeInstance = TodoStore.create({
-    todos: [{
-        title: "Get biscuit"
-    }]
+    todos: [
+        {
+            title: "Get biscuit"
+        }
+    ]
 })
 ```
 
@@ -380,7 +389,8 @@ Also, the closure of that function can be used to store so called _volatile_ sta
 be invoked from the actions, but not from the outside.
 
 ```javascript
-const Todo = types.model({
+const Todo = types
+    .model({
         title: types.string
     })
     .actions(self => {
@@ -397,10 +407,12 @@ const Todo = types.model({
 Or, shorter if no local state or private functions are involved:
 
 ```javascript
-const Todo = types.model({
+const Todo = types
+    .model({
         title: types.string
     })
-    .actions(self => ({ // note the `({`, we are returning an object literal
+    .actions(self => ({
+        // note the `({`, we are returning an object literal
         setTitle(newTitle) {
             self.title = newTitle
         }
@@ -409,10 +421,10 @@ const Todo = types.model({
 
 Actions are replayable and are therefore constrained in several ways:
 
-- Trying to modify a node without using an action will throw an exception.
-- It's recommended to make sure action arguments are serializable. Some arguments can be serialized automatically, such as relative paths to other nodes
-- Actions can only modify models that belong to the (sub)tree on which they are invoked
-- You cannot use `this` inside actions, instead, use `self`. This makes it safe to pass actions around without binding them or wrapping them in arrow functions.
+-   Trying to modify a node without using an action will throw an exception.
+-   It's recommended to make sure action arguments are serializable. Some arguments can be serialized automatically, such as relative paths to other nodes
+-   Actions can only modify models that belong to the (sub)tree on which they are invoked
+-   You cannot use `this` inside actions, instead, use `self`. This makes it safe to pass actions around without binding them or wrapping them in arrow functions.
 
 Useful methods:
 
@@ -433,7 +445,8 @@ _Warning: don't import `flow` from `"mobx"`, but from `"mobx-state-tree"` instea
 import { types, flow } from "mobx-state-tree"
 
 someModel.actions(self => {
-    const fetchProjects = flow(function* () { // <- note the star, this a generator function!
+    const fetchProjects = flow(function*() {
+        // <- note the star, this a generator function!
         self.state = "pending"
         try {
             // ... yield can be used in async/await style
@@ -568,6 +581,7 @@ References and identifiers are a first-class concept in MST.
 This makes it possible to declare references, and keep the data normalized in the background, while you interact with it in a denormalized manner.
 
 Example:
+
 ```javascript
 const Todo = types.model({
     id: types.identifier,
@@ -581,10 +595,12 @@ const TodoStore = types.model({
 
 // create a store with a normalized snapshot
 const storeInstance = TodoStore.create({
-    todos: [{
-        id: "47",
-        title: "Get coffee"
-    }],
+    todos: [
+        {
+            id: "47",
+            title: "Get coffee"
+        }
+    ],
     selectedTodo: "47"
 })
 
@@ -602,7 +618,7 @@ console.log(storeInstance.selectedTodo.title)
 -   The `map.put()` method can be used to simplify adding objects that have identifiers to [maps](API.md#typesmap)
 -   The primary goal of identifiers is not validation, but reconciliation and reference resolving. For this reason identifiers cannot be defined or updated after creation. If you want to check if some value just looks as an identifier, without providing the above semantics; use something like: `types.refinement(types.string, v => v.match(/someregex/))`
 
-_Tip: If you know the format of the identifiers in your application, leverage `types.refinement` to actively check this, for example the following definition enforces that identifiers of `Car` always start with the string `Car_`:_
+_Tip: If you know the format of the identifiers in your application, leverage `types.refinement` to actively check this, for example the following definition enforces that identifiers of `Car` always start with the string `Car_`:\_
 
 ```javascript
 const Car = types.model("Car", {
@@ -724,7 +740,6 @@ Finally, it is not only possible to be notified about snapshots, patches or acti
 
 <i><a style="color: white; background:cornflowerblue;padding:5px;margin:5px;border-radius:2px" href="https://egghead.io/lessons/react-use-volatile-state-and-lifecycle-methods-to-manage-private-state">egghead.io lesson 15: Use Volatile State and Lifecycle Methods to Manage Private State</a></i>
 
-
 MST models primarily aid in storing _persistable_ state. State that can be persisted, serialized, transferred, patched, replaced etc.
 However, sometimes you need to keep track of temporary, non-persistable state. This is called _volatile_ state in MST. Examples include promises, sockets, DOM elements etc. - state which is needed for local purposes as long as the object is alive.
 
@@ -735,7 +750,8 @@ Volatile is preserved for the life-time of an object, and not reset when snapsho
 The following is an example of an object with volatile state. Note that volatile state here is used to track a XHR request, and clean up resources when it is disposed. Without volatile state this kind of information would need to be stored in an external WeakMap or something similar.
 
 ```javascript
-const Store = types.model({
+const Store = types
+    .model({
         todos: types.array(Todo),
         state: types.enumeration("State", ["loading", "loaded", "error"])
     })
@@ -761,15 +777,15 @@ const Store = types.model({
 
 Some tips:
 
-1. Note that multiple `actions` calls can be chained. This makes it possible to create multiple closures with their own protected volatile state.
-1. Although in the above example the `pendingRequest` could be initialized directly in the action initializer, it is recommended to do this in the `afterCreate` hook, which will only once the entire instance has been set up (there might be many action and property initializers for a single type).
+1.  Note that multiple `actions` calls can be chained. This makes it possible to create multiple closures with their own protected volatile state.
+1.  Although in the above example the `pendingRequest` could be initialized directly in the action initializer, it is recommended to do this in the `afterCreate` hook, which will only once the entire instance has been set up (there might be many action and property initializers for a single type).
 
-1. The above example doesn't actually use the promise. For how to work with promises / asynchronous flows, see the [asynchronous actions](#asynchronous-actions) section above.
+1.  The above example doesn't actually use the promise. For how to work with promises / asynchronous flows, see the [asynchronous actions](#asynchronous-actions) section above.
 
-1. It is possible to share volatile state between views and actions by using `extend`. `.extend` works like a combination of `.actions` and `.views` and should return an object with a `actions` and `views` field:
+1.  It is possible to share volatile state between views and actions by using `extend`. `.extend` works like a combination of `.actions` and `.views` and should return an object with a `actions` and `views` field:
 
 ```javascript
-const Todo =  types.model({}).extend(self => {
+const Todo = types.model({}).extend(self => {
     let localState = 3
 
     return {
@@ -794,7 +810,8 @@ In that case, in the above example, `localState` could have been declared as `co
 Since this is such a common pattern, there is a shorthand to declare such properties, and the example above could be rewritten to:
 
 ```javascript
-const Todo =  types.model({})
+const Todo = types
+    .model({})
     .volatile(self => ({
         localState: 3
     }))
@@ -807,13 +824,13 @@ const Todo =  types.model({})
 
 The object that is returned from the `volatile` initializer function can contain any piece of data, and will result in an instance property with the same name. Volatile properties have the following characteristics:
 
-1. The can be read from outside the model (if you want hidden volatile state, keep the state in your closure as shown in the previous section)
-2. The volatile properties will be only observable be [observable _references_](https://mobx.js.org/refguide/modifiers.html). Values assigned to them will be unmodified and not automatically converted to deep observable structures.
-3. Like normal properties, they can only be modified through actions
-5. Volatile props will not show up in snapshots, and cannot be updated by applying snapshots
-5. Volatile props are preserved during the lifecycle of an instance. See also [reconciliation](#reconciliation)
-4. Changes in volatile props won't show up in the patch or snapshot stream
-4. It is currently not supported to define getters / setters in the object returned by `volatile`
+1.  The can be read from outside the model (if you want hidden volatile state, keep the state in your closure as shown in the previous section)
+2.  The volatile properties will be only observable be [observable _references_](https://mobx.js.org/refguide/modifiers.html). Values assigned to them will be unmodified and not automatically converted to deep observable structures.
+3.  Like normal properties, they can only be modified through actions
+4.  Volatile props will not show up in snapshots, and cannot be updated by applying snapshots
+5.  Volatile props are preserved during the lifecycle of an instance. See also [reconciliation](#reconciliation)
+6.  Changes in volatile props won't show up in the patch or snapshot stream
+7.  It is currently not supported to define getters / setters in the object returned by `volatile`
 
 ## Dependency injection
 
@@ -826,7 +843,8 @@ See also the [bookshop example](https://github.com/mobxjs/mobx-state-tree/blob/a
 ```javascript
 import { types, getEnv } from "mobx-state-tree"
 
-const Todo = types.model({
+const Todo = types
+    .model({
         title: ""
     })
     .actions(self => ({
@@ -848,9 +866,11 @@ const logger = {
     }
 }
 
-const store = Store.create({
+const store = Store.create(
+    {
         todos: [{ title: "Grab tea" }]
-    }, {
+    },
+    {
         logger: logger // inject logger to the tree
     }
 )
@@ -868,40 +888,41 @@ These are the types available in MST. All types can be found in the `types` name
 
 ## Complex types
 
-* `types.model(properties, actions)` Defines a "class like" type, with properties and actions to operate on the object.
-* `types.array(type)` Declares an array of the specified type.
-* `types.map(type)` Declares a map of the specified type.
+-   `types.model(properties, actions)` Defines a "class like" type, with properties and actions to operate on the object.
+-   `types.array(type)` Declares an array of the specified type.
+-   `types.map(type)` Declares a map of the specified type.
 
 ## Primitive types
 
-* `types.string`
-* `types.number`
-* `types.integer`
-* `types.boolean`
-* `types.Date`
-* `types.custom` creates a custom primitive type. This is useful to define your own types that map a serialized form one-to-one to an immutable object like a Decimal or Date.
+-   `types.string`
+-   `types.number`
+-   `types.integer`
+-   `types.boolean`
+-   `types.Date`
+-   `types.custom` creates a custom primitive type. This is useful to define your own types that map a serialized form one-to-one to an immutable object like a Decimal or Date.
 
 ## Utility types
 
-* `types.union(dispatcher?, types...)` create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
-* `types.optional(type, defaultValue)` marks an value as being optional (in e.g. a model). If a value is not provided the `defaultValue` will be used instead. If `defaultValue` is a function, it will be evaluated. This can be used to generate, for example, IDs or timestamps upon creation.
-* `types.literal(value)` can be used to create a literal type, where the only possible value is specifically that value. This is very powerful in combination with `union`s. E.g. `temperature: types.union(types.literal("hot"), types.literal("cold"))`.
-* `types.enumeration(name?, options: string[])` creates an enumeration. This method is a shorthand for a union of string literals.
-* `types.refinement(name?, baseType, (snapshot) => boolean)` creates a type that is more specific than the base type, e.g. `types.refinement(types.string, value => value.length > 5)` to create a type of strings that can only be longer then 5.
-* `types.maybe(type)` makes a type optional and nullable, shorthand for `types.optional(types.union(type, types.literal(undefined)), undefined)`.
-* `types.maybeNull(type)` like `maybe`, but uses `null` to represent the absence of a value.
-* `types.null` the type of `null`
-* `types.undefined` the type of `undefined`
-* `types.late(() => type)` can be used to create recursive or circular types, or types that are spread over files in such a way that circular dependencies between files would be an issue otherwise.
-* `types.frozen` Accepts any kind of serializable value (both primitive and complex), but assumes that the value itself is **immutable** and **serializable**.
-* `types.compose(name?, type1...typeX)`, creates a new model type by taking a bunch of existing types and combining them into a new one
+-   `types.union(dispatcher?, types...)` create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
+-   `types.optional(type, defaultValue)` marks an value as being optional (in e.g. a model). If a value is not provided the `defaultValue` will be used instead. If `defaultValue` is a function, it will be evaluated. This can be used to generate, for example, IDs or timestamps upon creation.
+-   `types.literal(value)` can be used to create a literal type, where the only possible value is specifically that value. This is very powerful in combination with `union`s. E.g. `temperature: types.union(types.literal("hot"), types.literal("cold"))`.
+-   `types.enumeration(name?, options: string[])` creates an enumeration. This method is a shorthand for a union of string literals.
+-   `types.refinement(name?, baseType, (snapshot) => boolean)` creates a type that is more specific than the base type, e.g. `types.refinement(types.string, value => value.length > 5)` to create a type of strings that can only be longer then 5.
+-   `types.maybe(type)` makes a type optional and nullable, shorthand for `types.optional(types.union(type, types.literal(undefined)), undefined)`.
+-   `types.maybeNull(type)` like `maybe`, but uses `null` to represent the absence of a value.
+-   `types.null` the type of `null`
+-   `types.undefined` the type of `undefined`
+-   `types.late(() => type)` can be used to create recursive or circular types, or types that are spread over files in such a way that circular dependencies between files would be an issue otherwise.
+-   `types.frozen` Accepts any kind of serializable value (both primitive and complex), but assumes that the value itself is **immutable** and **serializable**.
+-   `types.compose(name?, type1...typeX)`, creates a new model type by taking a bunch of existing types and combining them into a new one
 
 ## Property types
 
 Property types can only be used as a direct member of a `types.model` type and not further composed (for now).
-* `types.identifier` Only one such member can exist in a `types.model` and should uniquely identify the object. See [identifiers](#identifiers) for more details. `subType` should be either `types.string` or `types.number`, defaulting to the first if not specified.
-* `types.identifierNumber` Similar to `types.identifier`. However, during serialization, the identifier value will be parsed from / serialized to a number
-* `types.reference(targetType)` creates a property that is a reference to another item of the given `targetType` somewhere in the same tree. See [references](#references) for more details.
+
+-   `types.identifier` Only one such member can exist in a `types.model` and should uniquely identify the object. See [identifiers](#identifiers) for more details. `subType` should be either `types.string` or `types.number`, defaulting to the first if not specified.
+-   `types.identifierNumber` Similar to `types.identifier`. However, during serialization, the identifier value will be parsed from / serialized to a number
+-   `types.reference(targetType)` creates a property that is a reference to another item of the given `targetType` somewhere in the same tree. See [references](#references) for more details.
 
 ## LifeCycle hooks for `types.model`
 
@@ -910,13 +931,11 @@ Property types can only be used as a direct member of a `types.model` type and n
 All of the below hooks can be created by returning an action with the given name, like:
 
 ```javascript
-const Todo = types
-    .model("Todo", { done: true })
-    .actions(self => ({
-        afterCreate() {
-            console.log("Created a new todo!")
-        }
-    }))
+const Todo = types.model("Todo", { done: true }).actions(self => ({
+    afterCreate() {
+        console.log("Created a new todo!")
+    }
+}))
 ```
 
 The exception to this rule is the `preProcessSnapshot` hook. Because it is needed before instantiating model elements, it needs to be defined on the type itself:
@@ -937,76 +956,74 @@ types
 
 Note; pre and post processing are just meant to convert your data into types that are more acceptable to MST. Typically it should be the case that `postProcess(preProcess(snapshot)) === snapshot. If that isn't the case, consider whether you shouldn't be using a dedicated a view instead to normalize your snapshot to some other format you need.
 
-| Hook            | Meaning                                                                                                                                                   |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `preProcessSnapshot` | Before creating an instance or applying a snapshot to an existing instance, this hook is called to give the option to transform the snapshot before it is applied. The hook should be a _pure_ function that returns a new snapshot. This can be useful to do some data conversion, enrichment, property renames etc. This hook is not called for individual property updates. _**Note 1: Unlike the other hooks, this one is _not_ created as part of the `actions` initializer, but directly on the type!**_ _**Note 2: The `preProcessSnapshot` transformation must be pure; it should not modify its original input argument!**_ |
-| `afterCreate`   | Immediately after an instance is created and initial values are applied. Children will fire this event before parents. You can't make assumptions about the parent safely, use `afterAttach` if you need to.                                     |
-| `afterAttach`   | As soon as the _direct_ parent is assigned (this node is attached to another node). If an element is created as part of a parent, `afterAttach` is also fired. Unlike `afterCreate`, `afterAttach` will fire breadth first. So, in `afterAttach` one can safely make assumptions about the parent, but in `afterCreate` not |
-| `postProcessSnapshot` | This hook is called every time a new snapshot is being generated. Typically it is the inverse function of `preProcessSnapshot`. This function should be a pure function that returns a new snapshot. _**Note: Unlike the other hooks, this one is _not_ created as part of the `actions` initializer, but directly on the type!**_
-| `beforeDetach`  | As soon as the node is removed from the _direct_ parent, but only if the node is _not_ destroyed. In other words, when `detach(node)` is used             |
-| `beforeDestroy` | Called before the node is destroyed, as a result of calling `destroy`, or by removing or replacing the node from the tree. Child destructors will fire before parents |
+| Hook                  | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `preProcessSnapshot`  | Before creating an instance or applying a snapshot to an existing instance, this hook is called to give the option to transform the snapshot before it is applied. The hook should be a _pure_ function that returns a new snapshot. This can be useful to do some data conversion, enrichment, property renames etc. This hook is not called for individual property updates. _\*\*Note 1: Unlike the other hooks, this one is \_not_ created as part of the `actions` initializer, but directly on the type!**\_ \_**Note 2: The `preProcessSnapshot` transformation must be pure; it should not modify its original input argument!\*\*\_ |
+| `afterCreate`         | Immediately after an instance is created and initial values are applied. Children will fire this event before parents. You can't make assumptions about the parent safely, use `afterAttach` if you need to.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `afterAttach`         | As soon as the _direct_ parent is assigned (this node is attached to another node). If an element is created as part of a parent, `afterAttach` is also fired. Unlike `afterCreate`, `afterAttach` will fire breadth first. So, in `afterAttach` one can safely make assumptions about the parent, but in `afterCreate` not                                                                                                                                                                                                                                                                                                                  |
+| `postProcessSnapshot` | This hook is called every time a new snapshot is being generated. Typically it is the inverse function of `preProcessSnapshot`. This function should be a pure function that returns a new snapshot. _\*\*Note: Unlike the other hooks, this one is \_not_ created as part of the `actions` initializer, but directly on the type!\*\*\_                                                                                                                                                                                                                                                                                                     |
+| `beforeDetach`        | As soon as the node is removed from the _direct_ parent, but only if the node is _not_ destroyed. In other words, when `detach(node)` is used                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `beforeDestroy`       | Called before the node is destroyed, as a result of calling `destroy`, or by removing or replacing the node from the tree. Child destructors will fire before parents                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 
 Note, except for `preProcessSnapshot`, all hooks should be defined as actions.
 
 All hooks can be defined multiple times and can be composed automatically.
 
-
-
 # Api overview
 
 See the [full API docs](API.md) for more details.
 
-| signature | |
-| ---- | --- |
-| [`addDisposer(node, () => void)`](API.md#adddisposer) | Function to be invoked whenever the target node is to be destroyed |
-| [`addMiddleware(node, middleware: (actionDescription, next) => any, includeHooks)`](API.md#addmiddleware) | Attaches middleware to a node. See [middleware](docs/middleware.md). Returns disposer. |
-| [`applyAction(node, actionDescription)`](API.md#applyaction) | Replays an action on the targeted node |
-| [`applyPatch(node, jsonPatch)`](API.md#applypatch) | Applies a JSON patch, or array of patches, to a node in the tree |
-| [`cast(nodeOrSnapshot)`](API.md#cast) | Cast a node instance or snapshot to a node so it can be used in assignment operations |
-| [`applySnapshot(node, snapshot)`](API.md#applysnapshot) | Updates a node with the given snapshot |
-| [`createActionTrackingMiddleware`](API.md#createactiontrackingmiddleware) | Utility to make writing middleware that tracks async actions less cumbersome |
-| [`clone(node, keepEnvironment?: true \| false \| newEnvironment)`](API.md#clone) | Creates a full clone of the given node. By default preserves the same environment |
-| [`decorate(handler, function)`](API.md#decorate) | Attaches middleware to a specific action (or flow) |
-| [`destroy(node)`](API.md#destroy) | Kills `node`, making it unusable. Removes it from any parent in the process |
-| [`detach(node)`](API.md#detach) | Removes `node` from its current parent, and lets it live on as standalone tree |
-| [`flow(generator)`](API.md#flow) | creates an asynchronous flow based on a generator function |
-| [`getChildType(node, property?)`](API.md#getchildtype) | Returns the declared type of the given `property` of `node`. For arrays and maps `property` can be omitted as they all have the same type |
-| [`getEnv(node)`](API.md#getenv) | Returns the environment of `node`, see [environments](#environments) |
-| [`getParent(node, depth=1)`](API.md#getparent) | Returns the intermediate parent of the `node`, or a higher one if `depth > 1` |
-| [`getParentOfType(node, type)`](API.md#getparentoftype) | Return the first parent that satisfies the provided type |
-| [`getPath(node)`](API.md#getpath) | Returns the path of `node` in the tree |
-| [`getPathParts(node)`](API.md#getpathparts) | Returns the path of `node` in the tree, unescaped as separate parts |
-| [`getRelativePath(base, target)`](API.md#getrelativepath) | Returns the short path, which one could use to walk from node `base` to node `target`, assuming they are in the same tree. Up is represented as `../` |
-| [`getRoot(node)`](API.md#getroot) | Returns the root element of the tree containing `node` |
-| [`getIdentifier(node)`](API.md#getidentifier) | Returns the identifier of the given element |
-| [`getSnapshot(node, applyPostProcess)`](API.md#getsnapshot) | Returns the snapshot of the `node`. See [snapshots](#snapshots) |
-| [`getType(node)`](API.md#gettype) | Returns the type of `node` |
-| [`hasParent(node, depth=1)`](API.md#hasparent) | Returns `true` if `node` has a parent at `depth` |
-| [`hasParentOfType(node, type)`](API.md#hasparentoftype) | Returns `true` if the `node` has a parent that satisfies the provided type |
-| [`isAlive(node)`](API.md#isalive) | Returns `true` if `node` is alive |
-| [`isStateTreeNode(value)`](API.md#isstatetreenode) | Returns `true` if `value` is a node of a mobx-state-tree |
-| [`isProtected(value)`](API.md#isprotected) | Returns `true` if the given node is protected, see [actions](#actions) |
-| [`isRoot(node)`](API.md#isroot) | Returns true if `node` has no parents  |
-| [`joinJsonPath(parts)`](API.md#joinjsonpath) | Joins and escapes the given path `parts` into a JSON path |
-| [`onAction(node, (actionDescription) => void)`](API.md#onaction) | A built-in middleware that calls the provided callback with an action description upon each invocation. Returns disposer |
-| [`onPatch(node, (patch) => void)`](API.md#onpatch) | Attach a JSONPatch listener, that is invoked for each change in the tree. Returns disposer |
-| [`onSnapshot(node, (snapshot) => void)`](API.md#onsnapshot) | Attach a snapshot listener, that is invoked for each change in the tree. Returns disposer |
-| [`process(generator)`](API.md#process) | `DEPRECATED` – replaced with [flow](API.md#flow) |
-| [`protect(node)`](API.md#protect) | Protects an unprotected tree against modifications from outside actions |
-| [`recordActions(node)`](API.md#recordactions) | Creates a recorder that listens to all actions in `node`. Call `.stop()` on the recorder to stop this, and `.replay(target)` to replay the recorded actions on another tree  |
-| [`recordPatches(node)`](API.md#recordpatches) | Creates a recorder that listens to all patches emitted by the node. Call `.stop()` on the recorder to stop this, and `.replay(target)` to replay the recorded patches on another tree |
-| [`getMembers(node)`](API.md#getMembers) | Returns the model name, properties, actions, views, volatiles |
-| [`resolve(node, path)`](API.md#resolve) | Resolves a `path` (json path) relatively to the given `node` |
-| [`resolveIdentifier(type, target, identifier)`](API.md#resolveidentifier) | resolves an identifier of a given type in a model tree |
-| [`resolvePath(target, path)`](API.md#resolvepath) | resolves a JSON path, starting at the specified target |
-| [`setLivelynessChecking("warn" \| "ignore" \| "error")`](API.md#setlivelynesschecking) | Defines what MST should do when running into reads / writes to objects that have died. By default it will print a warning. Use te `"error"` option to easy debugging to see where the error was thrown and when the offending read / write took place |
-| [`splitJsonPath(path)`](API.md#splitjsonpath) | Splits and unescapes the given JSON `path` into path parts |
-| [`typecheck(type, value)`](API.md#typecheck) | Typechecks a value against a type. Throws on errors. Use this if you need typechecks even in a production build. |
-| [`tryResolve(node, path)`](API.md#tryresolve) | Like `resolve`, but just returns `null` if resolving fails at any point in the path |
-| [`unprotect(node)`](API.md#unprotect) | Unprotects `node`, making it possible to directly modify any value in the subtree, without actions |
-| [`walk(startNode, (node) => void)`](API.md#walk) | Performs a depth-first walk through a tree |
-| [`escapeJsonPath(path)`](API.md#escapejsonpath) | escape special characters in an identifier, according to http://tools.ietf.org/html/rfc6901 |
-| [`unescapeJsonPath(path)`](API.md#unescapejsonpath) | escape special characters in an identifier, according to http://tools.ietf.org/html/rfc6901 |
+| signature                                                                                                 |                                                                                                                                                                                                                                                       |
+| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`addDisposer(node, () => void)`](API.md#adddisposer)                                                     | Function to be invoked whenever the target node is to be destroyed                                                                                                                                                                                    |
+| [`addMiddleware(node, middleware: (actionDescription, next) => any, includeHooks)`](API.md#addmiddleware) | Attaches middleware to a node. See [middleware](docs/middleware.md). Returns disposer.                                                                                                                                                                |
+| [`applyAction(node, actionDescription)`](API.md#applyaction)                                              | Replays an action on the targeted node                                                                                                                                                                                                                |
+| [`applyPatch(node, jsonPatch)`](API.md#applypatch)                                                        | Applies a JSON patch, or array of patches, to a node in the tree                                                                                                                                                                                      |
+| [`cast(nodeOrSnapshot)`](API.md#cast)                                                                     | Cast a node instance or snapshot to a node so it can be used in assignment operations                                                                                                                                                                 |
+| [`applySnapshot(node, snapshot)`](API.md#applysnapshot)                                                   | Updates a node with the given snapshot                                                                                                                                                                                                                |
+| [`createActionTrackingMiddleware`](API.md#createactiontrackingmiddleware)                                 | Utility to make writing middleware that tracks async actions less cumbersome                                                                                                                                                                          |
+| [`clone(node, keepEnvironment?: true \| false \| newEnvironment)`](API.md#clone)                          | Creates a full clone of the given node. By default preserves the same environment                                                                                                                                                                     |
+| [`decorate(handler, function)`](API.md#decorate)                                                          | Attaches middleware to a specific action (or flow)                                                                                                                                                                                                    |
+| [`destroy(node)`](API.md#destroy)                                                                         | Kills `node`, making it unusable. Removes it from any parent in the process                                                                                                                                                                           |
+| [`detach(node)`](API.md#detach)                                                                           | Removes `node` from its current parent, and lets it live on as standalone tree                                                                                                                                                                        |
+| [`flow(generator)`](API.md#flow)                                                                          | creates an asynchronous flow based on a generator function                                                                                                                                                                                            |
+| [`getChildType(node, property?)`](API.md#getchildtype)                                                    | Returns the declared type of the given `property` of `node`. For arrays and maps `property` can be omitted as they all have the same type                                                                                                             |
+| [`getEnv(node)`](API.md#getenv)                                                                           | Returns the environment of `node`, see [environments](#environments)                                                                                                                                                                                  |
+| [`getParent(node, depth=1)`](API.md#getparent)                                                            | Returns the intermediate parent of the `node`, or a higher one if `depth > 1`                                                                                                                                                                         |
+| [`getParentOfType(node, type)`](API.md#getparentoftype)                                                   | Return the first parent that satisfies the provided type                                                                                                                                                                                              |
+| [`getPath(node)`](API.md#getpath)                                                                         | Returns the path of `node` in the tree                                                                                                                                                                                                                |
+| [`getPathParts(node)`](API.md#getpathparts)                                                               | Returns the path of `node` in the tree, unescaped as separate parts                                                                                                                                                                                   |
+| [`getRelativePath(base, target)`](API.md#getrelativepath)                                                 | Returns the short path, which one could use to walk from node `base` to node `target`, assuming they are in the same tree. Up is represented as `../`                                                                                                 |
+| [`getRoot(node)`](API.md#getroot)                                                                         | Returns the root element of the tree containing `node`                                                                                                                                                                                                |
+| [`getIdentifier(node)`](API.md#getidentifier)                                                             | Returns the identifier of the given element                                                                                                                                                                                                           |
+| [`getSnapshot(node, applyPostProcess)`](API.md#getsnapshot)                                               | Returns the snapshot of the `node`. See [snapshots](#snapshots)                                                                                                                                                                                       |
+| [`getType(node)`](API.md#gettype)                                                                         | Returns the type of `node`                                                                                                                                                                                                                            |
+| [`hasParent(node, depth=1)`](API.md#hasparent)                                                            | Returns `true` if `node` has a parent at `depth`                                                                                                                                                                                                      |
+| [`hasParentOfType(node, type)`](API.md#hasparentoftype)                                                   | Returns `true` if the `node` has a parent that satisfies the provided type                                                                                                                                                                            |
+| [`isAlive(node)`](API.md#isalive)                                                                         | Returns `true` if `node` is alive                                                                                                                                                                                                                     |
+| [`isStateTreeNode(value)`](API.md#isstatetreenode)                                                        | Returns `true` if `value` is a node of a mobx-state-tree                                                                                                                                                                                              |
+| [`isProtected(value)`](API.md#isprotected)                                                                | Returns `true` if the given node is protected, see [actions](#actions)                                                                                                                                                                                |
+| [`isRoot(node)`](API.md#isroot)                                                                           | Returns true if `node` has no parents                                                                                                                                                                                                                 |
+| [`joinJsonPath(parts)`](API.md#joinjsonpath)                                                              | Joins and escapes the given path `parts` into a JSON path                                                                                                                                                                                             |
+| [`onAction(node, (actionDescription) => void)`](API.md#onaction)                                          | A built-in middleware that calls the provided callback with an action description upon each invocation. Returns disposer                                                                                                                              |
+| [`onPatch(node, (patch) => void)`](API.md#onpatch)                                                        | Attach a JSONPatch listener, that is invoked for each change in the tree. Returns disposer                                                                                                                                                            |
+| [`onSnapshot(node, (snapshot) => void)`](API.md#onsnapshot)                                               | Attach a snapshot listener, that is invoked for each change in the tree. Returns disposer                                                                                                                                                             |
+| [`process(generator)`](API.md#process)                                                                    | `DEPRECATED` – replaced with [flow](API.md#flow)                                                                                                                                                                                                      |
+| [`protect(node)`](API.md#protect)                                                                         | Protects an unprotected tree against modifications from outside actions                                                                                                                                                                               |
+| [`recordActions(node)`](API.md#recordactions)                                                             | Creates a recorder that listens to all actions in `node`. Call `.stop()` on the recorder to stop this, and `.replay(target)` to replay the recorded actions on another tree                                                                           |
+| [`recordPatches(node)`](API.md#recordpatches)                                                             | Creates a recorder that listens to all patches emitted by the node. Call `.stop()` on the recorder to stop this, and `.replay(target)` to replay the recorded patches on another tree                                                                 |
+| [`getMembers(node)`](API.md#getMembers)                                                                   | Returns the model name, properties, actions, views, volatiles                                                                                                                                                                                         |
+| [`resolve(node, path)`](API.md#resolve)                                                                   | Resolves a `path` (json path) relatively to the given `node`                                                                                                                                                                                          |
+| [`resolveIdentifier(type, target, identifier)`](API.md#resolveidentifier)                                 | resolves an identifier of a given type in a model tree                                                                                                                                                                                                |
+| [`resolvePath(target, path)`](API.md#resolvepath)                                                         | resolves a JSON path, starting at the specified target                                                                                                                                                                                                |
+| [`setLivelynessChecking("warn" \| "ignore" \| "error")`](API.md#setlivelynesschecking)                    | Defines what MST should do when running into reads / writes to objects that have died. By default it will print a warning. Use te `"error"` option to easy debugging to see where the error was thrown and when the offending read / write took place |
+| [`splitJsonPath(path)`](API.md#splitjsonpath)                                                             | Splits and unescapes the given JSON `path` into path parts                                                                                                                                                                                            |
+| [`typecheck(type, value)`](API.md#typecheck)                                                              | Typechecks a value against a type. Throws on errors. Use this if you need typechecks even in a production build.                                                                                                                                      |
+| [`tryResolve(node, path)`](API.md#tryresolve)                                                             | Like `resolve`, but just returns `null` if resolving fails at any point in the path                                                                                                                                                                   |
+| [`unprotect(node)`](API.md#unprotect)                                                                     | Unprotects `node`, making it possible to directly modify any value in the subtree, without actions                                                                                                                                                    |
+| [`walk(startNode, (node) => void)`](API.md#walk)                                                          | Performs a depth-first walk through a tree                                                                                                                                                                                                            |
+| [`escapeJsonPath(path)`](API.md#escapejsonpath)                                                           | escape special characters in an identifier, according to http://tools.ietf.org/html/rfc6901                                                                                                                                                           |
+| [`unescapeJsonPath(path)`](API.md#unescapejsonpath)                                                       | escape special characters in an identifier, according to http://tools.ietf.org/html/rfc6901                                                                                                                                                           |
 
 A _disposer_ is a function that cancels the effect it was created for.
 
@@ -1043,6 +1060,7 @@ export function LateStore() {
 ```
 
 In the importing file
+
 ```javascript
 import { LateStore } from "./circular-dep"
 
@@ -1125,7 +1143,7 @@ export const LoggingSquare = types
 
 ### When not to use MST?
 
-MST provides access to snapshots, patches and interceptable actions.  Also, it fixes the `this` problem.
+MST provides access to snapshots, patches and interceptable actions. Also, it fixes the `this` problem.
 All these features have a downside as they incur a little runtime overhead.
 Although in many places the MST core can still be optimized significantly, there will always be a constant overhead.
 If you have a performance critical application that handles a huge amount of mutable data, you will probably be better
@@ -1137,15 +1155,15 @@ Likewise, if your application mainly processes stateless information (such as a 
 
 MST doesn't offer an any type because it can't reason about it. For example, given a snapshot and a field with `any`, how should MST know how to deserialize it? Or apply patches to it? Etc. etc. If you need `any` there are following options
 
-1. Use `types.frozen`. Frozen values need to be immutable and serializable (so MST can treat them verbatim)
-2. Use volatile state. Volatile state can store anything, but won't appear in snapshots, patches etc.
-3. If your type is regular, and you just are too lazy to type the model, you could also consider generating the type at runtime once (after all, MST types are just JS...). But you will loose static typing and any confusion it causes is up to you to handle :-).
+1.  Use `types.frozen`. Frozen values need to be immutable and serializable (so MST can treat them verbatim)
+2.  Use volatile state. Volatile state can store anything, but won't appear in snapshots, patches etc.
+3.  If your type is regular, and you just are too lazy to type the model, you could also consider generating the type at runtime once (after all, MST types are just JS...). But you will loose static typing and any confusion it causes is up to you to handle :-).
 
 ### How does reconciliation work?
 
-* When applying snapshots, MST will always try to reuse existing object instances for snapshots with the same identifier (see `types.identifier`).
-* If no identifier is specified, but the type of the snapshot is correct, MST will reconcile objects as well if they are stored in a specific model property or under the same map key.
-* In arrays, items without an identifier are never reconciled.
+-   When applying snapshots, MST will always try to reuse existing object instances for snapshots with the same identifier (see `types.identifier`).
+-   If no identifier is specified, but the type of the snapshot is correct, MST will reconcile objects as well if they are stored in a specific model property or under the same map key.
+-   In arrays, items without an identifier are never reconciled.
 
 If an object is reconciled, the consequence is that localState is preserved and `postCreate` / `attach` life-cycle hooks are not fired because applying a snapshot results just in an existing tree node being updated.
 
@@ -1160,6 +1178,7 @@ See [creating asynchronous flow](docs/async-actions.md).
 Yep, perfectly fine. No problem. Go on. `observer`, `autorun` etc. will work as expected.
 
 ### Should all state of my app be stored in `mobx-state-tree`?
+
 No, or, not necessarily. An application can use both state trees and vanilla MobX observables at the same time.
 State trees are primarily designed to store your domain data, as this kind of state is often distributed and not very local.
 For local component state, for example, vanilla MobX observables might often be simpler to use.
@@ -1168,10 +1187,9 @@ For local component state, for example, vanilla MobX observables might often be 
 
 <i><a style="color: white; background:cornflowerblue;padding:5px;margin:5px;border-radius:2px" href="https://egghead.io/lessons/react-restore-the-model-tree-state-using-hot-module-reloading-when-model-definitions-change">egghead.io lesson 10: Restore the Model Tree State using Hot Module Reloading when Model Definitions Change</a></i>
 
-
 Yes, with MST it is pretty straight forward to setup hot reloading for your store definitions, while preserving state. See the [todomvc example](https://github.com/mobxjs/mobx-state-tree/blob/745904101fdaeb51f16f40ebb80cd7fecf742572/packages/mst-example-todomvc/src/index.js#L60-L64)
 
-### TypeScript & MST
+### TypeScript and MST
 
 TypeScript support is best-effort, as not all patterns can be expressed in TypeScript. But except for assigning snapshots to properties we get pretty close! As MST uses the latest fancy Typescript features it is required to use TypeScript 2.8 or higher, with `noImplicitThis` and `strictNullChecks` enabled.
 
@@ -1187,13 +1205,15 @@ What about compile time? You can use TypeScript interfaces to perform those chec
 Good news! You don't need to write it twice!
 
 There are three kinds of types available, plus one helper type:
-- `Instance<typeof TYPE>` or `Instance<typeof VARIABLE>` is the node instance type. (Legacy form is `typeof MODEL.Type`).
-- `InSnapshot<typeof TYPE>` or `InSnapshot<typeof VARIABLE>` is the input (creation) snapshot type. (Legacy form is `typeof MODEL.CreationType`).
-- `OutSnapshot<typeof TYPE>` or `OutSnapshot<typeof VARIABLE>` is the output (creation) snapshot type. (Legacy form is `typeof MODEL.SnapshotType`).  
-- `SnapshotOrInstance<typeof TYPE>` or `SnapshotOrInstance<typeof VARIABLE>` is `InSnapshot<T> | Instance<T>`. This type is useful when you want to declare an input parameter that is able consume both types.
+
+-   `Instance<typeof TYPE>` or `Instance<typeof VARIABLE>` is the node instance type. (Legacy form is `typeof MODEL.Type`).
+-   `SnapshotIn<typeof TYPE>` or `SnapshotIn<typeof VARIABLE>` is the input (creation) snapshot type. (Legacy form is `typeof MODEL.CreationType`).
+-   `SnapshotOut<typeof TYPE>` or `SnapshotOut<typeof VARIABLE>` is the output (creation) snapshot type. (Legacy form is `typeof MODEL.SnapshotType`).
+-   `SnapshotOrInstance<typeof TYPE>` or `SnapshotOrInstance<typeof VARIABLE>` is `SnapshotIn<T> | Instance<T>`. This type is useful when you want to declare an input parameter that is able consume both types.
 
 ```typescript
-const Todo = types.model({
+const Todo = types
+    .model({
         title: "hello"
     })
     .actions(self => ({
@@ -1204,23 +1224,23 @@ const Todo = types.model({
 
 type ITodo = Instance<typeof Todo> // => { title: string; setTitle: (v: string) => void }
 
-type ITodoInSnapshot = InSnapshot<typeof Todo> // => { title?: string }
+type ITodoSnapshotIn = SnapshotIn<typeof Todo> // => { title?: string }
 
-type ITodoOutSnapshot = OutSnapshot<typeof Todo> // => { title: string }
+type ITodoSnapshotOut = SnapshotOut<typeof Todo> // => { title: string }
 ```
 
 Due to the way typeof operator works, when working with big and deep models trees, it might make your IDE/ts server takes a lot of CPU time and freeze vscode (or others)
 A partial solution for this is to turn the types into interfaces.
 
 ```ts
-type ITodoType = Instance<typeof Todo>;
-interface ITodo extends ITodoType {};
+type ITodoType = Instance<typeof Todo>
+interface ITodo extends ITodoType {}
 
-type ITodoInSnapshotType = InSnapshot<typeof Todo>;
-interface ITodoInSnapshot extends ITodoInSnapshotType {};
+type ITodoSnapshotInType = SnapshotIn<typeof Todo>
+interface ITodoSnapshotIn extends ITodoSnapshotInType {}
 
-type ITodoOutSnapshotType = OutSnapshot<typeof Todo>;
-interface ITodoOutSnapshot extends ITodoOutSnapshotType {};
+type ITodoSnapshotOutType = SnapshotOut<typeof Todo>
+interface ITodoSnapshotOut extends ITodoSnapshotOutType {}
 ```
 
 #### Typing `self` in actions and views
@@ -1233,17 +1253,17 @@ For example:
 
 ```typescript
 const Example = types
-  .model('Example', {
-    prop: types.string,
-  })
-  .views(self => ({
-    get upperProp(): string {
-      return self.prop.toUpperCase();
-    },
-    get twiceUpperProp(): string {
-      return self.upperProp + self.upperProp; // Compile error: `self.upperProp` is not yet defined
-    },
-  }));
+    .model("Example", {
+        prop: types.string
+    })
+    .views(self => ({
+        get upperProp(): string {
+            return self.prop.toUpperCase()
+        },
+        get twiceUpperProp(): string {
+            return self.upperProp + self.upperProp // Compile error: `self.upperProp` is not yet defined
+        }
+    }))
 ```
 
 You can circumvent this situation by declaring the views in two steps:
@@ -1266,20 +1286,20 @@ const Example = types
 
 _**NOTE: the above approach will incur runtime performance penalty as accessing such computed values (e.g. inside `render()` method of an observed component) always leads to full recompute (see [this issue](https://github.com/mobxjs/mobx-state-tree/issues/818#issue-323164363) for details). For a heavily-used computed properties it's recommended to use one of below approaches.**_
 
-
 Alternatively, you can manually override the inferred type of `self`:
 
 ```typescript
 const Example = types
-  .model('Example', { prop: types.string })
-  .views((self: typeof Example.Type) => ({ // use typeof instead of predefined type to avoid circular references
-    get upperProp(): string {
-      return self.prop.toUpperCase();
-    },
-    get twiceUpperProp(): string {
-      return self.upperProp + self.upperProp;
-    }
-  }))
+    .model("Example", { prop: types.string })
+    .views((self: typeof Example.Type) => ({
+        // use typeof instead of predefined type to avoid circular references
+        get upperProp(): string {
+            return self.prop.toUpperCase()
+        },
+        get twiceUpperProp(): string {
+            return self.upperProp + self.upperProp
+        }
+    }))
 ```
 
 Note that you can also declare multiple `.views` block, in which case the `self` parameter gets extended after each block
@@ -1304,26 +1324,24 @@ Similarly, when writing actions or views one can use helper functions:
 ```typescript
 import { types, flow } from "mobx-state-tree"
 
-const Example = types
-  .model('Example', { prop: types.string })
-  .actions(self => {
+const Example = types.model("Example", { prop: types.string }).actions(self => {
     // Don't forget that async operations HAVE
     // to use `flow( ... )`.
-    const fetchData = flow(function *fetchData() {
-      yield doSomething()
+    const fetchData = flow(function* fetchData() {
+        yield doSomething()
     })
 
     return {
-      fetchData,
-      afterCreate() {
-        // Notice that we call the function directly
-        // instead of using `self.fetchData()`. This is
-        // because Typescript doesn't know yet about `fetchData()`
-        // being part of `self` in this context.
-        fetchData()
-      }
+        fetchData,
+        afterCreate() {
+            // Notice that we call the function directly
+            // instead of using `self.fetchData()`. This is
+            // because Typescript doesn't know yet about `fetchData()`
+            // being part of `self` in this context.
+            fetchData()
+        }
     }
-  });
+})
 ```
 
 #### Snapshots can be used to write values
@@ -1358,20 +1376,22 @@ Using both at the same time we can express property assignation of complex prope
 const Task = types.model({
     done: false
 })
-const Store = types.model({
-    tasks: types.array(Task)
-}).actions(self => ({
-    addTask(task: SnapshotOrInstance<typeof Task>) {
-        self.tasks.push(cast(task))
-    },
-    replaceTasks(tasks: SnapshotOrInstance<typeof self.tasks>) {
-        self.tasks = cast(tasks)
-    }
-}))
+const Store = types
+    .model({
+        tasks: types.array(Task)
+    })
+    .actions(self => ({
+        addTask(task: SnapshotOrInstance<typeof Task>) {
+            self.tasks.push(cast(task))
+        },
+        replaceTasks(tasks: SnapshotOrInstance<typeof self.tasks>) {
+            self.tasks = cast(tasks)
+        }
+    }))
 
 const s = Store.create({ tasks: [] })
 
-s.addTask({}) 
+s.addTask({})
 // or
 s.addTask(Task.create({}))
 
@@ -1391,7 +1411,7 @@ import { types } from "mobx-state-tree"
 
 export const Todo = types.model({
     title: types.string
-});
+})
 
 export type ITodo = typeof Todo.Type
 ```
@@ -1418,11 +1438,11 @@ Until Microsoft fixes this issue the solution is to re-export IModelType:
 ```typescript
 import { types, IModelType } from "mobx-state-tree"
 
-export type __IModelType = IModelType<any,any>;
+export type __IModelType = IModelType<any, any>
 
 export const Todo = types.model({
     title: types.string
-});
+})
 
 export type ITodo = typeof Todo.Type
 ```
@@ -1434,10 +1454,11 @@ It ain't pretty, but it works.
 Optional parameters, including "empty" maps, should be either a valid snapshot or a MST instance. To fix type errors such as `Error while converting {} to map`, define your type as such:
 
 ```typescript
-  map: types.optional(types.map(OtherType), {})
+map: types.optional(types.map(OtherType), {})
 ```
 
 ### How does MST compare to Redux
+
 So far this might look a lot like an immutable state tree as found for example in Redux apps, but there're are only so many reasons to use redux as per [article linked at the very top of redux guide](https://medium.com/@dan_abramov/you-might-not-need-redux-be46360cf367) that MST covers too, meanwhile:
 
 -   Like Redux, and unlike MobX, MST prescribes a very specific state architecture.
@@ -1449,20 +1470,20 @@ So far this might look a lot like an immutable state tree as found for example i
 
 ## Contributing
 
-1. Clone this repository
-2. Yarn is the package manager of choice. Make sure to run Node 8 or higher.
-2. Run `yarn install && yarn run bootstrap`.
-3. Run `yarn build` at least once in `packages/mobx-state-tree`
-3. For MST changes: go to `packages/mobx-state-tree` and run `yarn watch` (the test runner is Jest)
-3. Editor settings are optimized for VS Code, so just run `code .` in the root folder. Debugger settings are included in the project.
-3. After updating jsdocs, best run `yarn build-docs`
-3. When creating PRs, make sure to check the travis build, it will run some tests which are by default not run locally
-3. Extensive pull requests are best discussed in an issue first
-3. Have fun!
+1.  Clone this repository
+2.  Yarn is the package manager of choice. Make sure to run Node 8 or higher.
+3.  Run `yarn install && yarn run bootstrap`.
+4.  Run `yarn build` at least once in `packages/mobx-state-tree`
+5.  For MST changes: go to `packages/mobx-state-tree` and run `yarn watch` (the test runner is Jest)
+6.  Editor settings are optimized for VS Code, so just run `code .` in the root folder. Debugger settings are included in the project.
+7.  After updating jsdocs, best run `yarn build-docs`
+8.  When creating PRs, make sure to check the travis build, it will run some tests which are by default not run locally
+9.  Extensive pull requests are best discussed in an issue first
+10. Have fun!
 
 ## Thanks!
 
-* [Mendix](https://mendix.com) for sponsoring and providing the opportunity to work on exploratory projects like MST.
-* [Dan Abramov](https://twitter.com/dan_abramov)'s work on [Redux](http://redux.js.org) has strongly influenced the idea of snapshots and transactional actions in MST.
-* [Giulio Canti](https://twitter.com/GiulioCanti)'s work on [tcomb](http://github.com/gcanti/tcomb) and type systems in general has strongly influenced the type system of MST.
-* All the early adopters encouraging to pursue this whole idea and proving it is something feasible.
+-   [Mendix](https://mendix.com) for sponsoring and providing the opportunity to work on exploratory projects like MST.
+-   [Dan Abramov](https://twitter.com/dan_abramov)'s work on [Redux](http://redux.js.org) has strongly influenced the idea of snapshots and transactional actions in MST.
+-   [Giulio Canti](https://twitter.com/GiulioCanti)'s work on [tcomb](http://github.com/gcanti/tcomb) and type systems in general has strongly influenced the type system of MST.
+-   All the early adopters encouraging to pursue this whole idea and proving it is something feasible.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# x.x.x
+
+* Made the internal CreationType/SnapshotType/Type official via the new InSnapshot/OutSnapshot/Instance/SnapshotOrInstance<typeof X>
+* A new 'cast' method that makes automatic casts from instances/input snapshots for assignments
+
 # 3.1.1
 
 * Fixed typings of `getParent` and `getRoot`. Fixes [#951](https://github.com/mobxjs/mobx-state-tree/issues/951) through [#953](https://github.com/mobxjs/mobx-state-tree/pull/953) by [@xaviergonz](https://github.com/xaviergonz)

--- a/changelog.md
+++ b/changelog.md
@@ -1,25 +1,25 @@
 # x.x.x
 
-* Made the internal CreationType/SnapshotType/Type official via the new InSnapshot/OutSnapshot/Instance/SnapshotOrInstance<typeof X>
-* A new 'cast' method that makes automatic casts from instances/input snapshots for assignments
+-   Made the internal CreationType/SnapshotType/Type official via the new [`SnapshotIn`, `SnapshotOut`, `Instance` and `SnapshotOrInstance<typeof X>`](README.md#typeScript-and-mst)
+-   A new [`cast` method](README.md#snapshots-can-be-used-to-write-values) that makes automatic casts from instances/input snapshots for assignments
 
 # 3.1.1
 
-* Fixed typings of `getParent` and `getRoot`. Fixes [#951](https://github.com/mobxjs/mobx-state-tree/issues/951) through [#953](https://github.com/mobxjs/mobx-state-tree/pull/953) by [@xaviergonz](https://github.com/xaviergonz)
+-   Fixed typings of `getParent` and `getRoot`. Fixes [#951](https://github.com/mobxjs/mobx-state-tree/issues/951) through [#953](https://github.com/mobxjs/mobx-state-tree/pull/953) by [@xaviergonz](https://github.com/xaviergonz)
 
 # 3.1.0
 
-* Fixed issue where snapshot post-processors where not always applied. Fixes [#926](https://github.com/mobxjs/mobx-state-tree/issues/926), [#961](https://github.com/mobxjs/mobx-state-tree/issues/961), through [#959](https://github.com/mobxjs/mobx-state-tree/pull/959) by [@k-g-a](https://github.com/k-g-a)
+-   Fixed issue where snapshot post-processors where not always applied. Fixes [#926](https://github.com/mobxjs/mobx-state-tree/issues/926), [#961](https://github.com/mobxjs/mobx-state-tree/issues/961), through [#959](https://github.com/mobxjs/mobx-state-tree/pull/959) by [@k-g-a](https://github.com/k-g-a)
 
 # 3.0.3
 
-* Fixed re-adding the same objects to an array. Fixes [#928](https://github.com/mobxjs/mobx-state-tree/issues/928) through [#949](https://github.com/mobxjs/mobx-state-tree/pull/949) by [@Krivega](https://github.com/Krivega)
+-   Fixed re-adding the same objects to an array. Fixes [#928](https://github.com/mobxjs/mobx-state-tree/issues/928) through [#949](https://github.com/mobxjs/mobx-state-tree/pull/949) by [@Krivega](https://github.com/Krivega)
 
 # 3.0.2
 
-* Introduced `types.integer`! By [@jayarjo](https://github.com/jayarjo) through [#935](https://github.com/mobxjs/mobx-state-tree/pull/935)
-* Improved typescript typings, several fixes to the type system. Awesome contribution by [@xaviergonz](https://github.com/xaviergonz) through [#937](https://github.com/mobxjs/mobx-state-tree/pull/937) and [#945](https://github.com/mobxjs/mobx-state-tree/pull/945). Fixes [#922](https://github.com/mobxjs/mobx-state-tree/issues/922), [#930](https://github.com/mobxjs/mobx-state-tree/issues/930), [#932](https://github.com/mobxjs/mobx-state-tree/issues/932), [#923](https://github.com/mobxjs/mobx-state-tree/issues/923)
-* Improved handling of `types.late`
+-   Introduced `types.integer`! By [@jayarjo](https://github.com/jayarjo) through [#935](https://github.com/mobxjs/mobx-state-tree/pull/935)
+-   Improved typescript typings, several fixes to the type system. Awesome contribution by [@xaviergonz](https://github.com/xaviergonz) through [#937](https://github.com/mobxjs/mobx-state-tree/pull/937) and [#945](https://github.com/mobxjs/mobx-state-tree/pull/945). Fixes [#922](https://github.com/mobxjs/mobx-state-tree/issues/922), [#930](https://github.com/mobxjs/mobx-state-tree/issues/930), [#932](https://github.com/mobxjs/mobx-state-tree/issues/932), [#923](https://github.com/mobxjs/mobx-state-tree/issues/923)
+-   Improved handling of `types.late`
 
 # 3.0.1 (retracted)
 
@@ -33,187 +33,184 @@ MST 3 is twice as fast in initializing trees with half the memory consumption co
 
 Running `yarn speedtest` on Node 9.3:
 
-|  | MST 2 | MST 3 |
-| --- | --- | --- |
-| Time | 24sec | 12 sec |
-| Mem | 315MB | 168MB |
+|                 | MST 2  | MST 3  |
+| --------------- | ------ | ------ |
+| Time            | 24sec  | 12 sec |
+| Mem             | 315MB  | 168MB  |
 | Size (min+gzip) | 14.1KB | 15.0KB |
 
 Beyond that, MST 3 uses TypeScript 2.8, which results in more accurate TypeScript support.
 
-The type system has been simplified and improved in several areas. Several open issues around maps and (numberic) keys have been resolved. The `frozen` type can now be fully typed.  See below for the full details.
+The type system has been simplified and improved in several areas. Several open issues around maps and (numberic) keys have been resolved. The `frozen` type can now be fully typed. See below for the full details.
 
 Also, the 'object has died' exception can be supressed now. One should still address it, but at least it won't be a show-stopper from now on.
 
 ## Changes in the type system
 
-* **[BREAKING]** `types.identifier` can no longer be parameterized with either `types.string` or `types.number`. So instead of `types.identifier()` use `types.identifier`. Identifiers are now always normalized to strings. This reflects what was already happening internally and solves a lot of edge cases. To use numbers as identifiers, `types.identifierNumber` (instead of `types.identifier(types.number)`) can be used, which serializes it's snapshot to a number, but will internally work like a string based identifier
-* **[BREAKING]** `types.maybe` now serializes to / from `undefined` by default, as it is more and more the common best practice to don't use `null` at all and MST follows this practice. Use `types.maybeNull` for the old behavior (see [#830](https://github.com/mobxjs/mobx-state-tree/issues/830))
-* **[BREAKING]** `types.frozen` is now a function, and can now be invoked in a few different ways:
-  1. `types.frozen()` - behaves the same as `types.frozen` in MST 2.
-  1. `types.frozen(SubType)` - provide a valid MST type and frozen will check if the provided data conforms the snapshot for that type. Note that the type will not actually be instantiated, so it can only be used to check the _shape_ of the data. Adding views or actions to `SubType` would be pointless.
-  2. `types.frozen(someDefaultValue)` - provide a primitive value, object or array, and MST will infer the type from that object, and also make it the default value for the field
-  3. `types.frozen<TypeScriptType>()` - provide a typescript type, to help in strongly typing the field (design time only)
-* It is no longer necessary to wrap `types.map` or `types.array` in `types.optional` when used in a `model` type, `map` and `array` are now optional by default when used as property type. See [#906](https://github.com/mobxjs/mobx-state-tree/issues/906)
-* **[BREAKING]** `postProcessSnapshot` can no longer be declared as action, but, like `preProcessSnapshot`, needs to be defined on the type rather than on the instance.
-* **[BREAKING]** `types.union` is now eager, which means that if multiple valid types for a value are encountered, the first valid type is picked, rather then throwing.  #907 / #804, `dispatcher` param => option,
-
+-   **[BREAKING]** `types.identifier` can no longer be parameterized with either `types.string` or `types.number`. So instead of `types.identifier()` use `types.identifier`. Identifiers are now always normalized to strings. This reflects what was already happening internally and solves a lot of edge cases. To use numbers as identifiers, `types.identifierNumber` (instead of `types.identifier(types.number)`) can be used, which serializes it's snapshot to a number, but will internally work like a string based identifier
+-   **[BREAKING]** `types.maybe` now serializes to / from `undefined` by default, as it is more and more the common best practice to don't use `null` at all and MST follows this practice. Use `types.maybeNull` for the old behavior (see [#830](https://github.com/mobxjs/mobx-state-tree/issues/830))
+-   **[BREAKING]** `types.frozen` is now a function, and can now be invoked in a few different ways:
+    1.  `types.frozen()` - behaves the same as `types.frozen` in MST 2.
+    1.  `types.frozen(SubType)` - provide a valid MST type and frozen will check if the provided data conforms the snapshot for that type. Note that the type will not actually be instantiated, so it can only be used to check the _shape_ of the data. Adding views or actions to `SubType` would be pointless.
+    1.  `types.frozen(someDefaultValue)` - provide a primitive value, object or array, and MST will infer the type from that object, and also make it the default value for the field
+    1.  `types.frozen<TypeScriptType>()` - provide a typescript type, to help in strongly typing the field (design time only)
+-   It is no longer necessary to wrap `types.map` or `types.array` in `types.optional` when used in a `model` type, `map` and `array` are now optional by default when used as property type. See [#906](https://github.com/mobxjs/mobx-state-tree/issues/906)
+-   **[BREAKING]** `postProcessSnapshot` can no longer be declared as action, but, like `preProcessSnapshot`, needs to be defined on the type rather than on the instance.
+-   **[BREAKING]** `types.union` is now eager, which means that if multiple valid types for a value are encountered, the first valid type is picked, rather then throwing. #907 / #804, `dispatcher` param => option,
 
 ## Other improvements
 
-* **[BREAKING]** MobX-state-tree now requires at least TypeScript 2.8 when using MST with typescript. The type system has been revamped, and should now be a lot more accurate, especially concerning snapshot types.
-* **[BREAKING]** `map.put` will now return the inserted node, rather than the map itself. This makes it easier to find objects for which the identifier is not known upfront. See [#766](https://github.com/mobxjs/mobx-state-tree/issues/766) by [k-g-a](https://github.com/k-g-a)
-* **[BREAKING]** The order of firing hooks when instantiating has slighlty changed, as the `afterCreate` hook will now only be fired upon instantation of the tree node, which now happens lazily (on first read / action). The internal order in which hooks are fired within a single node has remained the same. See [#845](https://github.com/mobxjs/mobx-state-tree/issues/845) for details
-* Significantly improved the performance of constructing MST trees. Significantly reduced the memory footprint of MST. Big shoutout to the relentless effort by [k-g-a](https://github.com/k-g-a) to optimize all the things! See [#845](https://github.com/mobxjs/mobx-state-tree/issues/845) for details.
-* Introduced `setLivelynessChecking("warn" | "ignore" | "error")`, this can be used to customize how MST should act when one tries to read or write to a node that has already been removed from the tree. The default behavior is `warn`.
-* Improved the overloads of `model.compose`, see [#892](https://github.com/mobxjs/mobx-state-tree/pull/892) by [t49tran](https://github.com/t49tran)
-* Fixed issue where computed properties based on `getPath` could return stale results, fixes [#917](https://github.com/mobxjs/mobx-state-tree/issues/917)
-* Fixed issue where onAction middleware threw on dead nodes when attachAfter option was used
-* Fixed several issues with maps and numberic identifiers, such as [#884](https://github.com/mobxjs/mobx-state-tree/issues/884) and [#826](https://github.com/mobxjs/mobx-state-tree/issues/826)
+-   **[BREAKING]** MobX-state-tree now requires at least TypeScript 2.8 when using MST with typescript. The type system has been revamped, and should now be a lot more accurate, especially concerning snapshot types.
+-   **[BREAKING]** `map.put` will now return the inserted node, rather than the map itself. This makes it easier to find objects for which the identifier is not known upfront. See [#766](https://github.com/mobxjs/mobx-state-tree/issues/766) by [k-g-a](https://github.com/k-g-a)
+-   **[BREAKING]** The order of firing hooks when instantiating has slighlty changed, as the `afterCreate` hook will now only be fired upon instantation of the tree node, which now happens lazily (on first read / action). The internal order in which hooks are fired within a single node has remained the same. See [#845](https://github.com/mobxjs/mobx-state-tree/issues/845) for details
+-   Significantly improved the performance of constructing MST trees. Significantly reduced the memory footprint of MST. Big shoutout to the relentless effort by [k-g-a](https://github.com/k-g-a) to optimize all the things! See [#845](https://github.com/mobxjs/mobx-state-tree/issues/845) for details.
+-   Introduced `setLivelynessChecking("warn" | "ignore" | "error")`, this can be used to customize how MST should act when one tries to read or write to a node that has already been removed from the tree. The default behavior is `warn`.
+-   Improved the overloads of `model.compose`, see [#892](https://github.com/mobxjs/mobx-state-tree/pull/892) by [t49tran](https://github.com/t49tran)
+-   Fixed issue where computed properties based on `getPath` could return stale results, fixes [#917](https://github.com/mobxjs/mobx-state-tree/issues/917)
+-   Fixed issue where onAction middleware threw on dead nodes when attachAfter option was used
+-   Fixed several issues with maps and numberic identifiers, such as [#884](https://github.com/mobxjs/mobx-state-tree/issues/884) and [#826](https://github.com/mobxjs/mobx-state-tree/issues/826)
 
 ## TL,DR Migration guide
 
-* `types.identifier(types.number)` => `types.identifierNumber`
-* `types.identifier()` and `types.identifier(types.string) => `types.identifier`
-* `types.frozen` => `types.frozen()`
-* `types.maybe(x)` => `types.maybeNull(x)`
-* `postProcessSnapshot` should now be declared on the type instead of as action
+-   `types.identifier(types.number)` => `types.identifierNumber`
+-   `types.identifier()` and `types.identifier(types.string) =>`types.identifier`
+-   `types.frozen` => `types.frozen()`
+-   `types.maybe(x)` => `types.maybeNull(x)`
+-   `postProcessSnapshot` should now be declared on the type instead of as action
 
 # 2.2.0
 
-* Added support for MobX 5. Initiative by [@jeffberry](https://github.com/jeffberry) through [#868](https://github.com/mobxjs/mobx-state-tree/pull/868/files). Please not that there are JavaScript engine restrictions for MobX 5 (no Internet Explorer, or React Native Android). If you need to target those versions please keep using MobX 4 as peer dependency (MST is compatible with both)
-* Reduced memory footprint with ~10-20%, by [k-g-a](https://github.com/k-g-a) through [#872](https://github.com/mobxjs/mobx-state-tree/pull/872)
-* Fixed issue where undo manager was not working correctly for non-root stores, by [marcofugaro](https://github.com/marcofugaro) trough [#875](https://github.com/mobxjs/mobx-state-tree/pull/875)
+-   Added support for MobX 5. Initiative by [@jeffberry](https://github.com/jeffberry) through [#868](https://github.com/mobxjs/mobx-state-tree/pull/868/files). Please not that there are JavaScript engine restrictions for MobX 5 (no Internet Explorer, or React Native Android). If you need to target those versions please keep using MobX 4 as peer dependency (MST is compatible with both)
+-   Reduced memory footprint with ~10-20%, by [k-g-a](https://github.com/k-g-a) through [#872](https://github.com/mobxjs/mobx-state-tree/pull/872)
+-   Fixed issue where undo manager was not working correctly for non-root stores, by [marcofugaro](https://github.com/marcofugaro) trough [#875](https://github.com/mobxjs/mobx-state-tree/pull/875)
 
 # 2.1.0
 
-* Fixed issue where default values of `types.frozen` where not applied correctly after apply snapshot. [#842](https://github.com/mobxjs/mobx-state-tree/pull/842) by [SirbyAlive](https://github.com/SirbyAlive). Fixes [#643](https://github.com/mobxjs/mobx-state-tree/issues/634)
-* Fixed issue where empty patch sets resulted in in unnecessary history items. [#838](https://github.com/mobxjs/mobx-state-tree/pull/838) by [chemitaxis](https://github.com/chemitaxis). Fixes [#837](https://github.com/mobxjs/mobx-state-tree/issues/837)
-* `flow`s of destroyed nodes can no 'safely' resume. [#798](https://github.com/mobxjs/mobx-state-tree/pull/798/files) by [Bnaya](https://github.com/Bnaya). Fixes [#792](https://github.com/mobxjs/mobx-state-tree/issues/792)
-* Made sure the type `Snapshot` is exposed. [#821](https://github.com/mobxjs/mobx-state-tree/pull/821) by [dsabanin](https://github.com/dsabanin)
-* Fix: the function parameter was incorrectly typed as non-optional. [#851](https://github.com/mobxjs/mobx-state-tree/pull/851) by [abruzzihraig](https://github.com/abruzzihraig)
+-   Fixed issue where default values of `types.frozen` where not applied correctly after apply snapshot. [#842](https://github.com/mobxjs/mobx-state-tree/pull/842) by [SirbyAlive](https://github.com/SirbyAlive). Fixes [#643](https://github.com/mobxjs/mobx-state-tree/issues/634)
+-   Fixed issue where empty patch sets resulted in in unnecessary history items. [#838](https://github.com/mobxjs/mobx-state-tree/pull/838) by [chemitaxis](https://github.com/chemitaxis). Fixes [#837](https://github.com/mobxjs/mobx-state-tree/issues/837)
+-   `flow`s of destroyed nodes can no 'safely' resume. [#798](https://github.com/mobxjs/mobx-state-tree/pull/798/files) by [Bnaya](https://github.com/Bnaya). Fixes [#792](https://github.com/mobxjs/mobx-state-tree/issues/792)
+-   Made sure the type `Snapshot` is exposed. [#821](https://github.com/mobxjs/mobx-state-tree/pull/821) by [dsabanin](https://github.com/dsabanin)
+-   Fix: the function parameter was incorrectly typed as non-optional. [#851](https://github.com/mobxjs/mobx-state-tree/pull/851) by [abruzzihraig](https://github.com/abruzzihraig)
 
 # 2.0.5
 
-* It is now possible to get the snapshot of a node without triggering the `postProcessSnapshot` hook. See [#745](https://github.com/mobxjs/mobx-state-tree/pull/745) for details. By @robinfehr
-* Introduced `getParentOfType` and `hasParentOfType`. See [#767](https://github.com/mobxjs/mobx-state-tree/pull/767) by @k-g-a
-* Fixed issue where running `typeCheck` accidentally logged typecheck errors to the console. Fixes [#781](https://github.com/mobxjs/mobx-state-tree/issues/781)
+-   It is now possible to get the snapshot of a node without triggering the `postProcessSnapshot` hook. See [#745](https://github.com/mobxjs/mobx-state-tree/pull/745) for details. By @robinfehr
+-   Introduced `getParentOfType` and `hasParentOfType`. See [#767](https://github.com/mobxjs/mobx-state-tree/pull/767) by @k-g-a
+-   Fixed issue where running `typeCheck` accidentally logged typecheck errors to the console. Fixes [#781](https://github.com/mobxjs/mobx-state-tree/issues/781)
 
 # 2.0.4
 
-* Removed accidental dependency on mobx
+-   Removed accidental dependency on mobx
 
 # 2.0.3
 
-* Fixed issue where middleware that changed arguments wasn't properly picked up. See [#732](https://github.com/mobxjs/mobx-state-tree/pull/732) by @robinfehr. Fixes [#731](https://github.com/mobxjs/mobx-state-tree/issues/731)
-* Fixed reassigning to a custom type from a different type in a union silently failing. See [#737](https://github.com/mobxjs/mobx-state-tree/pull/737) by @univerio. Fixes [#736](https://github.com/mobxjs/mobx-state-tree/issues/736)
-* Fixed typings issue with TypeScript 2.8. See [#740](https://github.com/mobxjs/mobx-state-tree/pull/740) by @bnaya.
-* Fixed undo manager apply grouped patches in the wrong order. See [#755](https://github.com/mobxjs/mobx-state-tree/pull/755) by @robinfehr. Fixes [#754](https://github.com/mobxjs/mobx-state-tree/issues/754)
+-   Fixed issue where middleware that changed arguments wasn't properly picked up. See [#732](https://github.com/mobxjs/mobx-state-tree/pull/732) by @robinfehr. Fixes [#731](https://github.com/mobxjs/mobx-state-tree/issues/731)
+-   Fixed reassigning to a custom type from a different type in a union silently failing. See [#737](https://github.com/mobxjs/mobx-state-tree/pull/737) by @univerio. Fixes [#736](https://github.com/mobxjs/mobx-state-tree/issues/736)
+-   Fixed typings issue with TypeScript 2.8. See [#740](https://github.com/mobxjs/mobx-state-tree/pull/740) by @bnaya.
+-   Fixed undo manager apply grouped patches in the wrong order. See [#755](https://github.com/mobxjs/mobx-state-tree/pull/755) by @robinfehr. Fixes [#754](https://github.com/mobxjs/mobx-state-tree/issues/754)
 
 # 2.0.2
 
-* Fixed bidirectional references from nodes to nodes, see [#728](https://github.com/mobxjs/mobx-state-tree/pull/728) by @robinfehr
-* `joinJsonPath` and `splitJsonPath` are now exposed as utilities, see [#724](https://github.com/mobxjs/mobx-state-tree/pull/724) by @jjrv
-* Several documentation and example fixes
+-   Fixed bidirectional references from nodes to nodes, see [#728](https://github.com/mobxjs/mobx-state-tree/pull/728) by @robinfehr
+-   `joinJsonPath` and `splitJsonPath` are now exposed as utilities, see [#724](https://github.com/mobxjs/mobx-state-tree/pull/724) by @jjrv
+-   Several documentation and example fixes
 
 # 2.0.1
 
-* Fixed typings for maps of maps [#704](https://github.com/mobxjs/mobx-state-tree/pull/704) by @xaviergonz
-* Fixed dependency issue in `mst-middlewares` package
+-   Fixed typings for maps of maps [#704](https://github.com/mobxjs/mobx-state-tree/pull/704) by @xaviergonz
+-   Fixed dependency issue in `mst-middlewares` package
 
 # 2.0.0
 
 **Breaking changes**
 
-* MobX-state-tree now requires MobX 4.0 or higher
-* Identifiers are now internally always normalized to strings. This also means that adding an object with an number identifier to an observable map, it should still be requested back as string. In general, we recommend to always use string based identifiers to avoid confusion.
+-   MobX-state-tree now requires MobX 4.0 or higher
+-   Identifiers are now internally always normalized to strings. This also means that adding an object with an number identifier to an observable map, it should still be requested back as string. In general, we recommend to always use string based identifiers to avoid confusion.
 
 # 1.4.0
 
 **Features**
 
-* It is now possible to create [custom primitive(like) types](https://github.com/mobxjs/mobx-state-tree/blob/master/API.md#typescustom)! Implements [#673](https://github.com/mobxjs/mobx-state-tree/issues/673) through [#689](https://github.com/mobxjs/mobx-state-tree/pull/689)
-* [`getIdentifier`](https://github.com/mobxjs/mobx-state-tree/blob/master/API.md#getidentifier) is now exposed as function, to get the identifier of a model instance (if any). Fixes [#674](https://github.com/mobxjs/mobx-state-tree/issues/674) through [#678](https://github.com/mobxjs/mobx-state-tree/pull/678) by TimHollies
-* Writing [middleware](https://github.com/mobxjs/mobx-state-tree/blob/master/docs/middleware.md) has slightly changed, to make it less error prone and more explicit whether a middleware chain should be aborted. For details, see [#675](https://github.com/mobxjs/mobx-state-tree/pull/675) by Robin Fehr
-* It is now possible to configure whether [attached middleware](https://github.com/mobxjs/mobx-state-tree/blob/master/API.md#addmiddleware) should be triggered for the built-in hooks / operations. [#653](https://github.com/mobxjs/mobx-state-tree/pull/653) by Robin Fehr
-* We exposed an [api](https://github.com/mobxjs/mobx-state-tree/blob/master/API.md#getmembers) to perform reflection on model instances. [#649](https://github.com/mobxjs/mobx-state-tree/pull/649) by Robin Fehr
+-   It is now possible to create [custom primitive(like) types](https://github.com/mobxjs/mobx-state-tree/blob/master/API.md#typescustom)! Implements [#673](https://github.com/mobxjs/mobx-state-tree/issues/673) through [#689](https://github.com/mobxjs/mobx-state-tree/pull/689)
+-   [`getIdentifier`](https://github.com/mobxjs/mobx-state-tree/blob/master/API.md#getidentifier) is now exposed as function, to get the identifier of a model instance (if any). Fixes [#674](https://github.com/mobxjs/mobx-state-tree/issues/674) through [#678](https://github.com/mobxjs/mobx-state-tree/pull/678) by TimHollies
+-   Writing [middleware](https://github.com/mobxjs/mobx-state-tree/blob/master/docs/middleware.md) has slightly changed, to make it less error prone and more explicit whether a middleware chain should be aborted. For details, see [#675](https://github.com/mobxjs/mobx-state-tree/pull/675) by Robin Fehr
+-   It is now possible to configure whether [attached middleware](https://github.com/mobxjs/mobx-state-tree/blob/master/API.md#addmiddleware) should be triggered for the built-in hooks / operations. [#653](https://github.com/mobxjs/mobx-state-tree/pull/653) by Robin Fehr
+-   We exposed an [api](https://github.com/mobxjs/mobx-state-tree/blob/master/API.md#getmembers) to perform reflection on model instances. [#649](https://github.com/mobxjs/mobx-state-tree/pull/649) by Robin Fehr
 
 **Fixes**
 
-* Fixed a bug where items in maps where not properly reconciled when the `put` operation was used. Fixed [#683](https://github.com/mobxjs/mobx-state-tree/issues/683) and [#672](https://github.com/mobxjs/mobx-state-tree/issues/672) through [#693](https://github.com/mobxjs/mobx-state-tree/pull/693)
-* Fixed issue where trying to resolve a path would throw exceptions. Fixed [#686](https://github.com/mobxjs/mobx-state-tree/issues/686) through [#692](https://github.com/mobxjs/mobx-state-tree/pull/692)
-* In non production builds actions and views on models can now be replaced, to simplify mocking. Fixes [#646](https://github.com/mobxjs/mobx-state-tree/issues/646) through [#690](https://github.com/mobxjs/mobx-state-tree/pull/690)
-* Fixed bug where `tryResolve` could leave a node in a corrupt state. [#668](https://github.com/mobxjs/mobx-state-tree/pull/668) by dnakov
-* Fixed typings for TypeScript 2.7, through [#667](https://github.com/mobxjs/mobx-state-tree/pull/667) by Javier Gonzalez
-* Several improvements to error messages
+-   Fixed a bug where items in maps where not properly reconciled when the `put` operation was used. Fixed [#683](https://github.com/mobxjs/mobx-state-tree/issues/683) and [#672](https://github.com/mobxjs/mobx-state-tree/issues/672) through [#693](https://github.com/mobxjs/mobx-state-tree/pull/693)
+-   Fixed issue where trying to resolve a path would throw exceptions. Fixed [#686](https://github.com/mobxjs/mobx-state-tree/issues/686) through [#692](https://github.com/mobxjs/mobx-state-tree/pull/692)
+-   In non production builds actions and views on models can now be replaced, to simplify mocking. Fixes [#646](https://github.com/mobxjs/mobx-state-tree/issues/646) through [#690](https://github.com/mobxjs/mobx-state-tree/pull/690)
+-   Fixed bug where `tryResolve` could leave a node in a corrupt state. [#668](https://github.com/mobxjs/mobx-state-tree/pull/668) by dnakov
+-   Fixed typings for TypeScript 2.7, through [#667](https://github.com/mobxjs/mobx-state-tree/pull/667) by Javier Gonzalez
+-   Several improvements to error messages
 
 # 1.3.1
 
-* Fixed bug where `flows` didn't properly batch their next ticks properly in actions, significantly slowing processes down. Fixes [#563]([#563](https://github.com/mobxjs/mobx-state-tree/issues/563))
+-   Fixed bug where `flows` didn't properly batch their next ticks properly in actions, significantly slowing processes down. Fixes [#563](<[#563](https://github.com/mobxjs/mobx-state-tree/issues/563)>)
 
 # 1.3.0
 
-* Significantly improved the undo/redo manager. The undo manager now supports groups. See [#504](https://github.com/mobxjs/mobx-state-tree/pull/504) by @robinfehr! See the [updated docs](https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mst-middlewares/README.md#undomanager) for more details.
-* Significantly improved performance, improvements of 20% could be expected, but changes of course per case. See [#553](https://github.com/mobxjs/mobx-state-tree/pull/553)
-* Implemented `actionLogger` middleware, which logs most events for async actions
-* Slightly changed the order in which life cycle hooks are fired. `afterAttach` will no fire first on the parent, then on the children. So, unlike `afterCreate`, in `afterAttach` one can assume in `afterAttach that the parent has completely initialized.
+-   Significantly improved the undo/redo manager. The undo manager now supports groups. See [#504](https://github.com/mobxjs/mobx-state-tree/pull/504) by @robinfehr! See the [updated docs](https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mst-middlewares/README.md#undomanager) for more details.
+-   Significantly improved performance, improvements of 20% could be expected, but changes of course per case. See [#553](https://github.com/mobxjs/mobx-state-tree/pull/553)
+-   Implemented `actionLogger` middleware, which logs most events for async actions
+-   Slightly changed the order in which life cycle hooks are fired. `afterAttach` will no fire first on the parent, then on the children. So, unlike `afterCreate`, in `afterAttach` one can assume in `afterAttach that the parent has completely initialized.
 
 # 1.2.1
 
-* 1.2.0 didn't seem to be released correctly...
+-   1.2.0 didn't seem to be released correctly...
 
 # 1.2.0
 
-* Introduced customizable reference types. See the [reference and identifiers](https://github.com/mobxjs/mobx-state-tree#references-and-identifiers) section.
-* Introduced `model.volatile` to more easily declare and reuse volatile instance state. Volatile state can contain arbitrary data, is shallowly observable and, like props, cannot be modified without actions. See [`model.volatile`](https://github.com/mobxjs/mobx-state-tree#model-volatile) for more details.
+-   Introduced customizable reference types. See the [reference and identifiers](https://github.com/mobxjs/mobx-state-tree#references-and-identifiers) section.
+-   Introduced `model.volatile` to more easily declare and reuse volatile instance state. Volatile state can contain arbitrary data, is shallowly observable and, like props, cannot be modified without actions. See [`model.volatile`](https://github.com/mobxjs/mobx-state-tree#model-volatile) for more details.
 
 # 1.1.1
 
 ### Improvements
 
-* Fixed an issue where nodes where not always created correctly, see #534. Should fix #513 and #531.
-* All tests are now run in both PROD and non PROD configurations, after running into some bugs that only occurred in production builds.
-* Some internal optimizations have been applied (and many more will follow). Like having internal leaner node for immutable data. See #474
-* A lot of minor improvements on the docs
+-   Fixed an issue where nodes where not always created correctly, see #534. Should fix #513 and #531.
+-   All tests are now run in both PROD and non PROD configurations, after running into some bugs that only occurred in production builds.
+-   Some internal optimizations have been applied (and many more will follow). Like having internal leaner node for immutable data. See #474
+-   A lot of minor improvements on the docs
 
 # 1.1.0
 
 ### Improvements
 
-* The concept of process (asynchronous actions) has been renamed to flows. (Mainly to avoid issues with bundlers)
-* We changed to a lerna setup which allows separately distributing middleware and testing examples with more ease
-* Every MST middleware is now shipped in a separate package named `mst-middlewares`. They are now written in TypeScript and fully transpiled to ES5 to avoid problems with uglifyjs in create-react-app bundling.
-* Introduced `createActionTrackingMiddleware`, this significantly simplifies writing middleware for common scenarios. Especially middleware that deals with asynchronous actions (flows)
-* Renamed `process` to `flow`. Deprecated `process`.
-* **BREAKING** As a result some middleware event names have also been changed. If you have custom middlewares this change might affect you. Rename middleware event type prefixes starting with `process` to now start with `flow`.
+-   The concept of process (asynchronous actions) has been renamed to flows. (Mainly to avoid issues with bundlers)
+-   We changed to a lerna setup which allows separately distributing middleware and testing examples with more ease
+-   Every MST middleware is now shipped in a separate package named `mst-middlewares`. They are now written in TypeScript and fully transpiled to ES5 to avoid problems with uglifyjs in create-react-app bundling.
+-   Introduced `createActionTrackingMiddleware`, this significantly simplifies writing middleware for common scenarios. Especially middleware that deals with asynchronous actions (flows)
+-   Renamed `process` to `flow`. Deprecated `process`.
+-   **BREAKING** As a result some middleware event names have also been changed. If you have custom middlewares this change might affect you. Rename middleware event type prefixes starting with `process` to now start with `flow`.
 
 ### Fixes
 
-* Fixed nested maps + environments not working correctly, [#447](https://github.com/mobxjs/mobx-state-tree/pull/447) by @xaviergonz
-* Improved typescript typings for enumerations, up to 50 values are now supported [#424](https://github.com/mobxjs/mobx-state-tree/pull/447) by @danielduwaer
-
+-   Fixed nested maps + environments not working correctly, [#447](https://github.com/mobxjs/mobx-state-tree/pull/447) by @xaviergonz
+-   Improved typescript typings for enumerations, up to 50 values are now supported [#424](https://github.com/mobxjs/mobx-state-tree/pull/447) by @danielduwaer
 
 # 1.0.2
 
-* Introduced `modelType.extend` which allows creating views and actions with shared state.
+-   Introduced `modelType.extend` which allows creating views and actions with shared state.
 
 # 1.0.1
 
-
 ### Features
 
-* Added the middlewares `atomic` and types `TimeTraveller`, `UndoManager`. Check out the [docs](https://github.com/mobxjs/mobx-state-tree/blob/master/docs/middleware.md)!
-* Introduced `createActionTrackingMiddleware` to simplify the creation of middleware that support complex async processes
-* exposed `typecheck(type, value)` as public api (will ignore environment flags)
+-   Added the middlewares `atomic` and types `TimeTraveller`, `UndoManager`. Check out the [docs](https://github.com/mobxjs/mobx-state-tree/blob/master/docs/middleware.md)!
+-   Introduced `createActionTrackingMiddleware` to simplify the creation of middleware that support complex async processes
+-   exposed `typecheck(type, value)` as public api (will ignore environment flags)
 
 ### Improvements
 
-* `getEnv` will return an empty object instead of throwing when a tree was initialized without environment
-* Fixed issue where patches generated for nested maps were incorrect (#396)
-* Fixed the escaping of (back)slashes in JSON paths (#405)
-* Improved the algorithm that reconcile items in an array (#384)
-* Assigning a node that has an environment to a parent is now allowed, as long as the environment is strictly the same (#387)
-* Many minor documentation improvements. Thanks everybody who created a PR!
+-   `getEnv` will return an empty object instead of throwing when a tree was initialized without environment
+-   Fixed issue where patches generated for nested maps were incorrect (#396)
+-   Fixed the escaping of (back)slashes in JSON paths (#405)
+-   Improved the algorithm that reconcile items in an array (#384)
+-   Assigning a node that has an environment to a parent is now allowed, as long as the environment is strictly the same (#387)
+-   Many minor documentation improvements. Thanks everybody who created a PR!
 
 # 1.0.0
 
@@ -221,49 +218,49 @@ No changes
 
 # 0.12.0
 
-* **BREAKING** The redux utilities are no longer part of the core package, but need to be imported from `mobx-state-tree/middleware/redux`.
+-   **BREAKING** The redux utilities are no longer part of the core package, but need to be imported from `mobx-state-tree/middleware/redux`.
 
 # 0.11.0
 
 ### Breaking changes
 
-* **BREAKING** `onAction` middleware no longer throws when encountering unserializable arguments. Rather, it serializes a struct like `{ $MST_UNSERIALIZABLE: true, type: "someType" }`. MST Nodes are no longer automatically serialized. Rather, one should either pass 1: an id, 2: a (relative) path, 3: a snapshot
-* **BREAKING** `revertPatch` has been dropped. `IReversableJsonPatch` is no longer exposed, instead use the inverse patches generated by `onPatch`
-* **BREAKING** some middleware events have been renamed: `process_yield` -> `process_resume`, `process_yield_error` -> `process_resume_error`, to make it less confusing how these events relate to `yield` statements.
-* **BREAKING** patchRecorder's field `patches` has been renamed to `rawPatches, `cleanPatches` to `patches`, and `inversePatches` was added.
+-   **BREAKING** `onAction` middleware no longer throws when encountering unserializable arguments. Rather, it serializes a struct like `{ $MST_UNSERIALIZABLE: true, type: "someType" }`. MST Nodes are no longer automatically serialized. Rather, one should either pass 1: an id, 2: a (relative) path, 3: a snapshot
+-   **BREAKING** `revertPatch` has been dropped. `IReversableJsonPatch` is no longer exposed, instead use the inverse patches generated by `onPatch`
+-   **BREAKING** some middleware events have been renamed: `process_yield` -> `process_resume`, `process_yield_error` -> `process_resume_error`, to make it less confusing how these events relate to `yield` statements.
+-   **BREAKING** patchRecorder's field `patches` has been renamed to `rawPatches,`cleanPatches`to`patches`, and`inversePatches` was added.
 
 ### New features
 
-* Introduced `decorate(middleware, action)` to easily attach middleware to a specific action
-* Handlers passed to `onPatch(handler: (patch, inversePatch) => void)` now receive as second argument the inverse patch of the emitted patch
-* `onAction` lister now supports an `attachAfter` parameter
-* Middleware events now also contain `parentId` (id of the causing action, `0` if none) and `tree` (the root of context)
+-   Introduced `decorate(middleware, action)` to easily attach middleware to a specific action
+-   Handlers passed to `onPatch(handler: (patch, inversePatch) => void)` now receive as second argument the inverse patch of the emitted patch
+-   `onAction` lister now supports an `attachAfter` parameter
+-   Middleware events now also contain `parentId` (id of the causing action, `0` if none) and `tree` (the root of context)
 
 ### Fixes
 
-* ReduxDevTools connection is no longer one step behind [#287](https://github.com/mobxjs/mobx-state-tree/issues/287)
-* Middleware is no longer run as part of the transaction of the targeted action
-* Fixed representation of `union` types in error messages
+-   ReduxDevTools connection is no longer one step behind [#287](https://github.com/mobxjs/mobx-state-tree/issues/287)
+-   Middleware is no longer run as part of the transaction of the targeted action
+-   Fixed representation of `union` types in error messages
 
 # 0.10.3
 
-* **BREAKISH** Redefining lifecycle hooks will now automatically compose them, implements [#252](https://github.com/mobxjs/mobx-state-tree/issues/252)
-* Added dev-only checks, typecheck will be performed only in dev-mode and top-level API-calls will be checked.
-* The internal types `IMiddleWareEvent`, `IMiddlewareEventType`, `ISerializedActionCall` are now exposed (fixes [#315](https://github.com/mobxjs/mobx-state-tree/issues/315))
+-   **BREAKISH** Redefining lifecycle hooks will now automatically compose them, implements [#252](https://github.com/mobxjs/mobx-state-tree/issues/252)
+-   Added dev-only checks, typecheck will be performed only in dev-mode and top-level API-calls will be checked.
+-   The internal types `IMiddleWareEvent`, `IMiddlewareEventType`, `ISerializedActionCall` are now exposed (fixes [#315](https://github.com/mobxjs/mobx-state-tree/issues/315))
 
 # 0.10.2
 
-* Object model instances no longer share a prototype.
+-   Object model instances no longer share a prototype.
 
 # 0.10.1
 
-* Removed accidental dependency on the codemod
+-   Removed accidental dependency on the codemod
 
 # 0.10.0
 
-* **BREAKING** the syntax to define model types has been updated. See the [updated docs](https://github.com/mobxjs/mobx-state-tree#creating-models) or the original proposal:[#282](https://github.com/mobxjs/mobx-state-tree/pull/286), but no worries, theres a codemod! :D
-* **BREAKING** `preProcessSnapshot` hook is no longer a normal hook that can be defined as action. Instead, it should be defined on the type using `types.model(...).preProcessSnapshot(value => value)`
-* **BREAKING** Asynchronous process should now be defined using `process`. See this [example](https://github.com/mobxjs/mobx-state-tree/blob/adba1943af263898678fe148a80d3d2b9f8dbe63/examples/bookshop/src/stores/BookStore.js#L25) or the [asynchronous action docs](https://github.com/mobxjs/mobx-state-tree/blob/master/docs/async-actions.md).
+-   **BREAKING** the syntax to define model types has been updated. See the [updated docs](https://github.com/mobxjs/mobx-state-tree#creating-models) or the original proposal:[#282](https://github.com/mobxjs/mobx-state-tree/pull/286), but no worries, theres a codemod! :D
+-   **BREAKING** `preProcessSnapshot` hook is no longer a normal hook that can be defined as action. Instead, it should be defined on the type using `types.model(...).preProcessSnapshot(value => value)`
+-   **BREAKING** Asynchronous process should now be defined using `process`. See this [example](https://github.com/mobxjs/mobx-state-tree/blob/adba1943af263898678fe148a80d3d2b9f8dbe63/examples/bookshop/src/stores/BookStore.js#L25) or the [asynchronous action docs](https://github.com/mobxjs/mobx-state-tree/blob/master/docs/async-actions.md).
 
 **How to run the codemod?**
 
@@ -278,122 +275,125 @@ PS: You could also use `npx` instead of installing the codemod globally! :)
 
 # 0.9.5
 
-* Asynchronous actions are now a first class concept in mobx-state-tree. See the [docs](https://github.com/mobxjs/mobx-state-tree/blob/master/docs/async-actions.md)
+-   Asynchronous actions are now a first class concept in mobx-state-tree. See the [docs](https://github.com/mobxjs/mobx-state-tree/blob/master/docs/async-actions.md)
 
 # 0.9.4
 
-* Introduced `types.null` and `types.undefined`
-* Introduced `types.enumeration(name?, options)`
+-   Introduced `types.null` and `types.undefined`
+-   Introduced `types.enumeration(name?, options)`
 
 # 0.9.3
 
-* Fix `note that a snapshot is compatible` when assigning a type to an optional version of itself
-* Fix error when deleting a non existing item from a map [#255](https://github.com/mobxjs/mobx-state-tree/issues/255)
-* Now all required TypeScript interfaces are exported in the main mobx-state-tree package [#256](https://github.com/mobxjs/mobx-state-tree/issues/256)
+-   Fix `note that a snapshot is compatible` when assigning a type to an optional version of itself
+-   Fix error when deleting a non existing item from a map [#255](https://github.com/mobxjs/mobx-state-tree/issues/255)
+-   Now all required TypeScript interfaces are exported in the main mobx-state-tree package [#256](https://github.com/mobxjs/mobx-state-tree/issues/256)
 
 # 0.9.2
 
 Introduced the concept of reverse patches, see [#231](https://github.com/mobxjs/mobx-state-tree/pull/231/)
-* Introduced the `revertPatch` operation, that takes a patch or list of patches, and reverse applies it to the target.
-* `onPatch` now takes a second argument, `includeOldValue`, defaulting to `false`, which, if set to true, includes in the patch any value that is being overwritten as result of the patch. Setting this option to true produces patches that can be used with `revertPatch`
-* `patchRecorder` now introduces additional fields / methods to be able to reverse apply changes: `patchRecorder.cleanPatches`, `patchRecorder.undo`
+
+-   Introduced the `revertPatch` operation, that takes a patch or list of patches, and reverse applies it to the target.
+-   `onPatch` now takes a second argument, `includeOldValue`, defaulting to `false`, which, if set to true, includes in the patch any value that is being overwritten as result of the patch. Setting this option to true produces patches that can be used with `revertPatch`
+-   `patchRecorder` now introduces additional fields / methods to be able to reverse apply changes: `patchRecorder.cleanPatches`, `patchRecorder.undo`
 
 # 0.9.1
 
-* Applying a snapshot or patches will now emit an action as well. The name of the emitted action will be `@APPLY_PATCHES`resp `@APPLY_SNAPSHOT`. See [#107](https://github.com/mobxjs/mobx-state-tree/issues/107)
-* Fixed issue where same Date instance could'nt be used two times in the same state tree [#229](https://github.com/mobxjs/mobx-state-tree/issues/229)
-* Fixed issue with reapplying snapshots to Date field resulting in snapshot typecheck error[#233](https://github.com/mobxjs/mobx-state-tree/issues/233)
-* Declaring `types.maybe(types.frozen)` will now result into an error [#224](https://github.com/mobxjs/mobx-state-tree/issues/224)
-* Added support for Mobx observable arrays in type checks [#221](https://github.com/mobxjs/mobx-state-tree/issues/221) (from [alessioscalici](https://github.com/alessioscalici))
+-   Applying a snapshot or patches will now emit an action as well. The name of the emitted action will be `@APPLY_PATCHES`resp `@APPLY_SNAPSHOT`. See [#107](https://github.com/mobxjs/mobx-state-tree/issues/107)
+-   Fixed issue where same Date instance could'nt be used two times in the same state tree [#229](https://github.com/mobxjs/mobx-state-tree/issues/229)
+-   Fixed issue with reapplying snapshots to Date field resulting in snapshot typecheck error[#233](https://github.com/mobxjs/mobx-state-tree/issues/233)
+-   Declaring `types.maybe(types.frozen)` will now result into an error [#224](https://github.com/mobxjs/mobx-state-tree/issues/224)
+-   Added support for Mobx observable arrays in type checks [#221](https://github.com/mobxjs/mobx-state-tree/issues/221) (from [alessioscalici](https://github.com/alessioscalici))
 
 # 0.9.0
 
-* **BREAKING** Removed `applyPatches` and `applyActions`. Use `applyPatch` resp. `applyAction`, as both will now also accept an array as argument
-* **BREAKING** `unprotect` and `protect` can only be applied at root nodes to avoid confusing scenarios Fixed [#180](https://github.com/mobxjs/mobx-state-tree/issues/180)
-* Fixed [#141](https://github.com/mobxjs/mobx-state-tree/issues/141), actions / views are no longer wrapped in dynamically generated functions for a better debugging experience
-* Small improvements to typings, fixed compilation issues with TypeScript 2.4.1.
-* Fixed issues where `compose` couldn't overwrite getters. [#209](https://github.com/mobxjs/mobx-state-tree/issues/209), by @homura
-* Fixed CDN links in readme
-* Added TodoMVC to the examples section
+-   **BREAKING** Removed `applyPatches` and `applyActions`. Use `applyPatch` resp. `applyAction`, as both will now also accept an array as argument
+-   **BREAKING** `unprotect` and `protect` can only be applied at root nodes to avoid confusing scenarios Fixed [#180](https://github.com/mobxjs/mobx-state-tree/issues/180)
+-   Fixed [#141](https://github.com/mobxjs/mobx-state-tree/issues/141), actions / views are no longer wrapped in dynamically generated functions for a better debugging experience
+-   Small improvements to typings, fixed compilation issues with TypeScript 2.4.1.
+-   Fixed issues where `compose` couldn't overwrite getters. [#209](https://github.com/mobxjs/mobx-state-tree/issues/209), by @homura
+-   Fixed CDN links in readme
+-   Added TodoMVC to the examples section
 
 # 0.8.2
 
-* Fixed issue in rollup module bundle
+-   Fixed issue in rollup module bundle
 
 # 0.8.1
 
-* Fixed issue in release script, rendering 0.8.0 useless
+-   Fixed issue in release script, rendering 0.8.0 useless
 
 # 0.8.0
 
-* **BREAKING** Dropped `types.extend` in favor of `types.compose`. See [#192](https://github.com/mobxjs/mobx-state-tree/issues/192)
-* Introduced the lifecycle hooks `preProcessSnapshot` and `postProcessSnapshot`. See [#203](https://github.com/mobxjs/mobx-state-tree/pull/203) / [#100](https://github.com/mobxjs/mobx-state-tree/issues/100)
-* Use rollup as bundler [#196](https://github.com/mobxjs/mobx-state-tree/pull/196)
+-   **BREAKING** Dropped `types.extend` in favor of `types.compose`. See [#192](https://github.com/mobxjs/mobx-state-tree/issues/192)
+-   Introduced the lifecycle hooks `preProcessSnapshot` and `postProcessSnapshot`. See [#203](https://github.com/mobxjs/mobx-state-tree/pull/203) / [#100](https://github.com/mobxjs/mobx-state-tree/issues/100)
+-   Use rollup as bundler [#196](https://github.com/mobxjs/mobx-state-tree/pull/196)
 
 # 0.7.3
 
-* Introduced the concept of volatile / local state in models. See [#168](https://github.com/mobxjs/mobx-state-tree/issues/168), or [docs](https://github.com/mobxjs/mobx-state-tree/tree/master#volatile-state)
-* Fixed issue with types.map() with types.identifier(types.number) [#191](https://github.com/mobxjs/mobx-state-tree/issues/191) reported by @boatkorachal
-* Fixed issue with reconciler that affected types.map when node already existed at that key reported by @boatkorachal [#191](https://github.com/mobxjs/mobx-state-tree/issues/191)
+-   Introduced the concept of volatile / local state in models. See [#168](https://github.com/mobxjs/mobx-state-tree/issues/168), or [docs](https://github.com/mobxjs/mobx-state-tree/tree/master#volatile-state)
+-   Fixed issue with types.map() with types.identifier(types.number) [#191](https://github.com/mobxjs/mobx-state-tree/issues/191) reported by @boatkorachal
+-   Fixed issue with reconciler that affected types.map when node already existed at that key reported by @boatkorachal [#191](https://github.com/mobxjs/mobx-state-tree/issues/191)
 
 # 0.7.2
 
-* Fixed `cannot read property resolve of undefined` thanks to @cpunion for reporting, now value of dead nodes will be undefined. [#186](https://github.com/mobxjs/mobx-state-tree/issues/186)
-* Fixed `[LateType] is not defined` thanks to @amir-arad for reporting, when using late as model property type [#187](https://github.com/mobxjs/mobx-state-tree/issues/187)
-* Fixed `Object.freeze can only be called on Object` thanks to @ds300 for reporting, when using MST on a ReactNative environment [#189](https://github.com/mobxjs/mobx-state-tree/issues/189)
-* Now the entire codebase is prettier! :D [#187](https://github.com/mobxjs/mobx-state-tree/issues/187)
+-   Fixed `cannot read property resolve of undefined` thanks to @cpunion for reporting, now value of dead nodes will be undefined. [#186](https://github.com/mobxjs/mobx-state-tree/issues/186)
+-   Fixed `[LateType] is not defined` thanks to @amir-arad for reporting, when using late as model property type [#187](https://github.com/mobxjs/mobx-state-tree/issues/187)
+-   Fixed `Object.freeze can only be called on Object` thanks to @ds300 for reporting, when using MST on a ReactNative environment [#189](https://github.com/mobxjs/mobx-state-tree/issues/189)
+-   Now the entire codebase is prettier! :D [#187](https://github.com/mobxjs/mobx-state-tree/issues/187)
 
 # 0.7.1
 
-* Fixed `array.remove` not working
+-   Fixed `array.remove` not working
 
 # 0.7.0
 
 The type system and internal administration has been refactoring, making the internals both simpler and more flexible.
 Things like references and identifiers are now first class types, making them much better composable. [#152](https://github.com/mobxjs/mobx-state-tree/issues/152)
 
-* **BREAKING** References with a predefined lookup path are no longer supported. Instead of that, identifiers are now looked up in the entire tree. For that reasons identifiers now have to be unique in the entire tree, per type.
-* **BREAKING** `resolve` is renamed to `resolvePath`
-* Introduced `resolveIdentifier(type, tree, identifier)` to find objects by identifier
-* **BREAKING** `types.reference` is by default non-nullable. For nullable identifiers, use `types.maybe(types.reference(X))`
-* Many, many improvements. Related open issues will be updated.
-* **BREAKING** `isMST` is renamed to `isStateTreeNode`
+-   **BREAKING** References with a predefined lookup path are no longer supported. Instead of that, identifiers are now looked up in the entire tree. For that reasons identifiers now have to be unique in the entire tree, per type.
+-   **BREAKING** `resolve` is renamed to `resolvePath`
+-   Introduced `resolveIdentifier(type, tree, identifier)` to find objects by identifier
+-   **BREAKING** `types.reference` is by default non-nullable. For nullable identifiers, use `types.maybe(types.reference(X))`
+-   Many, many improvements. Related open issues will be updated.
+-   **BREAKING** `isMST` is renamed to `isStateTreeNode`
 
 # 0.6.3
 
-* Fixed issue with array/maps of union types @abruzzihraig [#151](https://github.com/mobxjs/mobx-state-tree/issues/151)
-* Make types.extend support computed attributes @cpunion [#169](https://github.com/mobxjs/mobx-state-tree/issues/169)
-* Fixed issue with map of primitive types and applySnapshot @pioh [#155](https://github.com/mobxjs/mobx-state-tree/issues/155)
-* Better type declarations for union, up to 10 supported types
+-   Fixed issue with array/maps of union types @abruzzihraig [#151](https://github.com/mobxjs/mobx-state-tree/issues/151)
+-   Make types.extend support computed attributes @cpunion [#169](https://github.com/mobxjs/mobx-state-tree/issues/169)
+-   Fixed issue with map of primitive types and applySnapshot @pioh [#155](https://github.com/mobxjs/mobx-state-tree/issues/155)
+-   Better type declarations for union, up to 10 supported types
 
 # 0.6.2
 
-* Fixed issue where arrays where not properly serialized as action argument
+-   Fixed issue where arrays where not properly serialized as action argument
 
 # 0.6.1
 
-* Improved reporting of Type.is(), now it returns a fine grained report of why the provided value is not applicable.
+-   Improved reporting of Type.is(), now it returns a fine grained report of why the provided value is not applicable.
+
 ```
 [mobx-state-tree] Error while converting [{}] to AnonymousModel[]:
 at path "/name" snapshot undefined is not assignable to type: string.
 at path "/quantity" snapshot undefined is not assignable to type: number.
 ```
-* Fixed support for `types.reference` in combination with `types.late`, by @robinfehr
+
+-   Fixed support for `types.reference` in combination with `types.late`, by @robinfehr
 
 # 0.6.0
 
-* **BREAKING** `types.withDefault` has been renamed to `types.optional`
-* **BREAKING** Array and map types can no longer be left out of snapshots by default. Use `optional` to make them optional in the snapshot
-* **BREAKING** Literals no longer have a default value by default (use optional + literal instead)
-* **BREAKING** Disabled inlining type.model definitions as introduced in 0.5.1; to many subtle issues
-* Improved identifier support, they are no properly propageted through utility types like `maybe`, `union` etc
-* Fixed issue where fields where not referted back to default when a partial snapshot was provided
-* Fixed #122: `types.identifier` now also accepts a subtype to override the default string type; e.g. `types.identifier(types.number)`
+-   **BREAKING** `types.withDefault` has been renamed to `types.optional`
+-   **BREAKING** Array and map types can no longer be left out of snapshots by default. Use `optional` to make them optional in the snapshot
+-   **BREAKING** Literals no longer have a default value by default (use optional + literal instead)
+-   **BREAKING** Disabled inlining type.model definitions as introduced in 0.5.1; to many subtle issues
+-   Improved identifier support, they are no properly propageted through utility types like `maybe`, `union` etc
+-   Fixed issue where fields where not referted back to default when a partial snapshot was provided
+-   Fixed #122: `types.identifier` now also accepts a subtype to override the default string type; e.g. `types.identifier(types.number)`
 
 # 0.5.1
 
-* Introduced support for lazy evaluating values in `withDefault`, useful to generate UUID's, timestamps or non-primitive default values
-* ~~It is now possible to define something like~~ Removed in 0.6.0
+-   Introduced support for lazy evaluating values in `withDefault`, useful to generate UUID's, timestamps or non-primitive default values
+-   ~~It is now possible to define something like~~ Removed in 0.6.0
 
 ```javascript
 const Box = types.model({
@@ -408,11 +408,11 @@ Where the type of `point` property is inferred to `point: types.withDefault(type
 
 # 0.5.0
 
-* ** BREAKING ** protection is now enabled by default (#101)
-* ** BREAKING ** it is no longer possible to read values from a dead object. Except through `getSnapshot` or `clone` (#102)
-* ** BREAKING ** `types.recursive` has been removed in favor of `types.late`
-* Introduced `unprotect`, to disable protection mode for a certain instance. Useful in `afterCreate` hooks
-* Introduced `types.late`. Usage: `types.late(() => typeDefinition)`. Can be used for circular / recursive type definitions, even across files. See `test/circular(1|2).ts` for an example (#74)
+-   ** BREAKING ** protection is now enabled by default (#101)
+-   ** BREAKING ** it is no longer possible to read values from a dead object. Except through `getSnapshot` or `clone` (#102)
+-   ** BREAKING ** `types.recursive` has been removed in favor of `types.late`
+-   Introduced `unprotect`, to disable protection mode for a certain instance. Useful in `afterCreate` hooks
+-   Introduced `types.late`. Usage: `types.late(() => typeDefinition)`. Can be used for circular / recursive type definitions, even across files. See `test/circular(1|2).ts` for an example (#74)
 
 # 0.4.0
 
@@ -433,7 +433,7 @@ Now should be defined as:
 const Todo = types.model(
     "Todo",
     {
-        done: types.boolean,
+        done: types.boolean
     },
     {
         toggle() {
@@ -447,43 +447,43 @@ It is still possible to define functions on the first object. However, those fun
 
 # 0.3.3
 
-* Introduced lifecycle hooks `afterCreate`, `afterAttach`, `beforeDetach`, `beforeDestroy`, implements #76
-* Introduced the convenience method `addDisposer(this, cb)` that can be used to easily destruct reactions etc. which are set up in `afterCreate`. See #76
+-   Introduced lifecycle hooks `afterCreate`, `afterAttach`, `beforeDetach`, `beforeDestroy`, implements #76
+-   Introduced the convenience method `addDisposer(this, cb)` that can be used to easily destruct reactions etc. which are set up in `afterCreate`. See #76
 
 # 0.3.2
 
-* Fix: actions where not bound automatically
-* Improved and simplified the reconciliation mechanism, fixed many edge cases
-* Improved the reference mechanism, fixed many edge cases
-* Improved performance
+-   Fix: actions where not bound automatically
+-   Improved and simplified the reconciliation mechanism, fixed many edge cases
+-   Improved the reference mechanism, fixed many edge cases
+-   Improved performance
 
 # 0.3.1
 
-* (re) introduced the concept of environments, which can be passed as second argument to `.create`, and picked up using `getEnv`
+-   (re) introduced the concept of environments, which can be passed as second argument to `.create`, and picked up using `getEnv`
 
 # 0.3.0
 
-* Removed `primitive` type, use a more specific type instead
-* Improved typescript typings of snapshots
-* Added `depth` parameter to `getParent` and `hasParent`
-* Separated the concepts of middleware and serializable actions. It is now possible to intercept, modify actions etc through `addMiddleWare`. `onAction` now uses middleware, if it is used, all parameters of actions should be serializable!
+-   Removed `primitive` type, use a more specific type instead
+-   Improved typescript typings of snapshots
+-   Added `depth` parameter to `getParent` and `hasParent`
+-   Separated the concepts of middleware and serializable actions. It is now possible to intercept, modify actions etc through `addMiddleWare`. `onAction` now uses middleware, if it is used, all parameters of actions should be serializable!
 
 # 0.2.2
 
-* Introduced the concept of livelyness; if nodes are removed from the the tree because they are replaced by some other value, they will be marked as "died". This should help to early signal when people hold on to references that are not part of the tree anymore. To explicitly remove an node from a tree, with the intent to spawn a new state tree from it, use `detach`.
-* Introduced the convenience method `destroy` to remove a model from it's parent and mark it as dead.
-* Introduced the concept of protected trees. If a tree is protected using `protect`, it can only be modified through action, and not by mutating it directly anymore.
+-   Introduced the concept of livelyness; if nodes are removed from the the tree because they are replaced by some other value, they will be marked as "died". This should help to early signal when people hold on to references that are not part of the tree anymore. To explicitly remove an node from a tree, with the intent to spawn a new state tree from it, use `detach`.
+-   Introduced the convenience method `destroy` to remove a model from it's parent and mark it as dead.
+-   Introduced the concept of protected trees. If a tree is protected using `protect`, it can only be modified through action, and not by mutating it directly anymore.
 
 # 0.2.1
 
-* Introduced .Type and .SnapshotType to be used with TypeScript to get the type for a model
+-   Introduced .Type and .SnapshotType to be used with TypeScript to get the type for a model
 
 # 0.2.0
 
-* Renamed `createFactory` to `types.model` (breaking!)
-* Renamed `composeFactory` to `types.extend` (breaking!)
-* Actions should now be declared as `name(params) { body }`, instead of `name: action(function (params) { body})` (breaking!)
-* Models are no longer constructed by invoking the factory as function, but by calling `factory.create` (breaking!)
-* Introduced `identifier`
-* Introduced / improved `reference`
-* Greatly improved typescript support, type inference etc. However there are still limitations as the full typesystem of MST cannot be expressed in TypeScript. Especially concerning the type of snapshots and the possibility to use snapshots as first class value.
+-   Renamed `createFactory` to `types.model` (breaking!)
+-   Renamed `composeFactory` to `types.extend` (breaking!)
+-   Actions should now be declared as `name(params) { body }`, instead of `name: action(function (params) { body})` (breaking!)
+-   Models are no longer constructed by invoking the factory as function, but by calling `factory.create` (breaking!)
+-   Introduced `identifier`
+-   Introduced / improved `reference`
+-   Greatly improved typescript support, type inference etc. However there are still limitations as the full typesystem of MST cannot be expressed in TypeScript. Especially concerning the type of snapshots and the possibility to use snapshots as first class value.

--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -789,34 +789,6 @@ export function getMembers(target: IAnyStateTreeNode): IModelReflectionData {
     return reflected
 }
 
-/**
- * A type which is equivalent to the union of the CreationType with the InstanceType of a given typeof Type or typeof Instance.
- * For primitives it defaults to the primitive itself.
- *
- * For example:
- * - SnapshotOrInstance<typeof ModelA> = typeof ModelA.CreationType | typeof ModelA.Type
- * - SnapshotOrInstance<typeof self.a (where self.a is a ModelA)> = typeof ModelA.CreationType | typeof ModelA.Type
- *
- * Usually you might want to use this when your model has a setter action that sets a property.
- *
- * @example
- * const ModelA = types.model({
- *   n: types.number
- * })
- *
- * const ModelB = types.model({
- *   innerModel: ModelA
- * }).actions(self => ({
- *   // this will accept as property both the snapshot and the instance, whichever is preferred
- *   setInnerModel(m: SnapshotOrInstance<typeof self.innerModel>) {
- *     self.innerModel = cast(m)
- *   }
- * }))
- */
-export type SnapshotOrInstance<T> = T extends IStateTreeNode<infer STNC, any>
-    ? STNC | T
-    : T extends IType<infer TC, any, infer TT> ? TC | TT : T
-
 export type CastedType<T> = T extends IStateTreeNode<infer STNC> ? STNC | T : T
 
 /**
@@ -849,7 +821,7 @@ export type CastedType<T> = T extends IStateTreeNode<infer STNC> ? STNC | T : T
  * @returns {T}
  */
 export function cast<T = never>(snapshotOrInstance: CastedType<T>): T {
-    return (snapshotOrInstance as any) as T
+    return snapshotOrInstance as T
 }
 
 import {

--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -789,7 +789,7 @@ export function getMembers(target: IAnyStateTreeNode): IModelReflectionData {
     return reflected
 }
 
-export type CastedType<T> = T extends IStateTreeNode<infer STNC> ? STNC | T : T
+export type CastedType<T> = T extends IStateTreeNode<infer C> ? C | T : T
 
 /**
  * Casts a node snapshot or instance type to an instance type so it can be assigned to a type instance.

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -98,6 +98,42 @@ export type ExtractIStateTreeNode<IT extends IAnyType, C, S, T> =
         ? TAndInterface<ExtractT<RT>, IStateTreeNode<ExtractC<RT>, ExtractS<RT>>>
         : T extends ModelPrimitive ? T : TAndInterface<T, IStateTreeNode<C, S>>
 
+export type Instance<T> = T extends IStateTreeNode
+    ? T
+    : T extends IType<any, any, infer TT> ? TT : T
+export type InSnapshot<T> = T extends IStateTreeNode<infer STNC, any>
+    ? STNC
+    : T extends IType<infer TC, any, any> ? TC : T
+export type OutSnapshot<T> = T extends IStateTreeNode<any, infer STNS>
+    ? STNS
+    : T extends IType<any, infer TS, any> ? TS : T
+
+/**
+ * A type which is equivalent to the union of the InSnapshot with the Instance types of a given typeof TYPE or typeof VARIABLE.
+ * For primitives it defaults to the primitive itself.
+ *
+ * For example:
+ * - SnapshotOrInstance<typeof ModelA> = InSnapshot<typeof ModelA> | Instance<typeof ModelA>
+ * - SnapshotOrInstance<typeof self.a (where self.a is a ModelA)> = InSnapshot<typeof ModelA> | Instance<typeof ModelA>
+ *
+ * Usually you might want to use this when your model has a setter action that sets a property.
+ *
+ * @example
+ * const ModelA = types.model({
+ *   n: types.number
+ * })
+ *
+ * const ModelB = types.model({
+ *   innerModel: ModelA
+ * }).actions(self => ({
+ *   // this will accept as property both the snapshot and the instance, whichever is preferred
+ *   setInnerModel(m: SnapshotOrInstance<typeof self.innerModel>) {
+ *     self.innerModel = cast(m)
+ *   }
+ * }))
+ */
+export type SnapshotOrInstance<T> = InSnapshot<T> | Instance<T>
+
 /*
  * A complex type produces a MST node (Node in the state tree)
  */

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -101,20 +101,20 @@ export type ExtractIStateTreeNode<IT extends IAnyType, C, S, T> =
 export type Instance<T> = T extends IStateTreeNode
     ? T
     : T extends IType<any, any, infer TT> ? TT : T
-export type InSnapshot<T> = T extends IStateTreeNode<infer STNC, any>
+export type SnapshotIn<T> = T extends IStateTreeNode<infer STNC, any>
     ? STNC
     : T extends IType<infer TC, any, any> ? TC : T
-export type OutSnapshot<T> = T extends IStateTreeNode<any, infer STNS>
+export type SnapshotOut<T> = T extends IStateTreeNode<any, infer STNS>
     ? STNS
     : T extends IType<any, infer TS, any> ? TS : T
 
 /**
- * A type which is equivalent to the union of the InSnapshot with the Instance types of a given typeof TYPE or typeof VARIABLE.
+ * A type which is equivalent to the union of SnapshotIn and Instance types of a given typeof TYPE or typeof VARIABLE.
  * For primitives it defaults to the primitive itself.
  *
  * For example:
- * - SnapshotOrInstance<typeof ModelA> = InSnapshot<typeof ModelA> | Instance<typeof ModelA>
- * - SnapshotOrInstance<typeof self.a (where self.a is a ModelA)> = InSnapshot<typeof ModelA> | Instance<typeof ModelA>
+ * - SnapshotOrInstance<typeof ModelA> = SnapshotIn<typeof ModelA> | Instance<typeof ModelA>
+ * - SnapshotOrInstance<typeof self.a (where self.a is a ModelA)> = SnapshotIn<typeof ModelA> | Instance<typeof ModelA>
  *
  * Usually you might want to use this when your model has a setter action that sets a property.
  *
@@ -132,7 +132,7 @@ export type OutSnapshot<T> = T extends IStateTreeNode<any, infer STNS>
  *   }
  * }))
  */
-export type SnapshotOrInstance<T> = InSnapshot<T> | Instance<T>
+export type SnapshotOrInstance<T> = SnapshotIn<T> | Instance<T>
 
 /*
  * A complex type produces a MST node (Node in the state tree)

--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -128,8 +128,7 @@ export {
     Instance,
     InSnapshot,
     OutSnapshot,
-    SnapshotOrInstance,
-    cast
+    SnapshotOrInstance
 } from "./internal"
 
 export * from "./core/mst-operations"

--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -44,6 +44,9 @@ import {
     identifierNumber,
     maybeNull,
     TypeFlags,
+    Instance,
+    InSnapshot,
+    OutSnapshot,
     SnapshotOrInstance,
     cast
 } from "./internal"
@@ -122,6 +125,9 @@ export {
     ModelTypeConfig,
     CustomTypeOptions,
     UnionOptions,
+    Instance,
+    InSnapshot,
+    OutSnapshot,
     SnapshotOrInstance,
     cast
 } from "./internal"

--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -45,8 +45,8 @@ import {
     maybeNull,
     TypeFlags,
     Instance,
-    InSnapshot,
-    OutSnapshot,
+    SnapshotIn,
+    SnapshotOut,
     SnapshotOrInstance,
     cast
 } from "./internal"
@@ -126,8 +126,8 @@ export {
     CustomTypeOptions,
     UnionOptions,
     Instance,
-    InSnapshot,
-    OutSnapshot,
+    SnapshotIn,
+    SnapshotOut,
     SnapshotOrInstance
 } from "./internal"
 

--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -43,7 +43,9 @@ import {
     custom,
     identifierNumber,
     maybeNull,
-    TypeFlags
+    TypeFlags,
+    SnapshotOrInstance,
+    cast
 } from "./internal"
 
 export const types = {
@@ -119,7 +121,9 @@ export {
     ModelActions,
     ModelTypeConfig,
     CustomTypeOptions,
-    UnionOptions
+    UnionOptions,
+    SnapshotOrInstance,
+    cast
 } from "./internal"
 
 export * from "./core/mst-operations"

--- a/packages/mobx-state-tree/test/action.ts
+++ b/packages/mobx-state-tree/test/action.ts
@@ -6,7 +6,8 @@ import {
     applyPatch,
     applySnapshot,
     addMiddleware,
-    getRoot
+    getRoot,
+    cast
 } from "../src"
 /// Simple action replay and invocation
 const Task = types
@@ -376,7 +377,7 @@ test("after attach action should work correctly", () => {
         })
         .actions(self => ({
             remove() {
-                getRoot<typeof S>(self).remove(self as typeof Todo.Type)
+                getRoot<typeof S>(self).remove(cast(self))
             }
         }))
     const S = types

--- a/packages/mobx-state-tree/test/api.ts
+++ b/packages/mobx-state-tree/test/api.ts
@@ -48,7 +48,8 @@ const METHODS = [
     "unescapeJsonPath",
     "unprotect",
     "walk",
-    "getMembers"
+    "getMembers",
+    "cast"
 ]
 const TYPES = [
     "Date",

--- a/packages/mobx-state-tree/test/array.ts
+++ b/packages/mobx-state-tree/test/array.ts
@@ -10,7 +10,8 @@ import {
     getSnapshot,
     types,
     IJsonPatch,
-    setLivelynessChecking
+    setLivelynessChecking,
+    cast
 } from "../src"
 import { observable } from "mobx"
 const createTestFactories = () => {
@@ -145,13 +146,13 @@ test("paths shoud remain correct when splicing", () => {
         })
     unprotect(store)
     expect(store.todos.map(getPath)).toEqual(["/todos/0"])
-    store.todos.push({} as typeof Task.Type)
+    store.todos.push(cast({}))
     expect(store.todos.map(getPath)).toEqual(["/todos/0", "/todos/1"])
-    store.todos.unshift({} as typeof Task.Type)
+    store.todos.unshift(cast({}))
     expect(store.todos.map(getPath)).toEqual(["/todos/0", "/todos/1", "/todos/2"])
     store.todos.splice(0, 2)
     expect(store.todos.map(getPath)).toEqual(["/todos/0"])
-    store.todos.splice(0, 1, {} as typeof Task.Type, {} as typeof Task.Type, {} as typeof Task.Type)
+    store.todos.splice(0, 1, cast({}), cast({}), cast({}))
     expect(store.todos.map(getPath)).toEqual(["/todos/0", "/todos/1", "/todos/2"])
     store.todos.remove(store.todos[1])
     expect(store.todos.map(getPath)).toEqual(["/todos/0", "/todos/1"])

--- a/packages/mobx-state-tree/test/custom-type.ts
+++ b/packages/mobx-state-tree/test/custom-type.ts
@@ -1,4 +1,12 @@
-import { types, recordPatches, onSnapshot, unprotect, applySnapshot, applyPatch } from "../src"
+import {
+    types,
+    recordPatches,
+    onSnapshot,
+    unprotect,
+    applySnapshot,
+    applyPatch,
+    cast
+} from "../src"
 
 class Decimal {
     public number: number
@@ -74,7 +82,7 @@ class Decimal {
         const b1 = w1.balance
         expect(b1).toBeInstanceOf(Decimal)
 
-        w1.balance = "2.5" as any
+        w1.balance = cast("2.5")
         expect(b1).toBeInstanceOf(Decimal)
         expect(w1.balance).toBe(b1) // reconciled
 
@@ -84,7 +92,7 @@ class Decimal {
         w1.balance = new Decimal("3.5")
         expect(b1).toBeInstanceOf(Decimal)
 
-        w1.balance = "4.5" as any
+        w1.balance = cast("4.5")
         expect(b1).toBeInstanceOf(Decimal)
 
         w1.lastTransaction = b1
@@ -154,7 +162,7 @@ class Decimal {
         const b1 = w1.balance
         expect(b1).toBeInstanceOf(Decimal)
 
-        w1.balance = [2, 5] as any
+        w1.balance = cast([2, 5])
         expect(b1).toBeInstanceOf(Decimal)
         expect(w1.balance).not.toBe(b1) // not reconciled, balance is not deep equaled (TODO: future feature?)
 
@@ -164,7 +172,7 @@ class Decimal {
         w1.balance = new Decimal("3.5")
         expect(b1).toBeInstanceOf(Decimal)
 
-        w1.balance = [4, 5] as any
+        w1.balance = cast([4, 5])
         expect(b1).toBeInstanceOf(Decimal)
 
         // patches & snapshots

--- a/packages/mobx-state-tree/test/identifier.ts
+++ b/packages/mobx-state-tree/test/identifier.ts
@@ -1,4 +1,4 @@
-import { types, tryResolve, resolvePath } from "../src"
+import { types, tryResolve, resolvePath, cast, SnapshotOrInstance } from "../src"
 
 if (process.env.NODE_ENV !== "production") {
     test("#275 - Identifiers should check refinement", () => {
@@ -20,8 +20,8 @@ if (process.env.NODE_ENV !== "production") {
                 models: types.array(Model)
             })
             .actions(self => ({
-                addModel(model: typeof Model.Type | typeof Model.CreationType) {
-                    self.models.push(model as typeof Model.Type)
+                addModel(model: SnapshotOrInstance<typeof Model>) {
+                    self.models.push(cast(model))
                 }
             }))
         expect(() => {

--- a/packages/mobx-state-tree/test/optional.ts
+++ b/packages/mobx-state-tree/test/optional.ts
@@ -1,4 +1,4 @@
-import { getSnapshot, types, unprotect, applySnapshot } from "../src"
+import { getSnapshot, types, unprotect, applySnapshot, cast } from "../src"
 test("it should provide a default value, if no snapshot is provided", () => {
     const Row = types.model({
         name: "",
@@ -74,7 +74,7 @@ test("Values should reset to default if omitted in snapshot", () => {
     unprotect(store)
     store.todo.done = true
     expect(store.todo.done).toBe(true)
-    store.todo = { title: "stuff", id: "2" } as any
+    store.todo = cast({ title: "stuff", id: "2" })
     expect(store.todo.title).toBe("stuff")
     expect(store.todo.done).toBe(false)
 })

--- a/packages/mobx-state-tree/test/parent-properties.ts
+++ b/packages/mobx-state-tree/test/parent-properties.ts
@@ -1,4 +1,4 @@
-import { types, getEnv, getParent, getPath } from "../src"
+import { types, getEnv, getParent, getPath, cast } from "../src"
 const ChildModel = types
     .model("Child", {
         parentPropertyIsNullAfterCreate: false,
@@ -94,14 +94,16 @@ test("#917", () => {
         }))
         .actions(self => ({
             addTodo(title: string) {
-                self.todos.push({
-                    title,
-                    subTodos: [
-                        {
-                            title
-                        }
-                    ]
-                } as typeof Todo.Type) // TODO: if IObservableArray supported separate write/read types then this typecast could be avoided
+                self.todos.push(
+                    cast({
+                        title,
+                        subTodos: [
+                            {
+                                title
+                            }
+                        ]
+                    })
+                )
             }
         }))
 

--- a/packages/mobx-state-tree/test/protect.ts
+++ b/packages/mobx-state-tree/test/protect.ts
@@ -1,4 +1,4 @@
-import { protect, unprotect, applySnapshot, types, isProtected, getParent } from "../src"
+import { protect, unprotect, applySnapshot, types, isProtected, getParent, cast } from "../src"
 const Todo = types
     .model("Todo", {
         title: ""
@@ -45,7 +45,7 @@ test("protect should protect against any update", () => {
         "[mobx-state-tree] Cannot modify 'Todo@<root>', the object is protected and can only be modified by using an action."
     )
     expect(() => {
-        store.todos.push({ title: "test" } as typeof Todo.Type)
+        store.todos.push(cast({ title: "test" }))
     }).toThrowError(
         "[mobx-state-tree] Cannot modify 'Todo[]@/todos', the object is protected and can only be modified by using an action."
     )

--- a/packages/mobx-state-tree/test/reference-custom.ts
+++ b/packages/mobx-state-tree/test/reference-custom.ts
@@ -8,7 +8,8 @@ import {
     unprotect,
     getRoot,
     onSnapshot,
-    flow
+    flow,
+    cast
 } from "../src"
 
 test("it should support custom references - basics", () => {
@@ -134,7 +135,7 @@ test("it should support dynamic loading", done => {
         .actions(self => ({
             loadUser: flow(function* loadUser(name: string) {
                 events.push("loading " + name)
-                self.users.push({ name } as typeof User.Type)
+                self.users.push(cast({ name }))
                 yield new Promise(resolve => {
                     setTimeout(resolve, 200)
                 })

--- a/packages/mobx-state-tree/test/reference.ts
+++ b/packages/mobx-state-tree/test/reference.ts
@@ -11,7 +11,8 @@ import {
     getRoot,
     IType,
     IAnyType,
-    IComplexType
+    IComplexType,
+    cast
 } from "../src"
 test("it should support prefixed paths in maps", () => {
     const User = types.model({
@@ -117,7 +118,7 @@ test("it should resolve refs during creation, when using path", () => {
     })
     unprotect(s)
     reaction(() => s.entries.reduce((a, e) => a + e.price, 0), v => values.push(v))
-    s.entries.push({ book: s.books[0] } as any)
+    s.entries.push(cast({ book: s.books[0] }))
     expect(s.entries[0].price).toBe(4)
     expect(s.entries.reduce((a, e) => a + e.price, 0)).toBe(4)
     const entry = BookEntry.create({ book: s.books[0] }) // N.B. ref is initially not resolvable!
@@ -148,7 +149,7 @@ test("it should resolve refs over late types", () => {
         books: [{ id: "3", price: 2 }]
     })
     unprotect(s)
-    s.entries.push({ book: s.books[0] } as any)
+    s.entries.push(cast({ book: s.books[0] }))
     expect(s.entries[0].price).toBe(4)
     expect(s.entries.reduce((a, e) => a + e.price, 0)).toBe(4)
 })
@@ -176,7 +177,7 @@ test("it should resolve refs during creation, when using generic reference", () 
     })
     unprotect(s)
     reaction(() => s.entries.reduce((a, e) => a + e.price, 0), v => values.push(v))
-    s.entries.push({ book: s.books[0] } as any)
+    s.entries.push(cast({ book: s.books[0] }))
     expect(s.entries[0].price).toBe(4)
     expect(s.entries.reduce((a, e) => a + e.price, 0)).toBe(4)
     const entry = BookEntry.create({ book: s.books[0] }) // can refer to book, even when not part of tree yet
@@ -312,7 +313,7 @@ test("it should fail when reference snapshot is ambiguous", () => {
         }
     })
     expect(store.selected).toBe(store.boxes[0]) // unambigous identifier
-    store.arrows.push({ id: 1, name: "oops" } as any)
+    store.arrows.push(cast({ id: 1, name: "oops" }))
     expect(err.message).toBe(
         "[mobx-state-tree] Cannot resolve a reference to type '(Box | Arrow)' with id: '1' unambigously, there are multiple candidates: /boxes/0, /arrows/1"
     )

--- a/packages/mobx-state-tree/test/refinement.ts
+++ b/packages/mobx-state-tree/test/refinement.ts
@@ -1,4 +1,4 @@
-import { getSnapshot, types } from "../src"
+import { getSnapshot, types, cast } from "../src"
 test("it should allow if type and predicate is correct", () => {
     const Factory = types.model({
         number: types.refinement(

--- a/packages/mobx-state-tree/test/type-system.ts
+++ b/packages/mobx-state-tree/test/type-system.ts
@@ -6,7 +6,9 @@ import {
     getRoot,
     getParent,
     SnapshotOrInstance,
-    cast
+    cast,
+    InSnapshot,
+    Instance
 } from "../src"
 const createTestFactories = () => {
     const Box = types.model({
@@ -689,6 +691,7 @@ test("cast and SnapshotOrInstance", () => {
     }))
 
     const c = C.create({ a: { n2: 5 } })
+    unprotect(c)
     // all below works
     c.setA({ n2: 5 })
     c.setA(A.create({ n2: 5 }))

--- a/packages/mobx-state-tree/test/type-system.ts
+++ b/packages/mobx-state-tree/test/type-system.ts
@@ -7,7 +7,7 @@ import {
     getParent,
     SnapshotOrInstance,
     cast,
-    InSnapshot,
+    SnapshotIn,
     Instance
 } from "../src"
 const createTestFactories = () => {
@@ -675,11 +675,9 @@ test("cast and SnapshotOrInstance", () => {
         setA2(na: SnapshotOrInstance<typeof A>) {
             self.a = cast(na)
         },
-        // works too
-        setA3(na: InSnapshot<typeof A>) {
+        setA3(na: SnapshotIn<typeof A>) {
             self.a = cast(na)
         },
-        // works too
         setA4(na: Instance<typeof self.a>) {
             self.a = cast(na)
         },

--- a/packages/mobx-state-tree/test/type-system.ts
+++ b/packages/mobx-state-tree/test/type-system.ts
@@ -116,8 +116,8 @@ test("#66 - it should accept superfluous fields", () => {
     expect(Item.is({ id: 3 })).toBe(false)
     expect(Item.is({ id: 3, name: "" })).toBe(true)
     expect(Item.is({ id: 3, name: "", description: "" })).toBe(true)
-    const a = Item.create({ id: 3, name: "", description: "bla" } as any) as any
-    expect(a.description).toBe(undefined)
+    const a = Item.create({ id: 3, name: "", description: "bla" } as any)
+    expect((a as any).description).toBe(undefined)
 })
 test("#66 - it should not require defaulted fields", () => {
     const Item = types.model({
@@ -192,7 +192,7 @@ test("it is possible to refer to a type", () => {
             }
         })
     function x(): typeof Todo.Type {
-        return Todo.create({ title: "test" }) // as any to make sure the type is not inferred accidentally
+        return Todo.create({ title: "test" })
     }
     const z = x()
     unprotect(z)
@@ -573,15 +573,15 @@ test("#951", () => {
 
     // getRoot
     const modelRoot1 = getRoot<typeof ModelWithC>(modelInstance.c)
-    const modelCR1: typeof C.Type = modelRoot1.c
-    const modelRoot2 = getRoot<typeof ModelWithC.Type>(modelInstance.c)
-    const modelCR2: typeof C.Type = modelRoot2.c
+    const modelCR1: Instance<typeof C> = modelRoot1.c
+    const modelRoot2 = getRoot<Instance<typeof ModelWithC>>(modelInstance.c)
+    const modelCR2: Instance<typeof C> = modelRoot2.c
 
     // getParent
     const modelParent1 = getParent<typeof ModelWithC>(modelInstance.c)
-    const modelCP1: typeof ModelWithC.Type = modelParent1
-    const modelParent2 = getParent<typeof ModelWithC.Type>(modelInstance.c)
-    const modelCP2: typeof ModelWithC.Type = modelParent2
+    const modelCP1: Instance<typeof ModelWithC> = modelParent1
+    const modelParent2 = getParent<Instance<typeof ModelWithC>>(modelInstance.c)
+    const modelCP2: Instance<typeof ModelWithC> = modelParent2
 
     // array as root
     const ArrayOfC = types.array(C)
@@ -589,11 +589,11 @@ test("#951", () => {
 
     // getRoot
     const arrayRoot1 = getRoot<typeof ArrayOfC>(arrayInstance[0])
-    const arrayCR1: typeof C.Type = arrayRoot1[0]
+    const arrayCR1: Instance<typeof C> = arrayRoot1[0]
 
     // getParent
     const arrayParent1 = getParent<typeof ArrayOfC>(arrayInstance[0])
-    const arrayCP1: typeof ArrayOfC.Type = arrayParent1
+    const arrayCP1: Instance<typeof ArrayOfC> = arrayParent1
 
     // map as root
     const MapOfC = types.map(C)
@@ -601,11 +601,11 @@ test("#951", () => {
 
     // getRoot
     const mapRoot1 = getRoot<typeof MapOfC>(mapInstance.get("a")!)
-    const mapC1: typeof C.Type = mapRoot1.get("a")!
+    const mapC1: Instance<typeof C> = mapRoot1.get("a")!
 
     // getParent
     const mapParent1 = getRoot<typeof MapOfC>(mapInstance.get("a")!)
-    const mapCP1: typeof MapOfC.Type = mapParent1
+    const mapCP1: Instance<typeof MapOfC> = mapParent1
 })
 
 test("cast and SnapshotOrInstance", () => {
@@ -674,11 +674,11 @@ test("cast and SnapshotOrInstance", () => {
             self.a = cast(na)
         },
         // works too
-        setA3(na: typeof A.CreationType) {
+        setA3(na: InSnapshot<typeof A>) {
             self.a = cast(na)
         },
         // works too
-        setA4(na: typeof A.Type) {
+        setA4(na: Instance<typeof self.a>) {
             self.a = cast(na)
         },
         setA5() {
@@ -695,8 +695,8 @@ test("cast and SnapshotOrInstance", () => {
     c.setA2({ n2: 5 })
     c.setA2(A.create({ n2: 5 }))
     c.setA3({ n2: 5 })
-    // c.setA3(A.create({ n2: 5 })) // this one doesn't work, but that's expected, it wants the creation type
-    // c.setA4({n2: 5}) // this one doesn't work, but that's expected, it wants the instance type
+    // c.setA3(A.create({ n2: 5 })) // this one doesn't work (as expected, it wants the creation type)
+    // c.setA4({n2: 5}) // this one doesn't work (as expected, it wants the instance type)
     c.setA4(A.create({ n2: 5 }))
     c.setA5()
 
@@ -719,7 +719,7 @@ test("cast and SnapshotOrInstance", () => {
     c.a.setMap2({ a: 2, b: 3 })
     c.a.setMap2(NumberMap.create({ a: 2, b: 3 }))
     c.a.setMap3({ a: 2, b: 3 })
-    // c.a.setMap3(NumberMap.create({ a: 2, b: 3 })) // doesn't work as expected, wants a plain object
+    // c.a.setMap3(NumberMap.create({ a: 2, b: 3 })) // doesn't work (as expected, wants a plain object)
     c.a.setMap4()
 
     const arr = types.array(A).create()

--- a/packages/mobx-state-tree/test/type-system.ts
+++ b/packages/mobx-state-tree/test/type-system.ts
@@ -726,9 +726,11 @@ test("cast and SnapshotOrInstance", () => {
     c.a.setMap4()
 
     const arr = types.array(A).create()
+    unprotect(arr)
     arr[0] = cast({ n2: 5 })
 
     const map = types.map(A).create()
+    unprotect(map)
     map.set("a", cast({ n2: 5 })) // not really needed in this case, but whatever :)
 
     // and the best part, it actually doesn't work outside assignments :DDDD


### PR DESCRIPTION
adds a 'cast' method as introduced in IDEA 4 of https://github.com/mobxjs/mobx-state-tree/issues/955
makes "official" the .Type / .CreationType / .SnapshotType and exposes them

There are three kinds of types available, plus one helper type:
- `Instance<typeof TYPE>` or `Instance<typeof VARIABLE>` is the node instance type. (Legacy form is `typeof MODEL.Type`).
- `InSnapshot<typeof TYPE>` or `InSnapshot<typeof VARIABLE>` is the input (creation) snapshot type. (Legacy form is `typeof MODEL.CreationType`).
- `OutSnapshot<typeof TYPE>` or `OutSnapshot<typeof VARIABLE>` is the output (creation) snapshot type. (Legacy form is `typeof MODEL.SnapshotType`).  
- `SnapshotOrInstance<typeof TYPE>` or `SnapshotOrInstance<typeof VARIABLE>` is `InSnapshot<T> | Instance<T>`. This type is useful when you want to declare an input parameter that is able consume both types.

```typescript
const Todo = types.model({
        title: "hello"
    })
    .actions(self => ({
        setTitle(v: string) {
            self.title = v
        }
    }))

type ITodo = Instance<typeof Todo> // => ITodo is now a valid TypeScript type with { title: string; setTitle: (v: string) => void }

type ITodoInSnapshot = InSnapshot<typeof Todo> // => ITodoSnapshot is now a valid TypeScript type with { title?: string }

type ITodoOutSnapshot = OutSnapshot<typeof Todo> // => ITodoSnapshot is now a valid TypeScript type with { title: string }
```

Due to the way typeof operator works, when working with big and deep models trees, it might make your IDE/ts server takes a lot of CPU time and freeze vscode (or others)
A partial solution for this is to turn the types into interfaces.

```ts
type ITodoType = Instance<typeof Todo>;
interface ITodo extends ITodoType {};

type ITodoInSnapshotType = InSnapshot<typeof Todo>;
interface ITodoInSnapshot extends ITodoInSnapshotType {};

type ITodoOutSnapshotType = OutSnapshot<typeof Todo>;
interface ITodoOutSnapshot extends ITodoOutSnapshotType {};
```


#### Snapshots can be used to write values

Everywhere where you can modify your state tree and assign a model instance, you can also
just assign a snapshot, and MST will convert it to a model instance for you.
However, that is simply not expressible in static type systems atm (as the type written to a value differs to the type read from it).
As a workaround MST offers a `cast` function, which will try to fool the typesystem into thinking that an snapshot type (and instance as well)
is of the related instance type.

```typescript
const Task = types.model({
    done: false
})
const Store = types.model({
    tasks: types.array(Task),
    selection: types.maybe(Task)
})

const s = Store.create({ tasks: [] })
// `{}` is a valid snapshot of Task, and hence a valid task, MST allows this, but TS doesn't, so need to use 'cast'
s.tasks.push(cast({}))
s.selection = cast({})
```

Additionally, for function parameters, MST offers a `SnapshotOrInstance<T>` type, where T can either be a `typeof TYPE` or a
`typeof VARIABLE`. In both cases it will resolve to the union of the input (creation) snapshot and instance type of that TYPE or VARIABLE.

Using both at the same time we can express property assignation of complex properties in this form:

```typescript
const Task = types.model({
    done: false
})
const Store = types.model({
    tasks: types.array(Task)
}).actions(self => ({
    addTask(
        // equivalent to typeof Task.Type | typeof Task.CreationType
        task: SnapshotOrInstance<typeof Task>
    ) {
        self.tasks.push(cast(task))
    },
    replaceTasks(
        // equivalent to typeof typeof (types.array(Task)).Type | typeof (types.array(Task)).CreationType
        tasks: SnapshotOrInstance<typeof self.tasks>
    ) {
        self.tasks = cast(tasks)
    }
}))

const s = Store.create({ tasks: [] })

s.addTask({}) 
// or
s.addTask(Task.create({}))

s.replaceTasks([{ done: true }])
// or
s.replaceTasks(types.array(Task).create([{ done: true }]))
```
