### PR TITLE
Fix for exception when destroying children of types.maybe

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/object.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/object.test.ts
@@ -605,10 +605,10 @@ if (process.env.NODE_ENV !== "production") {
         unprotect(b)
         expect(() => {
             detach(b.a)
-        }).toThrowError(/Error while converting `null` to `A`/)
+        }).toThrowError(/Error while converting `undefined` to `A`/)
         expect(() => {
             destroy(b.a)
-        }).toThrowError(/Error while converting `null` to `A`/)
+        }).toThrowError(/Error while converting `undefined` to `A`/)
     })
 }
 test("it should be possible to share states between views and actions using enhance", () => {

--- a/packages/mobx-state-tree/__tests__/core/object.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/object.test.ts
@@ -620,6 +620,8 @@ if (process.env.NODE_ENV !== "production") {
             detach(a)
             destroy(a)
         }).not.toThrow()
+        expect(b.a).toBe(undefined)
+        expect(getSnapshot(b).a).toBe(undefined)
     })
     test("it should be possible to remove a node from a parent if it is defined as type maybeNull ", () => {
         const A = types.model("A", { x: 3 })
@@ -631,6 +633,8 @@ if (process.env.NODE_ENV !== "production") {
             detach(a)
             destroy(a)
         }).not.toThrow()
+        expect(b.a).toBe(null)
+        expect(getSnapshot(b).a).toBe(null)
     })
 }
 test("it should be possible to share states between views and actions using enhance", () => {

--- a/packages/mobx-state-tree/__tests__/core/object.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/object.test.ts
@@ -610,6 +610,30 @@ if (process.env.NODE_ENV !== "production") {
             destroy(b.a)
         }).toThrowError(/Error while converting `undefined` to `A`/)
     })
+    test("it should be possible to remove a node from a parent if it is defined as type maybe ", () => {
+        const A = types.model("A", { x: 3 })
+        const B = types.model("B", { a: types.maybe(A) })
+        const b = B.create({ a: { x: 7 } })
+        unprotect(b)
+        expect(() => {
+            detach(b.a!)
+        }).not.toThrowError(/Error while converting `undefined` to `A`/)
+        expect(() => {
+            destroy(b.a!)
+        }).not.toThrowError(/Error while converting `undefined` to `A`/)
+    })
+    test("it should be possible to remove a node from a parent if it is defined as type maybeNull ", () => {
+        const A = types.model("A", { x: 3 })
+        const B = types.model("B", { a: types.maybeNull(A) })
+        const b = B.create({ a: { x: 7 } })
+        unprotect(b)
+        expect(() => {
+            detach(b.a!)
+        }).not.toThrowError(/Error while converting `undefined` to `A`/)
+        expect(() => {
+            destroy(b.a!)
+        }).not.toThrowError(/Error while converting `undefined` to `A`/)
+    })
 }
 test("it should be possible to share states between views and actions using enhance", () => {
     const A = types.model({}).extend(self => {

--- a/packages/mobx-state-tree/__tests__/core/object.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/object.test.ts
@@ -616,8 +616,9 @@ if (process.env.NODE_ENV !== "production") {
         const b = B.create({ a: { x: 7 } })
         unprotect(b)
         expect(() => {
-            detach(b.a!)
-            destroy(b.a!)
+            const a = b.a!
+            detach(a)
+            destroy(a)
         }).not.toThrow()
     })
     test("it should be possible to remove a node from a parent if it is defined as type maybeNull ", () => {
@@ -626,8 +627,9 @@ if (process.env.NODE_ENV !== "production") {
         const b = B.create({ a: { x: 7 } })
         unprotect(b)
         expect(() => {
-            detach(b.a!)
-            destroy(b.a!)
+            const a = b.a!
+            detach(a)
+            destroy(a)
         }).not.toThrow()
     })
 }

--- a/packages/mobx-state-tree/__tests__/core/object.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/object.test.ts
@@ -617,10 +617,8 @@ if (process.env.NODE_ENV !== "production") {
         unprotect(b)
         expect(() => {
             detach(b.a!)
-        }).not.toThrowError(/Error while converting `undefined` to `A`/)
-        expect(() => {
             destroy(b.a!)
-        }).not.toThrowError(/Error while converting `undefined` to `A`/)
+        }).not.toThrow()
     })
     test("it should be possible to remove a node from a parent if it is defined as type maybeNull ", () => {
         const A = types.model("A", { x: 3 })
@@ -629,10 +627,8 @@ if (process.env.NODE_ENV !== "production") {
         unprotect(b)
         expect(() => {
             detach(b.a!)
-        }).not.toThrowError(/Error while converting `undefined` to `A`/)
-        expect(() => {
             destroy(b.a!)
-        }).not.toThrowError(/Error while converting `undefined` to `A`/)
+        }).not.toThrow()
     })
 }
 test("it should be possible to share states between views and actions using enhance", () => {

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -633,7 +633,7 @@ export class ModelType<S extends ModelProperties, T> extends ComplexType<any, an
     }
 
     removeChild(node: ObjectNode, subpath: string) {
-        node.storedValue[subpath] = null
+        node.storedValue[subpath] = undefined
     }
 }
 


### PR DESCRIPTION
Since ```types.maybe``` type in MST 3.0 no longer includes ```null```, trying to assign parent's property that was containing the child that is being removed would throw ```value `null` is not assignable to type:```.

```typescript
const A = types.model({id: types.reference, myChild: types.maybe(B)});
const B = types.model({id: types.reference, name: types.string});
destroy(B) // throws: value `null` is not assignable to type: `(B | undefined)`.
```

Setting parent's property to ```undefined``` fixes the issue, and should not cause any problems since both ```types.maybe``` and ```types.maybeNull``` include ```undefined```.