### PR TITLE
Replace InstanceOf mention in @deprecation with Instance

### DIFF
--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -93,7 +93,7 @@ export interface IType<C, S, T> {
     describe(): string
 
     /**
-     * @deprecated use `InstanceOf` instead.
+     * @deprecated use `Instance` instead.
      * @hidden
      */
     Type: T


### PR DESCRIPTION
Probably was forgot there during type rename, as InstanceOf type doesn't exist.