### PR TITLE
Explicit IAtom import added, marked as exception for IDE's

### DIFF
--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -1,4 +1,5 @@
-import { action, computed, createAtom, reaction } from "mobx"
+// noinspection ES6UnusedImports
+import { action, computed, createAtom, reaction, IAtom } from "mobx"
 import {
     addHiddenFinalProp,
     addReadOnlyProp,


### PR DESCRIPTION
Seems to fix [#968](https://github.com/mobxjs/mobx-state-tree/issues/968).