### PR TITLE
Fix typos in middleware.md and point to updated CodeSandbox example

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -9,8 +9,7 @@ The value returned by the action invoked/ the aborted value gets passed through 
 
 MST ships with a small set of [pre-built / example middlewares](../packages/mst-middlewares/README.md).
 
-Custom middleware example:
-[SandBox example](https://codesandbox.io/s/88jrqlzm1l)
+Play around with a simple example of middleware in action with [this CodeSandbox](https://codesandbox.io/s/24qq4924oj).
 
 ## Custom Middleware
 
@@ -130,7 +129,7 @@ use next to call the next middleware.
 
 #### abort
 
-use abort if you wan't kill the queue of middlewares and immediately return.
+use `abort` if you want to kill the queue of middlewares and immediately return.
 the implementation of the targeted action won't be reached if you abort the queue.
 
 `abort(value: any) : void`
@@ -139,7 +138,7 @@ the implementation of the targeted action won't be reached if you abort the queu
 
 ### includeHooks
 
-set this flag to `false` if you wan't to avoid having hooks passed to the middleware.
+set this flag to `false` if you want to avoid having hooks passed to the middleware.
 
 ## FAQ
 


### PR DESCRIPTION
Fixes some small typos in middleware.md. I also noticed the CodeSandbox example provided didn't actually seem to be working -- the middleware that intercepted calls and changed the arguments didn't actually modify the final state. Updating the dependencies seemed to fix it; I also tweaked the example a little bit to try to illustrate the flow of middleware better (eg. logging both before and after calling `next()`).