### PR TITLE
Wrong API doc link for MST middleware

### DIFF
--- a/packages/mst-middlewares/README.md
+++ b/packages/mst-middlewares/README.md
@@ -11,7 +11,7 @@ import { MiddlewareName } from "mst-middlewares"
 
 The middlewares serve as example and are supported on a best effort bases. The goal of these middlewares is that if they are critical to your system, you can simply copy paste them and further tailor them towards your specific needs.
 
-For the exact description of all middleware events offered by MST, see the [api docs](../docs/middleware.md)
+For the exact description of all middleware events offered by MST, see the [api docs](../../docs/middleware.md)
 
 # Contributing
 


### PR DESCRIPTION
The API doc link to MST middleware seems to be broken, this should fix it