### PR TITLE
throw on instance for types.optional, fix for typechecking of instances generated by function

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # 3.2.5
 
 -   Fix for TS3 issues with reference type [#994](https://github.com/mobxjs/mobx-state-tree/issues/994) through [#995](https://github.com/mobxjs/mobx-state-tree/pull/995) by [@xaviergonz](https://github.com/xaviergonz)
+-   types.optional will now throw if an instance is passed as default value [#1002](https://github.com/mobxjs/mobx-state-tree/issues/1002), fixes related to functions that generate instances inside types.optional incorrectly throwing through [#1003](https://github.com/mobxjs/mobx-state-tree/pull/1003) by [@xaviergonz](https://github.com/xaviergonz)
 
 # 3.2.4
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # 3.2.5
 
 -   Fix for TS3 issues with reference type [#994](https://github.com/mobxjs/mobx-state-tree/issues/994) through [#995](https://github.com/mobxjs/mobx-state-tree/pull/995) by [@xaviergonz](https://github.com/xaviergonz)
--   types.optional will now throw if an instance is passed as default value [#1002](https://github.com/mobxjs/mobx-state-tree/issues/1002), fixes related to functions that generate instances inside types.optional incorrectly throwing through [#1003](https://github.com/mobxjs/mobx-state-tree/pull/1003) by [@xaviergonz](https://github.com/xaviergonz)
+-   types.optional will now throw if an instance is directly passed as default value [#1002](https://github.com/mobxjs/mobx-state-tree/issues/1002) through [#1003](https://github.com/mobxjs/mobx-state-tree/pull/1003) by [@xaviergonz](https://github.com/xaviergonz)
 
 # 3.2.4
 

--- a/packages/mobx-state-tree/__tests__/core/optional.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/optional.test.ts
@@ -98,16 +98,29 @@ test("an instance is not a valid default value, snapshot or function that create
         quantity: 0
     })
 
+    // passing a node directly, without a generator function
     expect(() => {
         types.model({ rows: types.optional(types.array(Row), types.array(Row).create()) })
     }).toThrow(
         "default value cannot be an instance, pass a snapshot or a function that creates an instance/snapshot instead"
     )
 
-    // this however should be ok
-    const Factory = types.model("Factory", {
-        rows: types.optional(types.array(Row), () => types.array(Row).create())
-    })
-    const doc = Factory.create()
-    expect(getSnapshot(doc)).toEqual({ rows: [] })
+    // an alike node but created from a different yet equivalent type
+    expect(() => {
+        const Factory = types.model({
+            rows: types.optional(types.array(Row), () => types.array(Row).create())
+        })
+        // we need to create the node for it to throw, since generator functions are typechecked when nodes are created
+        Factory.create()
+    }).toThrow()
+
+    {
+        // a node created on a generator function of the exact same type
+        const RowArray = types.array(Row)
+        const Factory = types.model("Factory", {
+            rows: types.optional(RowArray, () => RowArray.create())
+        })
+        const doc = Factory.create()
+        expect(getSnapshot(doc)).toEqual({ rows: [] })
+    }
 })

--- a/packages/mobx-state-tree/__tests__/core/optional.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/optional.test.ts
@@ -106,13 +106,19 @@ test("an instance is not a valid default value, snapshot or function that create
     )
 
     // an alike node but created from a different yet equivalent type
-    expect(() => {
+    const e = expect(() => {
         const Factory = types.model({
             rows: types.optional(types.array(Row), () => types.array(Row).create())
         })
         // we need to create the node for it to throw, since generator functions are typechecked when nodes are created
+        // tslint:disable-next-line:no-unused-expression
         Factory.create()
-    }).toThrow()
+    })
+    if (process.env.NODE_ENV === "production") {
+        e.not.toThrow()
+    } else {
+        e.toThrow("Error while converting <> to `Row[]`")
+    }
 
     {
         // a node created on a generator function of the exact same type

--- a/packages/mobx-state-tree/src/core/type/type-checker.ts
+++ b/packages/mobx-state-tree/src/core/type/type-checker.ts
@@ -6,7 +6,8 @@ import {
     isStateTreeNode,
     isPrimitiveType,
     IAnyType,
-    CoreType
+    CoreType,
+    IType
 } from "../../internal"
 
 export interface IContextEntry {
@@ -141,7 +142,7 @@ export function flattenTypeErrors(errors: IValidationResult[]): IValidationResul
  * @internal
  * @private
  */
-export function typecheckInternal(type: IAnyType, value: any): void {
+export function typecheckInternal<C, S, T>(type: IType<C, S, T>, value: C | S | T): void {
     // if not in dev-mode, do not even try to run typecheck. Everything is developer fault!
     if (process.env.NODE_ENV === "production") return
     typecheck(type, value)
@@ -156,7 +157,7 @@ export function typecheckInternal(type: IAnyType, value: any): void {
  * @param {IAnyType} type
  * @param {*} value
  */
-export function typecheck(type: IAnyType, value: any): void {
+export function typecheck<C, S, T>(type: IType<C, S, T>, value: C | S | T): void {
     const errors = type.validate(value, [{ path: "", type }])
 
     if (errors.length > 0) {

--- a/packages/mobx-state-tree/src/types/utility-types/optional.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/optional.ts
@@ -70,7 +70,7 @@ export class OptionalValue<C, S, T> extends Type<C, S, T> {
         )
     }
 
-    public getDefaultInstanceOrSnapshot() {
+    getDefaultInstanceOrSnapshot() {
         const defaultInstanceOrSnapshot =
             typeof this.defaultValue === "function" ? this.defaultValue() : this.defaultValue
 
@@ -81,6 +81,13 @@ export class OptionalValue<C, S, T> extends Type<C, S, T> {
         }
 
         return defaultInstanceOrSnapshot
+    }
+
+    public getDefaultValueSnapshot() {
+        const instanceOrSnapshot = this.getDefaultInstanceOrSnapshot()
+        return isStateTreeNode(instanceOrSnapshot)
+            ? getStateTreeNode(instanceOrSnapshot).snapshot
+            : instanceOrSnapshot
     }
 
     isValidSnapshot(value: any, context: IContext): IValidationResult {

--- a/packages/mobx-state-tree/src/types/utility-types/optional.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/optional.ts
@@ -15,7 +15,6 @@ import {
     IComplexType,
     OptionalProperty
 } from "../../internal"
-import { getSnapshot } from "../.."
 
 /**
  * @internal


### PR DESCRIPTION
- Throws if an instance is passed as default value for types.optional (not if a function is passed and an instance is generated there though) - implements https://github.com/mobxjs/mobx-state-tree/issues/1002 (read the last comment on thoughts about this though)

- Improves typescript types.optional typing
- Fixed an issue where when a function was used to create an instance inside types.optional it would typecheck the instance (and in some cases fail) rather than the instance snapshot
- Reconciliation algorithm for default values will use the snapshot rather than the instance