### PR TITLE
better fix for cast in ts 3.1.1

### DIFF
--- a/API.md
+++ b/API.md
@@ -300,7 +300,7 @@ Casts a node snapshot or instance type to an instance type so it can be assigned
 Alternatively also casts a node snapshot or instance to an snapshot type so it can be assigned to a type snapshot.
 Note that this is just a cast for the type system, this is, it won't actually convert a snapshot to an instance
 (or vice-versa), but just fool typescript into thinking so.
-Casting only works on assignation operations, it won't work (compile) stand-alone.
+Either way, casting when outside an assignation operation will only yield an unusable type (never).
 
 ### Parameters
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# next
+
+-   Fix for cast method being broken in Typescript 3.1.1 through [#1028](https://github.com/mobxjs/mobx-state-tree/pull/1028) by [@xaviergonz](https://github.com/xaviergonz)
+
 # 3.4.0
 
 -   Added getPropertyMembers(typeOrNode) through [#1016](https://github.com/mobxjs/mobx-state-tree/pull/1016) by [@xaviergonz](https://github.com/xaviergonz)

--- a/packages/mobx-state-tree/__tests__/core/type-system.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/type-system.test.ts
@@ -768,14 +768,13 @@ test("cast and SnapshotOrInstance", () => {
     unprotect(map)
     map.set("a", cast({ n2: 5 })) // not really needed in this case, but whatever :)
 
-    // and the best part, it actually doesn't work outside assignments :DDDD
-    // all this fails to compile
-    // cast([])
-    // cast({a:5})
-    // cast(NumberArray.create([]))
-    // cast(A.create({n2: 5}))
-    // cast({a: 2, b: 5})
-    // cast(NumberMap({a: 2, b: 3}))
+    // although this compiles, it yields a never type
+    cast([])
+    cast({ a: 5 })
+    cast(NumberArray.create([]))
+    cast(A.create({ n2: 5 }))
+    cast({ a: 2, b: 5 })
+    cast(NumberMap.create({ a: 2, b: 3 }))
 })
 
 test("#994", () => {

--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -842,7 +842,7 @@ export type CastedType<T> = T extends IStateTreeNode<infer C> ? C | T : T
  * Alternatively also casts a node snapshot or instance to an snapshot type so it can be assigned to a type snapshot.
  * Note that this is just a cast for the type system, this is, it won't actually convert a snapshot to an instance
  * (or vice-versa), but just fool typescript into thinking so.
- * Casting only works on assignation operations, it won't work (compile) stand-alone.
+ * Either way, casting when outside an assignation operation will only yield an unusable type (never).
  *
  * @example
  * const ModelA = types.model({
@@ -866,6 +866,6 @@ export type CastedType<T> = T extends IStateTreeNode<infer C> ? C | T : T
  * @param {CastedType<T>} snapshotOrInstance
  * @returns {T}
  */
-export function cast<T = never>(snapshotOrInstance: CastedType<T>): T {
-    return snapshotOrInstance as T
+export function cast<T = never, C = CastedType<T>>(snapshotOrInstance: C): T {
+    return snapshotOrInstance as any
 }


### PR DESCRIPTION
Fixes cast being broken in Typescript 3.1.1

the only downside is that cast outside assignations will compile, yet it will yield an unusable "never" type