### PR TITLE
auto stalling of stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,23 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 10
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 4
+# Issues with these labels will never be considered stale
+exemptLabels:
+    - brainstorming/wild idea
+    - breaking change
+    - bug
+    - docs or examples
+    - enhancement
+    - has PR
+    - help/PR welcome
+    - require('@mweststrate')
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity in the last 10 days. It will be closed in 4 days if no further
+    activity occurs. Thank you for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
I just created a config to auto-stale issues if they are inactive (blacklisting some labels of course)
For it to work it also requires the bot to be installed into the repository, I already made a request for it, but I don't have permissions to enable it.

The bot in question is: https://probot.github.io/apps/stale/