### PR TITLE
fix json path escaping +  empty key handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+-   Fixed JSON path escaping, where '/' and '~' were incorrectly being encoded/decoded as '~0' and '~1' rather than '~1' and '~0'. Also fixed empty keys not being handled correctly by JSON patches [#1128](https://github.com/mobxjs/mobx-state-tree/issues/1128). Fixed through [#1129](https://github.com/mobxjs/mobx-state-tree/pull/1129) by [@xaviergonz](https://github.com/xaviergonz)
+
 # 3.10.0
 
 -   Fix for safeReference doesn't work when multiple nodes reference a single reference that gets deleted [#1115](https://github.com/mobxjs/mobx-state-tree/issues/1115) through [#1121](https://github.com/mobxjs/mobx-state-tree/pull/1121) by [@xaviergonz](https://github.com/xaviergonz)

--- a/packages/mobx-state-tree/__tests__/core/identifier.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/identifier.test.ts
@@ -201,11 +201,6 @@ test("it can resolve through refrences", () => {
 
     expect(resolvePath(root, "/children/2/target/children/../children/./0").name).toBe("c")
 
-    // double // resets the path to root!
-    expect(resolvePath(root, "/children/0//children/2/target/children/../children/./0").name).toBe(
-        "c"
-    )
-
     expect(() => resolvePath(root, "/children/3/target/children/0").name).toThrow(
         "[mobx-state-tree] Failed to resolve reference 'e' to type 'Folder' (from node: /children/3/target)"
     )

--- a/packages/mobx-state-tree/src/core/json-patch.ts
+++ b/packages/mobx-state-tree/src/core/json-patch.ts
@@ -74,18 +74,19 @@ function isNumber(x: string): boolean {
  *
  * http://tools.ietf.org/html/rfc6901
  */
-export function escapeJsonPath(str: string): string {
-    if (isNumber(str) === true) {
-        return "" + str
+export function escapeJsonPath(path: string): string {
+    if (isNumber(path) === true) {
+        return "" + path
     }
-    return str.replace(/~/g, "~1").replace(/\//g, "~0")
+    if (path.indexOf("/") === -1 && path.indexOf("~") === -1) return path
+    return path.replace(/~/g, "~0").replace(/\//g, "~1")
 }
 
 /**
  * Unescape slashes and backslashes.
  */
-export function unescapeJsonPath(str: string): string {
-    return str.replace(/~0/g, "/").replace(/~1/g, "~")
+export function unescapeJsonPath(path: string): string {
+    return path.replace(/~1/g, "/").replace(/~0/g, "~")
 }
 
 /**

--- a/packages/mobx-state-tree/src/core/node/node-utils.ts
+++ b/packages/mobx-state-tree/src/core/node/node-utils.ts
@@ -134,20 +134,6 @@ export function getRelativePathBetweenNodes(base: ObjectNode, target: ObjectNode
  * @internal
  * @hidden
  */
-export function resolveNodeByPath(base: ObjectNode, pathParts: string): INode
-/**
- * @internal
- * @hidden
- */
-export function resolveNodeByPath(
-    base: ObjectNode,
-    pathParts: string,
-    failIfResolveFails: boolean
-): INode | undefined
-/**
- * @internal
- * @hidden
- */
 export function resolveNodeByPath(
     base: ObjectNode,
     path: string,
@@ -156,20 +142,6 @@ export function resolveNodeByPath(
     return resolveNodeByPathParts(base, splitJsonPath(path), failIfResolveFails)
 }
 
-/**
- * @internal
- * @hidden
- */
-export function resolveNodeByPathParts(base: ObjectNode, pathParts: string[]): INode
-/**
- * @internal
- * @hidden
- */
-export function resolveNodeByPathParts(
-    base: ObjectNode,
-    pathParts: string[],
-    failIfResolveFails: boolean
-): INode | undefined
 /**
  * @internal
  * @hidden
@@ -183,17 +155,22 @@ export function resolveNodeByPathParts(
     // note that `../` is not part of the JSON pointer spec, which is actually a prefix format
     // in json pointer: "" = current, "/a", attribute a, "/" is attribute "" etc...
     // so we treat leading ../ apart...
-    let current: INode | null = base
+    let current: INode | null
+
+    if (pathParts.length > 0 && (pathParts[0] === "." || pathParts[0] === "..")) {
+        // extension - relative path
+        current = base
+    } else {
+        // absolute path
+        current = base.root
+    }
+
     for (let i = 0; i < pathParts.length; i++) {
         const part = pathParts[i]
-        if (part === "") {
-            current = current!.root
-            continue
-        } else if (part === "..") {
+        if (part === "..") {
             current = current!.parent
             if (current) continue // not everything has a parent
-        } else if (part === "." || part === "") {
-            // '/bla' or 'a//b' splits to empty strings
+        } else if (part === ".") {
             continue
         } else if (current) {
             if (current instanceof ScalarNode) {

--- a/packages/mobx-state-tree/src/types/utility-types/reference.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/reference.ts
@@ -29,7 +29,8 @@ import {
     ReferenceIdentifier,
     normalizeIdentifier,
     getIdentifier,
-    applyPatch
+    applyPatch,
+    joinJsonPath
 } from "../../internal"
 
 export type OnReferenceInvalidatedEvent<STN extends IAnyStateTreeNode> = {
@@ -189,19 +190,19 @@ export abstract class BaseReferenceType<IT extends IAnyComplexType> extends Type
             invalidTarget: refTargetNode ? refTargetNode.storedValue : undefined,
             invalidId: referenceId,
             replaceRef(newRef) {
-                applyPatch(storedRefParentValue, {
+                applyPatch(storedRefNode.root.storedValue, {
                     op: "replace",
                     value: newRef,
-                    path: storedRefNode.subpath
+                    path: storedRefNode.path
                 })
             },
             removeRef() {
                 if (isModelType(storedRefParentNode.type)) {
                     this.replaceRef(undefined as any)
                 } else {
-                    applyPatch(storedRefParentValue, {
+                    applyPatch(storedRefNode.root.storedValue, {
                         op: "remove",
-                        path: storedRefNode.subpath
+                        path: storedRefNode.path
                     })
                 }
             }


### PR DESCRIPTION
Fixes #1128 

- Fixed JSON path escaping, where '/' and '~' were incorrectly being encoded/decoded as '~0' and '~1' rather than '~1' and '~0'. Also fixed empty keys not being handled correctly by JSON patches