### PR TITLE
add docs re: optional map / array types of #906

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,6 +892,8 @@ These are the types available in MST. All types can be found in the `types` name
 -   `types.array(type)` Declares an array of the specified type.
 -   `types.map(type)` Declares a map of the specified type.
 
+When used in a model type as property type, `types.array` and `types.map` will be wrapped in `types.optional` by default, with `[]` and `{}` set as their default values, respectively.
+
 ## Primitive types
 
 -   `types.string`

--- a/README.md
+++ b/README.md
@@ -892,7 +892,7 @@ These are the types available in MST. All types can be found in the `types` name
 -   `types.array(type)` Declares an array of the specified type.
 -   `types.map(type)` Declares a map of the specified type.
 
-When used in a model type as property type, `types.array` and `types.map` will be wrapped in `types.optional` by default, with `[]` and `{}` set as their default values, respectively.
+Note that since MST v3 `types.array` and `types.map` are wrapped in `types.optional` by default, with `[]` and `{}` set as their default values, respectively.
 
 ## Primitive types
 


### PR DESCRIPTION
- a8c7c60 implemented this but did not change the docs

My literal process without first knowing these were optional:
When I was writing a few models, I first wrote `types.array` without `types.optional`, then came back like "oh sh*t, don't I need to wrap these in `types.optional`?". Looked at the docs, didn't see anything about them being optional by default, and then re-wrote them all as `types.optional(types.array(...), [])`. Then I did a search and found the answer in #906 and the changelog 😅

Figure these should be documented and explicit so someone in the future can save themselves that triple-checking haha.


P.S. I finally got around to using MST after hyping it up on Twitter for a while :) Some of the advanced usage in the docs took a bit to wrap my head around, but was very intuitive / straightforward once I just started writing code, with gotchas like `flow` documented well. This was one of the only things not explicitly answered in the docs (another might be usage of `getSnapshot` vs. `toJS`)