### PR TITLE
use throw fail rather than just fail to make typescript happier

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/object.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/object.test.ts
@@ -806,7 +806,7 @@ test("#993-1 - after attach should have a parent when accesing a reference direc
         })
         .actions(self => ({
             afterAttach() {
-                fail("should never be called")
+                throw fail("should never be called")
             }
         }))
 

--- a/packages/mobx-state-tree/src/core/action.ts
+++ b/packages/mobx-state-tree/src/core/action.ts
@@ -88,7 +88,7 @@ export function runWithActionContext(context: IMiddlewareEvent, fn: Function) {
  * @hidden
  */
 export function getActionContext(): IMiddlewareEvent {
-    if (!currentActionContext) return fail("Not running an action!")
+    if (!currentActionContext) throw fail("Not running an action!")
     return currentActionContext
 }
 
@@ -233,7 +233,7 @@ function runMiddleWares(node: ObjectNode, baseCall: IMiddlewareEvent, originalFn
             if (process.env.NODE_ENV !== "production") {
                 if (!nextInvoked && !abortInvoked) {
                     const node2 = getStateTreeNode(call.tree)
-                    fail(
+                    throw fail(
                         `Neither the next() nor the abort() callback within the middleware ${
                             handler.name
                         } for the action: "${call.name}" on the node: ${
@@ -243,7 +243,7 @@ function runMiddleWares(node: ObjectNode, baseCall: IMiddlewareEvent, originalFn
                 }
                 if (nextInvoked && abortInvoked) {
                     const node2 = getStateTreeNode(call.tree)
-                    fail(
+                    throw fail(
                         `The next() and abort() callback within the middleware ${
                             handler.name
                         } for the action: "${call.name}" on the node: ${

--- a/packages/mobx-state-tree/src/core/flow.ts
+++ b/packages/mobx-state-tree/src/core/flow.ts
@@ -142,7 +142,7 @@ export function createFlowSpawner(name: string, generator: Function) {
                 }
                 // TODO: support more type of values? See https://github.com/tj/co/blob/249bbdc72da24ae44076afd716349d2089b31c4c/index.js#L100
                 if (!ret.value || typeof ret.value.then !== "function")
-                    fail("Only promises can be yielded to `async`, got: " + ret)
+                    throw fail("Only promises can be yielded to `async`, got: " + ret)
                 return ret.value.then(onFulfilled, onRejected)
             }
         })

--- a/packages/mobx-state-tree/src/core/json-patch.ts
+++ b/packages/mobx-state-tree/src/core/json-patch.ts
@@ -19,7 +19,7 @@ export interface IReversibleJsonPatch extends IJsonPatch {
  * @hidden
  */
 export function splitPatch(patch: IReversibleJsonPatch): [IJsonPatch, IJsonPatch] {
-    if (!("oldValue" in patch)) fail(`Patches without \`oldValue\` field cannot be inversed`)
+    if (!("oldValue" in patch)) throw fail(`Patches without \`oldValue\` field cannot be inversed`)
     return [stripPatch(patch), invertPatch(patch)]
 }
 

--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -79,9 +79,11 @@ export function onPatch(
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
         if (typeof callback !== "function")
-            fail("expected second argument to be a function, got " + callback + " instead")
+            throw fail("expected second argument to be a function, got " + callback + " instead")
     }
     return getStateTreeNode(target).onPatch(callback)
 }
@@ -102,9 +104,11 @@ export function onSnapshot<S>(
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
         if (typeof callback !== "function")
-            fail("expected second argument to be a function, got " + callback + " instead")
+            throw fail("expected second argument to be a function, got " + callback + " instead")
     }
     return getStateTreeNode(target).onSnapshot(callback)
 }
@@ -122,13 +126,17 @@ export function onSnapshot<S>(
 export function applyPatch(
     target: IAnyStateTreeNode,
     patch: IJsonPatch | ReadonlyArray<IJsonPatch>
-) {
+): void {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
         if (typeof patch !== "object")
-            fail("expected second argument to be an object or array, got " + patch + " instead")
+            throw fail(
+                "expected second argument to be an object or array, got " + patch + " instead"
+            )
     }
     getStateTreeNode(target).applyPatches(asArray(patch))
 }
@@ -171,7 +179,7 @@ export function recordPatches(subject: IAnyStateTreeNode): IPatchRecorder {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(subject))
-            fail(
+            throw fail(
                 "expected first argument to be a mobx-state-tree node, got " + subject + " instead"
             )
     }
@@ -213,14 +221,16 @@ export function recordPatches(subject: IAnyStateTreeNode): IPatchRecorder {
  *
  * @param {IStateTreeNode} target
  */
-export function protect(target: IAnyStateTreeNode) {
+export function protect(target: IAnyStateTreeNode): void {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
     }
     const node = getStateTreeNode(target)
-    if (!node.isRoot) fail("`protect` can only be invoked on root nodes")
+    if (!node.isRoot) throw fail("`protect` can only be invoked on root nodes")
     node.isProtectionEnabled = true
 }
 
@@ -248,14 +258,16 @@ export function protect(target: IAnyStateTreeNode) {
  * todo.done = false // OK
  * ```
  */
-export function unprotect(target: IAnyStateTreeNode) {
+export function unprotect(target: IAnyStateTreeNode): void {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
     }
     const node = getStateTreeNode(target)
-    if (!node.isRoot) fail("`unprotect` can only be invoked on root nodes")
+    if (!node.isRoot) throw fail("`unprotect` can only be invoked on root nodes")
     node.isProtectionEnabled = false
 }
 
@@ -277,7 +289,9 @@ export function applySnapshot<C>(target: IStateTreeNode<C, any>, snapshot: C) {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
     }
     return getStateTreeNode(target).applySnapshot(snapshot)
 }
@@ -294,7 +308,9 @@ export function getSnapshot<S>(target: IStateTreeNode<any, S>, applyPostProcess 
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
     }
     const node = getStateTreeNode(target)
     if (applyPostProcess) return node.snapshot
@@ -313,10 +329,12 @@ export function hasParent(target: IAnyStateTreeNode, depth: number = 1): boolean
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
         if (typeof depth !== "number")
-            fail("expected second argument to be a number, got " + depth + " instead")
-        if (depth < 0) fail(`Invalid depth: ${depth}, should be >= 1`)
+            throw fail("expected second argument to be a number, got " + depth + " instead")
+        if (depth < 0) throw fail(`Invalid depth: ${depth}, should be >= 1`)
     }
     let parent: INode | null = getStateTreeNode(target).parent
     while (parent) {
@@ -346,10 +364,12 @@ export function getParent<IT extends IAnyStateTreeNode | IAnyType>(
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
         if (typeof depth !== "number")
-            fail("expected second argument to be a number, got " + depth + " instead")
-        if (depth < 0) fail(`Invalid depth: ${depth}, should be >= 1`)
+            throw fail("expected second argument to be a number, got " + depth + " instead")
+        if (depth < 0) throw fail(`Invalid depth: ${depth}, should be >= 1`)
     }
     let d = depth
     let parent: INode | null = getStateTreeNode(target).parent
@@ -357,7 +377,7 @@ export function getParent<IT extends IAnyStateTreeNode | IAnyType>(
         if (--d === 0) return parent.storedValue
         parent = parent.parent
     }
-    return fail(`Failed to find the parent of ${getStateTreeNode(target)} at depth ${depth}`)
+    throw fail(`Failed to find the parent of ${getStateTreeNode(target)} at depth ${depth}`)
 }
 
 /**
@@ -371,9 +391,13 @@ export function hasParentOfType(target: IAnyStateTreeNode, type: IAnyType): bool
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
         if (!isType(type))
-            fail("expected second argument to be a mobx-state-tree type, got " + type + " instead")
+            throw fail(
+                "expected second argument to be a mobx-state-tree type, got " + type + " instead"
+            )
     }
     let parent: INode | null = getStateTreeNode(target).parent
     while (parent) {
@@ -397,9 +421,13 @@ export function getParentOfType<IT extends IAnyType>(
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
         if (!isType(type))
-            fail("expected second argument to be a mobx-state-tree type, got " + type + " instead")
+            throw fail(
+                "expected second argument to be a mobx-state-tree type, got " + type + " instead"
+            )
     }
 
     let parent: INode | null = getStateTreeNode(target).parent
@@ -407,7 +435,7 @@ export function getParentOfType<IT extends IAnyType>(
         if (type.is(parent.storedValue)) return parent.storedValue
         parent = parent.parent
     }
-    return fail(`Failed to find the parent of ${getStateTreeNode(target)} of a given type`)
+    throw fail(`Failed to find the parent of ${getStateTreeNode(target)} of a given type`)
 }
 
 /**
@@ -425,7 +453,9 @@ export function getRoot<IT extends IAnyType | IAnyStateTreeNode>(
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
     }
     return getStateTreeNode(target).root.storedValue
 }
@@ -440,7 +470,9 @@ export function getPath(target: IAnyStateTreeNode): string {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
     }
     return getStateTreeNode(target).path
 }
@@ -455,7 +487,9 @@ export function getPathParts(target: IAnyStateTreeNode): string[] {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
     }
     return splitJsonPath(getStateTreeNode(target).path)
 }
@@ -470,7 +504,9 @@ export function isRoot(target: IAnyStateTreeNode): boolean {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
     }
     return getStateTreeNode(target).isRoot
 }
@@ -487,9 +523,11 @@ export function resolvePath(target: IAnyStateTreeNode, path: string): any {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
         if (typeof path !== "string")
-            fail("expected second argument to be a number, got " + path + " instead")
+            throw fail("expected second argument to be a number, got " + path + " instead")
     }
     const node = resolveNodeByPath(getStateTreeNode(target), path)
     return node ? node.value : undefined
@@ -512,13 +550,17 @@ export function resolveIdentifier<IT extends IAnyType>(
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isType(type))
-            fail("expected first argument to be a mobx-state-tree type, got " + type + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree type, got " + type + " instead"
+            )
         if (!isStateTreeNode(target))
-            fail(
+            throw fail(
                 "expected second argument to be a mobx-state-tree node, got " + target + " instead"
             )
         if (!(typeof identifier === "string" || typeof identifier === "number"))
-            fail("expected third argument to be a string or number, got " + identifier + " instead")
+            throw fail(
+                "expected third argument to be a string or number, got " + identifier + " instead"
+            )
     }
     const node = getStateTreeNode(target).root.identifierCache!.resolve(
         type,
@@ -539,7 +581,9 @@ export function getIdentifier(target: IAnyStateTreeNode): string | null {
 
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
     }
 
     return getStateTreeNode(target).identifier
@@ -568,7 +612,7 @@ export function tryReference<N extends IAnyStateTreeNode>(
                 return isAlive(node) ? node : undefined
             }
         } else {
-            return fail("The reference to be checked is not one of node, null or undefined")
+            throw fail("The reference to be checked is not one of node, null or undefined")
         }
     } catch (e) {
         if (e instanceof InvalidReferenceError) {
@@ -596,7 +640,7 @@ export function isValidReference<N extends IAnyStateTreeNode>(
         } else if (isStateTreeNode(node)) {
             return checkIfAlive ? isAlive(node) : true
         } else {
-            return fail("The reference to be checked is not one of node, null or undefined")
+            throw fail("The reference to be checked is not one of node, null or undefined")
         }
     } catch (e) {
         if (e instanceof InvalidReferenceError) {
@@ -617,9 +661,11 @@ export function tryResolve(target: IAnyStateTreeNode, path: string): any {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
         if (typeof path !== "string")
-            fail("expected second argument to be a string, got " + path + " instead")
+            throw fail("expected second argument to be a string, got " + path + " instead")
     }
     const node = resolveNodeByPath(getStateTreeNode(target), path, false)
     if (node === undefined) return undefined
@@ -644,12 +690,14 @@ export function getRelativePath(base: IAnyStateTreeNode, target: IAnyStateTreeNo
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail(
+            throw fail(
                 "expected second argument to be a mobx-state-tree node, got " + target + " instead"
             )
 
         if (!isStateTreeNode(base))
-            fail("expected first argument to be a mobx-state-tree node, got " + base + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + base + " instead"
+            )
     }
     return getRelativePathBetweenNodes(getStateTreeNode(base), getStateTreeNode(target))
 }
@@ -671,7 +719,9 @@ export function clone<T extends IAnyStateTreeNode>(
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(source))
-            fail("expected first argument to be a mobx-state-tree node, got " + source + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + source + " instead"
+            )
     }
     const node = getStateTreeNode(source)
     return node.type.create(
@@ -691,7 +741,9 @@ export function detach<T extends IAnyStateTreeNode>(target: T): T {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
     }
     getStateTreeNode(target).detach()
     return target
@@ -700,11 +752,13 @@ export function detach<T extends IAnyStateTreeNode>(target: T): T {
 /**
  * Removes a model element from the state tree, and mark it as end-of-life; the element should not be used anymore
  */
-export function destroy(target: IAnyStateTreeNode) {
+export function destroy(target: IAnyStateTreeNode): void {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
     }
     const node = getStateTreeNode(target)
     if (node.isRoot) node.die()
@@ -724,7 +778,9 @@ export function isAlive(target: IAnyStateTreeNode): boolean {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
     }
     return getStateTreeNode(target).observableIsAlive
 }
@@ -757,13 +813,15 @@ export function isAlive(target: IAnyStateTreeNode): boolean {
  * @param disposer
  * @returns The same disposer that was passed as argument
  */
-export function addDisposer(target: IAnyStateTreeNode, disposer: () => void): (() => void) {
+export function addDisposer(target: IAnyStateTreeNode, disposer: () => void): () => void {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
         if (typeof disposer !== "function")
-            fail("expected second argument to be a function, got " + disposer + " instead")
+            throw fail("expected second argument to be a function, got " + disposer + " instead")
     }
     const node = getStateTreeNode(target)
     node.addDisposer(disposer)
@@ -786,7 +844,9 @@ export function getEnv<T = any>(target: IAnyStateTreeNode): T {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
     }
     const node = getStateTreeNode(target)
     const env = node.root.environment
@@ -797,13 +857,18 @@ export function getEnv<T = any>(target: IAnyStateTreeNode): T {
 /**
  * Performs a depth first walk through a tree.
  */
-export function walk(target: IAnyStateTreeNode, processor: (item: IAnyStateTreeNode) => void) {
+export function walk(
+    target: IAnyStateTreeNode,
+    processor: (item: IAnyStateTreeNode) => void
+): void {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
         if (typeof processor !== "function")
-            fail("expected second argument to be a function, got " + processor + " instead")
+            throw fail("expected second argument to be a function, got " + processor + " instead")
     }
     const node = getStateTreeNode(target)
     // tslint:disable-next-line:no_unused-variable
@@ -836,7 +901,7 @@ export function getPropertyMembers(
     }
 
     if (process.env.NODE_ENV !== "production") {
-        if (!isModelType(type)) fail("expected a model type, but got " + type + " instead.")
+        if (!isModelType(type)) throw fail("expected a model type, but got " + type + " instead.")
     }
 
     return {

--- a/packages/mobx-state-tree/src/core/node/create-node.ts
+++ b/packages/mobx-state-tree/src/core/node/create-node.ts
@@ -18,7 +18,7 @@ export function createNode<C, S, T>(
             return existingNode
         }
 
-        fail(
+        throw fail(
             `Cannot add an object to a state tree if it is already part of the same or another state tree. Tried to assign an object to '${
                 parent ? parent.path : ""
             }/${subpath}', but it lives already at '${existingNode.path}'`

--- a/packages/mobx-state-tree/src/core/node/identifier-cache.ts
+++ b/packages/mobx-state-tree/src/core/node/identifier-cache.ts
@@ -30,14 +30,14 @@ export class IdentifierCache {
         return `${this.cacheId}-${modificationId}`
     }
 
-    addNodeToCache(node: ObjectNode, lastCacheUpdate = true) {
+    addNodeToCache(node: ObjectNode, lastCacheUpdate = true): void {
         if (node.identifierAttribute) {
             const identifier = node.identifier!
             if (!this.cache.has(identifier)) {
                 this.cache.set(identifier, observable.array<ObjectNode>([], mobxShallow))
             }
             const set = this.cache.get(identifier)!
-            if (set.indexOf(node) !== -1) fail(`Already registered`)
+            if (set.indexOf(node) !== -1) throw fail(`Already registered`)
             set.push(node)
             if (lastCacheUpdate) {
                 this.updateLastCacheModificationPerId(identifier)
@@ -103,7 +103,7 @@ export class IdentifierCache {
             case 1:
                 return matches[0]
             default:
-                return fail(
+                throw fail(
                     `Cannot resolve a reference to type '${
                         type.name
                     }' with id: '${identifier}' unambigously, there are multiple candidates: ${matches

--- a/packages/mobx-state-tree/src/core/node/node-utils.ts
+++ b/packages/mobx-state-tree/src/core/node/node-utils.ts
@@ -69,7 +69,7 @@ export function isStateTreeNode<C = any, S = any>(value: any): value is IStateTr
  */
 export function getStateTreeNode(value: IAnyStateTreeNode): ObjectNode {
     if (isStateTreeNode(value)) return value.$treenode!
-    else return fail(`Value ${value} is no MST Node`)
+    else throw fail(`Value ${value} is no MST Node`)
 }
 
 /**
@@ -111,7 +111,7 @@ const doubleDot = (_: any) => ".."
 export function getRelativePathBetweenNodes(base: ObjectNode, target: ObjectNode): string {
     // PRE condition target is (a child of) base!
     if (base.root !== target.root)
-        fail(
+        throw fail(
             `Cannot calculate relative path: objects '${base}' and '${target}' are not part of the same object tree`
         )
 
@@ -198,7 +198,7 @@ export function resolveNodeByPathParts(
             }
         }
         if (failIfResolveFails)
-            return fail(
+            throw fail(
                 `Could not resolve '${part}' in path '${joinJsonPath(pathParts.slice(0, i)) ||
                     "/"}' while resolving '${joinJsonPath(pathParts)}'`
             )

--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -139,7 +139,7 @@ export class ObjectNode extends BaseNode {
             }
 
             if (typeof id !== "string" && typeof id !== "number") {
-                fail(
+                throw fail(
                     `Instance identifier '${this.identifierAttribute}' for type '${
                         this.type.name
                     }' must be a string or a number`
@@ -225,18 +225,18 @@ export class ObjectNode extends BaseNode {
         return parent ? parent.root : this
     }
 
-    setParent(newParent: ObjectNode | null, subpath: string | null = null) {
+    setParent(newParent: ObjectNode | null, subpath: string | null = null): void {
         if (this.parent === newParent && this.subpath === subpath) return
         if (newParent && process.env.NODE_ENV !== "production") {
             if (this.parent && newParent !== this.parent) {
-                fail(
+                throw fail(
                     `A node cannot exists twice in the state tree. Failed to add ${this} to path '${
                         newParent.path
                     }/${subpath}'.`
                 )
             }
             if (!this.parent && newParent.root === this) {
-                fail(
+                throw fail(
                     `A state tree is not allowed to contain itself. Cannot assign ${this} to path '${
                         newParent.path
                     }/${subpath}'`
@@ -247,7 +247,7 @@ export class ObjectNode extends BaseNode {
                 !!this.root.environment &&
                 this.root.environment !== newParent.root.environment
             ) {
-                fail(
+                throw fail(
                     `A state tree cannot be made part of another state tree as long as their environments are different.`
                 )
             }
@@ -335,7 +335,7 @@ export class ObjectNode extends BaseNode {
 
             switch (getLivelinessChecking()) {
                 case "error":
-                    return fail(error)
+                    throw fail(error)
                 case "warn":
                     warnError(error)
             }
@@ -374,10 +374,10 @@ export class ObjectNode extends BaseNode {
         return this.root.isProtectionEnabled
     }
 
-    assertWritable() {
+    assertWritable(): void {
         this.assertAlive()
         if (!this.isRunningAction() && this.isProtected) {
-            fail(
+            throw fail(
                 `Cannot modify '${this}', the object is protected and can only be modified by using an action.`
             )
         }
@@ -412,8 +412,8 @@ export class ObjectNode extends BaseNode {
     }
 
     @action
-    detach() {
-        if (!this.isAlive) fail(`Error while detaching, node is not alive.`)
+    detach(): void {
+        if (!this.isAlive) throw fail(`Error while detaching, node is not alive.`)
         if (this.isRoot) return
 
         this.fireHook(Hook.beforeDetach)
@@ -540,12 +540,12 @@ export class ObjectNode extends BaseNode {
             this._internalEvents.register(InternalEvents.Dispose, disposer, true)
             return
         }
-        fail("cannot add a disposer when it is already registered for execution")
+        throw fail("cannot add a disposer when it is already registered for execution")
     }
 
     removeDisposer(disposer: () => void): void {
         if (!this._internalEvents.has(InternalEvents.Dispose, disposer)) {
-            return fail("cannot remove a disposer which was never registered for execution")
+            throw fail("cannot remove a disposer which was never registered for execution")
         }
         this._internalEvents.unregister(InternalEvents.Dispose, disposer)
     }

--- a/packages/mobx-state-tree/src/core/node/scalar-node.ts
+++ b/packages/mobx-state-tree/src/core/node/scalar-node.ts
@@ -39,18 +39,18 @@ export class ScalarNode extends BaseNode {
 
     get root(): ObjectNode {
         // future optimization: store root ref in the node and maintain it
-        if (!this.parent) return fail(`This scalar node is not part of a tree`)
+        if (!this.parent) throw fail(`This scalar node is not part of a tree`)
         return this.parent.root
     }
 
-    setParent(newParent: ObjectNode | null, subpath: string | null = null) {
+    setParent(newParent: ObjectNode | null, subpath: string | null = null): void {
         if (this.parent === newParent && this.subpath === subpath) return
         if (this.parent && !newParent) {
             this.die()
         } else {
             const newPath = subpath === null ? "" : subpath
             if (newParent && newParent !== this.parent) {
-                fail("assertion failed: scalar nodes cannot change their parent")
+                throw fail("assertion failed: scalar nodes cannot change their parent")
             } else if (this.subpath !== newPath) {
                 this.baseSetParent(this.parent, newPath)
             }

--- a/packages/mobx-state-tree/src/core/type/type-checker.ts
+++ b/packages/mobx-state-tree/src/core/type/type-checker.ts
@@ -160,7 +160,7 @@ export function typecheck<C, S, T>(type: IType<C, S, T>, value: C | S | T): void
     const errors = type.validate(value, [{ path: "", type }])
 
     if (errors.length > 0) {
-        fail(
+        throw fail(
             `Error while converting ${shortenPrintValue(prettyPrintValue(value))} to \`${
                 type.name
             }\`:\n\n    ` + errors.map(toErrorString).join("\n    ")

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -399,17 +399,17 @@ export abstract class ComplexType<C, S, T> implements IType<C, S, T & IStateTree
     }
 
     get Type(): T {
-        return fail(
+        throw fail(
             "Factory.Type should not be actually called. It is just a Type signature that can be used at compile time with Typescript, by using `typeof type.Type`"
         )
     }
     get SnapshotType(): S {
-        return fail(
+        throw fail(
             "Factory.SnapshotType should not be actually called. It is just a Type signature that can be used at compile time with Typescript, by using `typeof type.SnapshotType`"
         )
     }
     get CreationType(): C {
-        return fail(
+        throw fail(
             "Factory.CreationType should not be actually called. It is just a Type signature that can be used at compile time with Typescript, by using `typeof type.CreationType`"
         )
     }
@@ -444,11 +444,11 @@ export abstract class Type<C, S, T> extends ComplexType<C, S, T> implements ITyp
     }
 
     applySnapshot(node: INode, snapshot: C): void {
-        fail("Immutable types do not support applying snapshots")
+        throw fail("Immutable types do not support applying snapshots")
     }
 
     applyPatchLocally(node: INode, subpath: string, patch: IJsonPatch): void {
-        fail("Immutable types do not support applying patches")
+        throw fail("Immutable types do not support applying patches")
     }
 
     getChildren(node: INode): INode[] {
@@ -456,11 +456,11 @@ export abstract class Type<C, S, T> extends ComplexType<C, S, T> implements ITyp
     }
 
     getChildNode(node: INode, key: string): INode {
-        return fail(`No child '${key}' available in type: ${this.name}`)
+        throw fail(`No child '${key}' available in type: ${this.name}`)
     }
 
     getChildType(key: string): IAnyType {
-        return fail(`No child '${key}' available in type: ${this.name}`)
+        throw fail(`No child '${key}' available in type: ${this.name}`)
     }
 
     reconcile(current: INode, newValue: any): INode {
@@ -472,7 +472,7 @@ export abstract class Type<C, S, T> extends ComplexType<C, S, T> implements ITyp
     }
 
     removeChild(node: INode, subpath: string): void {
-        return fail(`No child '${subpath}' available in type: ${this.name}`)
+        throw fail(`No child '${subpath}' available in type: ${this.name}`)
     }
 }
 

--- a/packages/mobx-state-tree/src/middlewares/on-action.ts
+++ b/packages/mobx-state-tree/src/middlewares/on-action.ts
@@ -84,9 +84,13 @@ export function applyAction(
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
         if (typeof actions !== "object")
-            fail("expected second argument to be an object or array, got " + actions + " instead")
+            throw fail(
+                "expected second argument to be an object or array, got " + actions + " instead"
+            )
     }
     runInAction(() => {
         asArray(actions).forEach(action => baseApplyAction(target, action))
@@ -95,7 +99,7 @@ export function applyAction(
 
 function baseApplyAction(target: IAnyStateTreeNode, action: ISerializedActionCall): any {
     const resolvedTarget = tryResolve(target, action.path || "")
-    if (!resolvedTarget) return fail(`Invalid action path: ${action.path || ""}`)
+    if (!resolvedTarget) throw fail(`Invalid action path: ${action.path || ""}`)
     const node = getStateTreeNode(resolvedTarget)
 
     // Reserved functions
@@ -107,7 +111,7 @@ function baseApplyAction(target: IAnyStateTreeNode, action: ISerializedActionCal
     }
 
     if (!(typeof resolvedTarget[action.name] === "function"))
-        fail(`Action '${action.name}' does not exist in '${node.path}'`)
+        throw fail(`Action '${action.name}' does not exist in '${node.path}'`)
     return resolvedTarget[action.name].apply(
         resolvedTarget,
         action.args ? action.args.map(v => deserializeArgument(node, v)) : []
@@ -137,7 +141,7 @@ export function recordActions(subject: IAnyStateTreeNode): IActionRecorder {
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(subject))
-            fail(
+            throw fail(
                 "expected first argument to be a mobx-state-tree node, got " + subject + " instead"
             )
     }
@@ -198,7 +202,9 @@ export function onAction(
     // check all arguments
     if (process.env.NODE_ENV !== "production") {
         if (!isStateTreeNode(target))
-            fail("expected first argument to be a mobx-state-tree node, got " + target + " instead")
+            throw fail(
+                "expected first argument to be a mobx-state-tree node, got " + target + " instead"
+            )
         if (!isRoot(target))
             warnError(
                 "Warning: Attaching onAction listeners to non root nodes is dangerous: No events will be emitted for actions initiated higher up in the tree."

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -130,7 +130,7 @@ export class ArrayType<IT extends IAnyType, C = ExtractC<IT>, S = ExtractS<IT>> 
     getChildNode(node: ObjectNode, key: string): INode {
         const index = parseInt(key, 10)
         if (index < node.storedValue.length) return node.storedValue[index]
-        return fail("Not a child: " + key)
+        throw fail("Not a child: " + key)
     }
 
     willChange(change: IArrayWillChange<any> | IArrayWillSplice<any>): Object | null {
@@ -306,7 +306,9 @@ export class ArrayType<IT extends IAnyType, C = ExtractC<IT>, S = ExtractS<IT>> 
 export function array<IT extends IAnyType>(subtype: IT): IArrayType<IT> {
     if (process.env.NODE_ENV !== "production") {
         if (!isType(subtype))
-            fail("expected a mobx-state-tree type as first argument, got " + subtype + " instead")
+            throw fail(
+                "expected a mobx-state-tree type as first argument, got " + subtype + " instead"
+            )
     }
     const ret = new ArrayType<IT>(subtype.name + "[]", subtype)
     return ret as typeof ret & OptionalProperty
@@ -348,7 +350,7 @@ function reconcileArrayChildren<T>(
             // check if already belongs to the same parent. if so, avoid pushing item in. only swapping can occur.
             if (isStateTreeNode(newValue) && getStateTreeNode(newValue).parent === parent) {
                 // this node is owned by this parent, but not in the reconcilable set, so it must be double
-                fail(
+                throw fail(
                     `Cannot add an object to a state tree if it is already part of the same or another state tree. Tried to assign an object to '${
                         parent.path
                     }/${newPaths[i]}', but it lives already at '${getStateTreeNode(newValue).path}'`

--- a/packages/mobx-state-tree/src/types/primitives.ts
+++ b/packages/mobx-state-tree/src/types/primitives.ts
@@ -199,7 +199,7 @@ export function getPrimitiveFactoryFromValue(value: any): ISimpleType<any> {
         case "object":
             if (value instanceof Date) return DatePrimitive
     }
-    return fail("Cannot determine primitive type from value " + value)
+    throw fail("Cannot determine primitive type from value " + value)
 }
 
 /**

--- a/packages/mobx-state-tree/src/types/utility-types/enumeration.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/enumeration.ts
@@ -35,7 +35,7 @@ export function enumeration(name: string | string[], options?: any): ISimpleType
     if (process.env.NODE_ENV !== "production") {
         realOptions.forEach(option => {
             if (typeof option !== "string")
-                fail("expected all options to be string, got " + type + " instead")
+                throw fail("expected all options to be string, got " + type + " instead")
         })
     }
     const type = union(...realOptions.map(option => literal("" + option)))

--- a/packages/mobx-state-tree/src/types/utility-types/identifier.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/identifier.ts
@@ -33,14 +33,14 @@ export class IdentifierType extends Type<string, string, string> {
         snapshot: string
     ): INode {
         if (!parent || !(parent.type instanceof ModelType))
-            fail(`Identifier types can only be instantiated as direct child of a model type`)
+            throw fail(`Identifier types can only be instantiated as direct child of a model type`)
 
         return createNode(this, parent, subpath, environment, snapshot)
     }
 
     reconcile(current: INode, newValue: string) {
         if (current.storedValue !== newValue)
-            return fail(
+            throw fail(
                 `Tried to change identifier from '${
                     current.storedValue
                 }' to '${newValue}'. Changing identifiers is not allowed.`

--- a/packages/mobx-state-tree/src/types/utility-types/late.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/late.ts
@@ -40,12 +40,12 @@ export class Late<C, S, T> extends Type<C, S, T> {
                 else throw e
             }
             if (mustSucceed && t === undefined)
-                fail(
+                throw fail(
                     "Late type seems to be used too early, the definition (still) returns undefined"
                 )
             if (t) {
                 if (process.env.NODE_ENV !== "production" && !isType(t))
-                    fail(
+                    throw fail(
                         "Failed to determine subtype, make sure types.late returns a type definition."
                     )
                 this._subType = t
@@ -116,7 +116,7 @@ export function late(nameOrType: any, maybeType?: () => IAnyType): IAnyType {
     // checks that the type is actually a late type
     if (process.env.NODE_ENV !== "production") {
         if (!(typeof type === "function" && type.length === 0))
-            fail(
+            throw fail(
                 "Invalid late type, expected a function with zero arguments that returns a type, got: " +
                     type
             )

--- a/packages/mobx-state-tree/src/types/utility-types/literal.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/literal.ts
@@ -68,7 +68,7 @@ export class Literal<T> extends Type<T, T, T> {
 export function literal<S extends Primitives>(value: S): ISimpleType<S> {
     // check that the given value is a primitive
     if (process.env.NODE_ENV !== "production") {
-        if (!isPrimitive(value)) fail(`Literal types can be built only on top of primitives`)
+        if (!isPrimitive(value)) throw fail(`Literal types can be built only on top of primitives`)
     }
     return new Literal<S>(value)
 }

--- a/packages/mobx-state-tree/src/types/utility-types/maybe.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/maybe.ts
@@ -46,7 +46,7 @@ export interface IMaybeNull<IT extends IAnyType> extends IMaybeIType<IT, null | 
  */
 export function maybe<IT extends IAnyType>(type: IT): IMaybe<IT> {
     if (process.env.NODE_ENV !== "production" && !isType(type))
-        fail("expected a mobx-state-tree type as first argument, got " + type + " instead")
+        throw fail("expected a mobx-state-tree type as first argument, got " + type + " instead")
     return union(type, optionalUndefinedType) as any
 }
 
@@ -59,6 +59,6 @@ export function maybe<IT extends IAnyType>(type: IT): IMaybe<IT> {
  */
 export function maybeNull<IT extends IAnyType>(type: IT): IMaybeNull<IT> {
     if (process.env.NODE_ENV !== "production" && !isType(type))
-        fail("expected a mobx-state-tree type as first argument, got " + type + " instead")
+        throw fail("expected a mobx-state-tree type as first argument, got " + type + " instead")
     return union(type, optionalNullType) as any
 }

--- a/packages/mobx-state-tree/src/types/utility-types/optional.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/optional.ts
@@ -158,14 +158,16 @@ export function optional<IT extends IAnyType>(
 ): IT extends OptionalProperty ? IT : IOptionalIType<IT> {
     // make sure we never pass direct instances
     if (typeof defaultValueOrFunction !== "function" && isStateTreeNode(defaultValueOrFunction)) {
-        fail(
+        throw fail(
             "default value cannot be an instance, pass a snapshot or a function that creates an instance/snapshot instead"
         )
     }
 
     if (process.env.NODE_ENV !== "production") {
         if (!isType(type))
-            fail("expected a mobx-state-tree type as first argument, got " + type + " instead")
+            throw fail(
+                "expected a mobx-state-tree type as first argument, got " + type + " instead"
+            )
 
         // we only check default values if they are passed directly
         // if they are generator functions they will be checked once they are generated

--- a/packages/mobx-state-tree/src/types/utility-types/reference.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/reference.ts
@@ -72,14 +72,14 @@ class StoredReference<IT extends IAnyType> {
         } else if (isStateTreeNode(value)) {
             const targetNode = getStateTreeNode(value)
             if (!targetNode.identifierAttribute)
-                return fail(`Can only store references with a defined identifier attribute.`)
+                throw fail(`Can only store references with a defined identifier attribute.`)
             const id = targetNode.unnormalizedIdentifier
             if (id === null || id === undefined) {
-                return fail(`Can only store references to tree nodes with a defined identifier.`)
+                throw fail(`Can only store references to tree nodes with a defined identifier.`)
             }
             this.identifier = id
         } else {
-            return fail(`Can only store references to tree nodes or identifiers, got: '${value}'`)
+            throw fail(`Can only store references to tree nodes or identifiers, got: '${value}'`)
         }
     }
 
@@ -485,9 +485,13 @@ export function reference<IT extends IAnyComplexType>(
     // check that a type is given
     if (process.env.NODE_ENV !== "production") {
         if (!isType(subType))
-            fail("expected a mobx-state-tree type as first argument, got " + subType + " instead")
+            throw fail(
+                "expected a mobx-state-tree type as first argument, got " + subType + " instead"
+            )
         if (arguments.length === 2 && typeof arguments[1] === "string")
-            fail("References with base path are no longer supported. Please remove the base path.")
+            throw fail(
+                "References with base path are no longer supported. Please remove the base path."
+            )
     }
 
     const getSetOptions = options ? (options as ReferenceOptionsGetSet<IT>) : undefined
@@ -498,7 +502,7 @@ export function reference<IT extends IAnyComplexType>(
     if (getSetOptions && (getSetOptions.get || getSetOptions.set)) {
         if (process.env.NODE_ENV !== "production") {
             if (!getSetOptions.get || !getSetOptions.set) {
-                fail(
+                throw fail(
                     "reference options must either contain both a 'get' and a 'set' method or none of them"
                 )
             }

--- a/packages/mobx-state-tree/src/types/utility-types/refinement.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/refinement.ts
@@ -102,17 +102,17 @@ export function refinement(...args: any[]): IAnyType {
     // ensures all parameters are correct
     if (process.env.NODE_ENV !== "production") {
         if (typeof name !== "string")
-            fail("expected a string as first argument, got " + name + " instead")
+            throw fail("expected a string as first argument, got " + name + " instead")
         if (!isType(type))
-            fail(
+            throw fail(
                 "expected a mobx-state-tree type as first or second argument, got " +
                     type +
                     " instead"
             )
         if (typeof predicate !== "function")
-            fail("expected a function as third argument, got " + predicate + " instead")
+            throw fail("expected a function as third argument, got " + predicate + " instead")
         if (typeof message !== "function")
-            fail("expected a function as fourth argument, got " + message + " instead")
+            throw fail("expected a function as fourth argument, got " + message + " instead")
     }
     return new Refinement(name, type, predicate, message)
 }

--- a/packages/mobx-state-tree/src/types/utility-types/union.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/union.ts
@@ -75,13 +75,13 @@ export class Union extends Type<any, any, any> {
 
     instantiate(parent: INode, subpath: string, environment: any, value: any): INode {
         const type = this.determineType(value, undefined)
-        if (!type) return fail("No matching type for union " + this.describe()) // can happen in prod builds
+        if (!type) throw fail("No matching type for union " + this.describe()) // can happen in prod builds
         return type.instantiate(parent, subpath, environment, value)
     }
 
     reconcile(current: INode, newValue: any): INode {
         const type = this.determineType(newValue, current.type)
-        if (!type) return fail("No matching type for union " + this.describe()) // can happen in prod builds
+        if (!type) throw fail("No matching type for union " + this.describe()) // can happen in prod builds
         return type.reconcile(current, newValue)
     }
 
@@ -233,12 +233,12 @@ export function union(optionsOrType: UnionOptions | IAnyType, ...otherTypes: IAn
     // check all options
     if (process.env.NODE_ENV !== "production") {
         if (!isType(optionsOrType) && !isPlainObject(optionsOrType))
-            fail(
+            throw fail(
                 "First argument to types.union should either be a type, or an objects object of the form: { eager?: boolean, dispatcher?: Function }"
             )
         types.forEach(type => {
             if (!isType(type))
-                fail(
+                throw fail(
                     "expected all possible types to be a mobx-state-tree type, got " +
                         type +
                         " instead"

--- a/packages/mobx-state-tree/src/utils.ts
+++ b/packages/mobx-state-tree/src/utils.ts
@@ -32,8 +32,8 @@ export type IDisposer = () => void
  * @internal
  * @hidden
  */
-export function fail(message = "Illegal state"): never {
-    throw new Error("[mobx-state-tree] " + message)
+export function fail(message = "Illegal state"): Error {
+    return new Error("[mobx-state-tree] " + message)
 }
 
 /**

--- a/packages/mst-middlewares/__tests__/redux.test.ts
+++ b/packages/mst-middlewares/__tests__/redux.test.ts
@@ -16,7 +16,7 @@ test("waitAsync helper works", async () => {
 test("waitAsyncReject helper works", async () => {
     try {
         await waitAsyncReject(10)
-        fail("should have failed")
+        throw fail("should have failed")
     } catch {
         // do nothing
     }
@@ -148,7 +148,7 @@ function addStandardTests() {
     test("m.setXAsyncThrowSync()", async () => {
         try {
             await m.setXAsyncThrowSync()
-            fail("should have thrown")
+            throw fail("should have thrown")
         } catch {}
         expect(devTools.send.mock.calls).toMatchSnapshot()
     })
@@ -156,7 +156,7 @@ function addStandardTests() {
     test("m.setXAsyncThrowAsync()", async () => {
         try {
             await m.setXAsyncThrowAsync()
-            fail("should have thrown")
+            throw fail("should have thrown")
         } catch {}
         expect(devTools.send.mock.calls).toMatchSnapshot()
     })
@@ -182,7 +182,7 @@ function addStandardTests() {
     test("m.setXYAsyncThrowSync() -> m.setXAsyncThrowSync()", async () => {
         try {
             await m.setXYAsyncThrowSync()
-            fail("should have thrown")
+            throw fail("should have thrown")
         } catch {}
         expect(devTools.send.mock.calls).toMatchSnapshot()
     })
@@ -190,7 +190,7 @@ function addStandardTests() {
     test("m.setXYAsyncThrowAsync() -> m.setXYAsyncThrowAsync()", async () => {
         try {
             await m.setXYAsyncThrowAsync()
-            fail("should have thrown")
+            throw fail("should have thrown")
         } catch {}
         expect(devTools.send.mock.calls).toMatchSnapshot()
     })


### PR DESCRIPTION
This PR changes `fail(x)` to `throw fail(x)` to help typescript better follow the flow of the program and help catching errors.

e.g.
```
function fn() {
  if (foobar) {
    fail('x');
    something // typescript won't complain that this is unreachable, with throw wail it would
  }
  return 5;
}

function fn() {
  if (foobar) {
    return fail('x');
    something
    // typescript will complain that this is unreachable, but it will say that not code paths return a value
    // and then fn return type has to be manually changed to void
    // with throw fail it is not necessary
  }
  something else
}
```