### PR TITLE
Better flow typing for ts3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
         "prettier": "^1.13.6",
         "tslint": "^5.0.0",
         "tslint-config-prettier": "^1.14.0",
-        "typescript": "^2.9.2"
+        "typescript": "^3.0.0"
     }
 }

--- a/packages/mobx-state-tree/__tests__/core/async.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/async.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../../src"
 import { reaction, configure } from "mobx"
 
-function delay(time: number, value: any, shouldThrow = false) {
+function delay<TV>(time: number, value: TV, shouldThrow = false): Promise<TV> {
     return new Promise((resolve, reject) => {
         setTimeout(() => {
             if (shouldThrow) reject(value)
@@ -23,9 +23,11 @@ function delay(time: number, value: any, shouldThrow = false) {
 
 function testCoffeeTodo(
     done: () => void,
-    generator: any,
+    generator: (
+        self: any
+    ) => ((str: string) => IterableIterator<Promise<any> | string | undefined>),
     shouldError: boolean,
-    resultValue: any,
+    resultValue: string | undefined,
     producedCoffees: any[]
 ) {
     configure({ enforceActions: true })
@@ -34,7 +36,7 @@ function testCoffeeTodo(
             title: "get coffee"
         })
         .actions(self => ({
-            startFetch: flow(generator(self)) as (str: string) => Promise<string>
+            startFetch: flow(generator(self))
         }))
     const events: IMiddlewareEvent[] = []
     const coffees: any[] = []
@@ -44,7 +46,7 @@ function testCoffeeTodo(
         return next(c)
     })
     reaction(() => t1.title, coffee => coffees.push(coffee))
-    function handleResult(res: any) {
+    function handleResult(res: string | undefined) {
         expect(res).toBe(resultValue)
         expect(coffees).toEqual(producedCoffees)
         const filtered = filterRelevantStuff(events)
@@ -89,7 +91,7 @@ test("flow happens in single ticks", done => {
 test("can handle async actions", done => {
     testCoffeeTodo(
         done,
-        (self: any) =>
+        self =>
             function* fetchData(kind: string) {
                 self.title = "getting coffee " + kind
                 self.title = yield delay(100, "drinking coffee")
@@ -103,8 +105,8 @@ test("can handle async actions", done => {
 test("can handle erroring actions", done => {
     testCoffeeTodo(
         done,
-        (self: any) =>
-            function* fetchData(kind: string): IterableIterator<any> {
+        () =>
+            function* fetchData(kind: string): IterableIterator<never> {
                 throw kind
             },
         true,
@@ -115,8 +117,8 @@ test("can handle erroring actions", done => {
 test("can handle try catch", t => {
     testCoffeeTodo(
         t,
-        (self: any) =>
-            function* fetchData(kind: string): IterableIterator<any> {
+        self =>
+            function* fetchData(kind: string) {
                 try {
                     yield delay(10, "tea", true)
                 } catch (e) {
@@ -132,7 +134,7 @@ test("can handle try catch", t => {
 test("empty sequence works", t => {
     testCoffeeTodo(
         t,
-        (self: any) => function* fetchData(kind: string): IterableIterator<any> {},
+        () => function* fetchData(kind: string): IterableIterator<undefined> {},
         false,
         undefined,
         []
@@ -141,8 +143,8 @@ test("empty sequence works", t => {
 test("can handle throw from yielded promise works", t => {
     testCoffeeTodo(
         t,
-        (self: any) =>
-            function* fetchData(kind: string): IterableIterator<any> {
+        () =>
+            function* fetchData(kind: string) {
                 yield delay(10, "x", true)
             },
         true,
@@ -153,7 +155,7 @@ test("can handle throw from yielded promise works", t => {
 test("typings", done => {
     const M = types.model({ title: types.string }).actions(self => {
         function* a(x: string) {
-            yield delay(10, "x", false)
+            const aa = yield delay(10, "x", false)
             self.title = "7"
             return 23
         }
@@ -166,8 +168,8 @@ test("typings", done => {
         return { a: flow(a), b }
     })
     const m1 = M.create({ title: "test " })
-    const resA = m1.a("z") // Arg typings are correct. TODO: Result is correctly promise, but incorrect generic arg
-    const resB = m1.b("z") // Arg typings are correct, TODO: Result is correctly promise, but incorrect generic arg
+    const resA = m1.a("z")
+    const resB = m1.b("z")
     Promise.all([resA, resB]).then(([x1, x2]) => {
         expect(x1).toBe(23)
         expect(x2).toBe(24)
@@ -190,8 +192,8 @@ test("typings", done => {
         return { a: flow(a), b }
     })
     const m1 = M.create({ title: "test " })
-    const resA = m1.a("z") // Arg typings are correct. TODO: Result is correctly promise, but incorrect generic arg
-    const resB = m1.b("z") // Arg typings are correct, TODO: Result is correctly promise, but incorrect generic arg
+    const resA = m1.a("z")
+    const resB = m1.b("z")
     Promise.all([resA, resB]).then(([x1, x2]) => {
         expect(x1).toBe(23)
         expect(x2).toBe(24)
@@ -241,7 +243,7 @@ test("can handle nested async actions", t => {
     })
     testCoffeeTodo(
         t,
-        (self: any) =>
+        self =>
             function* fetchData(kind: string) {
                 self.title = yield uppercase("drinking " + kind)
                 return self.title
@@ -290,7 +292,7 @@ test("flow gain back control when node become not alive during yield", async () 
     const MyModel = types.model({}).actions(() => {
         return {
             doAction() {
-                return flow<void>(function*() {
+                return flow(function*() {
                     try {
                         yield delay(20, "").then(() => Promise.reject(rejectError))
                     } catch (e) {
@@ -312,8 +314,8 @@ test("flow gain back control when node become not alive during yield", async () 
     }
 })
 
-function filterRelevantStuff(stuff: any) {
-    return stuff.map((x: any) => {
+function filterRelevantStuff(stuff: IMiddlewareEvent[]) {
+    return stuff.map(x => {
         delete x.context
         delete x.tree
         return x

--- a/packages/mobx-state-tree/__tests__/core/deprecated.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/deprecated.test.ts
@@ -22,7 +22,7 @@ function createDeprecationListener() {
 }
 test("`process` should mirror `flow`", () => {
     const isDeprecated = createDeprecationListener()
-    const generator = function*(): IterableIterator<any> {}
+    const generator = function*(): IterableIterator<void> {}
     const flowResult = flow(generator)
     const processResult = mstProcess(generator)
     expect(processResult.name).toBe(flowResult.name)
@@ -31,7 +31,7 @@ test("`process` should mirror `flow`", () => {
 test("`createProcessSpawner` should mirror `createFlowSpawner`", () => {
     const isDeprecated = createDeprecationListener()
     const alias = "generatorAlias"
-    const generator = function*(): IterableIterator<any> {}
+    const generator = function*(): IterableIterator<void> {}
     const flowSpawnerResult = createFlowSpawner(alias, generator)
     const processSpawnerResult = createProcessSpawner(alias, generator)
     expect(processSpawnerResult.name).toBe(flowSpawnerResult.name)

--- a/packages/mobx-state-tree/package.json
+++ b/packages/mobx-state-tree/package.json
@@ -56,7 +56,7 @@
         "ts-jest": "^23.0.1",
         "ts-node": "^7.0.0",
         "tslib": "^1.7.1",
-        "typescript": "^2.9.2"
+        "typescript": "^3.0.0"
     },
     "peerDependencies": {
         "mobx": "^4.3.1 || ^5.0.3"

--- a/packages/mobx-state-tree/src/core/flow.ts
+++ b/packages/mobx-state-tree/src/core/flow.ts
@@ -1,37 +1,14 @@
-// based on: https://github.com/mobxjs/mobx-utils/blob/master/src/async-action.ts
+export interface FlowStep {
+    // fake, only for typing
+    "!!flowStep": undefined
+}
 
-export function flow<R>(generator: () => IterableIterator<any>): () => Promise<R>
-export function flow<A1>(generator: (a1: A1) => IterableIterator<any>): (a1: A1) => Promise<any> // Ideally we want to have R instead of Any, but cannot specify R without specifying A1 etc... 'any' as result is better then not specifying request args
-export function flow<A1, A2>(
-    generator: (a1: A1, a2: A2) => IterableIterator<any>
-): (a1: A1, a2: A2) => Promise<any>
-export function flow<A1, A2, A3>(
-    generator: (a1: A1, a2: A2, a3: A3) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3) => Promise<any>
-export function flow<A1, A2, A3, A4>(
-    generator: (a1: A1, a2: A2, a3: A3, a4: A4) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4) => Promise<any>
-export function flow<A1, A2, A3, A4, A5>(
-    generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => Promise<any>
-export function flow<A1, A2, A3, A4, A5, A6>(
-    generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => Promise<any>
-export function flow<A1, A2, A3, A4, A5, A6, A7>(
-    generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7) => Promise<any>
-export function flow<A1, A2, A3, A4, A5, A6, A7, A8>(
-    generator: (
-        a1: A1,
-        a2: A2,
-        a3: A3,
-        a4: A4,
-        a5: A5,
-        a6: A6,
-        a7: A7,
-        a8: A8
-    ) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8) => Promise<any>
+// we skip promises that are the result of yielding promises
+export type FlowReturnType<R> = FlowStepOnlyToVoid<R extends Promise<any> ? FlowStep : R>
+
+// we extract yielded promises from the return type
+export type FlowStepOnlyToVoid<R> = Exclude<R, FlowStep> extends never ? void : Exclude<R, FlowStep>
+
 /**
  * See [asynchronous actions](https://github.com/mobxjs/mobx-state-tree/blob/master/docs/async-actions.md).
  *
@@ -39,8 +16,10 @@ export function flow<A1, A2, A3, A4, A5, A6, A7, A8>(
  * @alias flow
  * @returns {Promise}
  */
-export function flow(asyncAction: any): any {
-    return createFlowSpawner(asyncAction.name, asyncAction)
+export function flow<R, Args extends any[]>(
+    generator: (...args: Args) => IterableIterator<R>
+): (...args: Args) => Promise<FlowReturnType<R>> {
+    return createFlowSpawner(generator.name, generator) as any
 }
 
 /**

--- a/packages/mst-middlewares/package.json
+++ b/packages/mst-middlewares/package.json
@@ -30,7 +30,7 @@
         "rollup-plugin-node-resolve": "^3.0.0",
         "rollup-plugin-uglify": "^5.0.0",
         "ts-jest": "^23.0.1",
-        "typescript": "^2.9.2"
+        "typescript": "^3.0.0"
     },
     "peerDependencies": {
         "mobx-state-tree": "^3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7287,9 +7287,9 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+typescript@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
Better flow typings, but require Typescript 3

Arguments are now properly inferred, and return types are chosen like this:

```
// this gives as definition: () => Promise<5>
flow(function*() {
  yield somePromise // this adds a Promise<any> return type, which will be ignored
  yield somePromise2 // this adds a Promise<any> return type, which will be ignored
  return 5; // this is the actual type that will be returned
}
```

```
// this gives as definition: () => Promise<void>
flow(function*() {
  // why?
  yield somePromise // this adds a Promise<any> return type, which will be ignored
  yield somePromise2 // this adds a Promise<any> return type, which will be ignored
  // since nothing is returned, it is transformed into void
}
```

A couple of caveats still exist though:
- if a Promise is actually returned as final value for the flow it will be inferred as return type void
- const a = yield somePromiseThatReturnsANumber // a will be any, know TS issue, see https://github.com/Microsoft/TypeScript/issues/2983
  - maybe could be fixed by using async function generators rather than just plain generators? (see https://jakearchibald.com/2017/async-iterators-and-generators/ - Async generators: Creating your own async iterator)
