### PR TITLE
Update customizable refrences link

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ References are looked up through the entire tree, but per type. So identifiers n
 
 The default implementation uses the `identifier` cache to resolve references (See [`resolveIdentifier`](API.md#resolveIdentifier)).
 However, it is also possible to override the resolve logic, and provide your own custom resolve logic.
-This also makes it possible to, for example, trigger a data fetch when trying to resolve the reference ([example](https://github.com/mobxjs/mobx-state-tree/blob/cdb3298a5621c3229b3856bb469327da6deb31ea/packages/mobx-state-tree/__tests__/core/reference-custom.ts#L150)).
+This also makes it possible to, for example, trigger a data fetch when trying to resolve the reference ([example](https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mobx-state-tree/__tests__/core/reference-custom.test.ts#L148)).
 
 Example:
 


### PR DESCRIPTION
The link was pointing to a non accessible URL. Here is the corrected version.