### PR TITLE
Extra `!` typo fix

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/reference-custom.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/reference-custom.test.ts
@@ -140,7 +140,7 @@ test("it should support dynamic loading", done => {
                     setTimeout(resolve, 200)
                 })
                 events.push("loaded " + name)
-                const user = (self.users.find(u => u.name === name)!.age = name.length * 3) // wonderful!
+                const user = (self.users.find(u => u.name === name).age = name.length * 3) // wonderful!
             })
         }))
         .views(self => ({


### PR DESCRIPTION
Seems that an extra `!` has been added here, so this doesn't run.