### PR TITLE
Lazy eventhandlers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+-   Performance improvement for event handlers so they consume less RAM through [#1160](https://github.com/mobxjs/mobx-state-tree/pull/1160) by [@xaviergonz](https://github.com/xaviergonz)
 -   Make liveliness errors give more info to trace their cause [#1142](https://github.com/mobxjs/mobx-state-tree/issues/1142) through [#1147](https://github.com/mobxjs/mobx-state-tree/pull/1147) by [@xaviergonz](https://github.com/xaviergonz)
 
 # 3.10.2

--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -69,7 +69,7 @@ const snapshotReactionOptions = {
     }
 }
 
-type IInternalEvents<S> = {
+type InternalEventHandlers<S> = {
     [InternalEvents.Dispose]: () => void
     [InternalEvents.Patch]: (patch: IJsonPatch, reversePatch: IJsonPatch) => void
     [InternalEvents.Snapshot]: (snapshot: S) => void
@@ -619,7 +619,7 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
 
     // #region internal event handling
 
-    private _internalEvents?: EventHandlers<IInternalEvents<S>>
+    private _internalEvents?: EventHandlers<InternalEventHandlers<S>>
 
     // we proxy the methods to avoid creating an EventHandlers instance when it is not needed
 
@@ -629,7 +629,7 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
 
     private _internalEventsRegister<IE extends InternalEvents>(
         event: IE,
-        eventHandler: IInternalEvents<S>[IE],
+        eventHandler: InternalEventHandlers<S>[IE],
         atTheBeginning = false
     ): IDisposer {
         if (!this._internalEvents) {
@@ -640,14 +640,14 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
 
     private _internalEventsHas<IE extends InternalEvents>(
         event: IE,
-        eventHandler: IInternalEvents<S>[IE]
+        eventHandler: InternalEventHandlers<S>[IE]
     ): boolean {
         return !!this._internalEvents && this._internalEvents.has(event, eventHandler)
     }
 
     private _internalEventsUnregister<IE extends InternalEvents>(
         event: IE,
-        eventHandler: IInternalEvents<S>[IE]
+        eventHandler: InternalEventHandlers<S>[IE]
     ): void {
         if (this._internalEvents) {
             this._internalEvents.unregister(event, eventHandler)
@@ -656,7 +656,7 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
 
     private _internalEventsEmit<IE extends InternalEvents>(
         event: IE,
-        ...args: ArgumentTypes<IInternalEvents<S>[IE]>
+        ...args: ArgumentTypes<InternalEventHandlers<S>[IE]>
     ): void {
         if (this._internalEvents) {
             this._internalEvents.emit(event, ...args)

--- a/packages/mobx-state-tree/src/types/utility-types/reference.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/reference.ts
@@ -225,11 +225,11 @@ export abstract class BaseReferenceType<IT extends IAnyComplexType> extends Type
             this.fireInvalidated(cause, storedRefNode, referenceId, refTargetNode)
         }
 
-        const refTargetDetachHookDisposer = refTargetNode.hookSubscribers.register(
+        const refTargetDetachHookDisposer = refTargetNode.registerHook(
             Hook.beforeDetach,
             hookHandler
         )
-        const refTargetDestroyHookDisposer = refTargetNode.hookSubscribers.register(
+        const refTargetDestroyHookDisposer = refTargetNode.registerHook(
             Hook.beforeDestroy,
             hookHandler
         )
@@ -253,7 +253,7 @@ export abstract class BaseReferenceType<IT extends IAnyComplexType> extends Type
 
         // get rid of the watcher hook when the stored ref node is destroyed
         // detached is ignored since scalar nodes (where the reference resides) cannot be detached
-        storedRefNode.hookSubscribers.register(Hook.beforeDestroy, () => {
+        storedRefNode.registerHook(Hook.beforeDestroy, () => {
             if (onRefTargetDestroyedHookDisposer) {
                 onRefTargetDestroyedHookDisposer()
             }
@@ -308,7 +308,7 @@ export abstract class BaseReferenceType<IT extends IAnyComplexType> extends Type
         } else {
             if (!storedRefNode.isRoot) {
                 // start watching once the whole tree is ready
-                storedRefNode.root.hookSubscribers.register(Hook.afterCreationFinalization, () => {
+                storedRefNode.root.registerHook(Hook.afterCreationFinalization, () => {
                     // make sure to attach it so it can start listening
                     if (storedRefNode.parent) {
                         storedRefNode.parent.createObservableInstanceIfNeeded()
@@ -316,7 +316,7 @@ export abstract class BaseReferenceType<IT extends IAnyComplexType> extends Type
                 })
             }
             // start watching once the node is attached somewhere / parent changes
-            storedRefNode.hookSubscribers.register(Hook.afterAttach, () => {
+            storedRefNode.registerHook(Hook.afterAttach, () => {
                 startWatching(false)
             })
         }

--- a/packages/mobx-state-tree/src/utils.ts
+++ b/packages/mobx-state-tree/src/utils.ts
@@ -219,7 +219,11 @@ export function addHiddenWritableProp(object: any, propName: string, value: any)
     })
 }
 
-type ArgumentTypes<F extends Function> = F extends (...args: infer A) => any ? A : never
+/**
+ * @internal
+ * @hidden
+ */
+export type ArgumentTypes<F extends Function> = F extends (...args: infer A) => any ? A : never
 
 /**
  * @internal

--- a/tslint.json
+++ b/tslint.json
@@ -12,7 +12,6 @@
         "no-duplicate-variable": true,
         "no-eval": true,
         "no-internal-module": true,
-        "no-trailing-whitespace": true,
         "no-shadowed-variable": true,
         "no-switch-case-fall-through": true,
         "no-unused-expression": true,


### PR DESCRIPTION
Performance optimization. does not create an EventHandlers object unless absolutely needed. In theory the ram gains should be bigger than the cpu gains.

```
after

-----------
Small Model
-----------
      31ms |      x 100 |  0.3ms avg
     182ms |    x 1,000 |  0.2ms avg
     794ms |   x 10,000 |  0.1ms avg
     163ms |    x 1,000 |  0.2ms avg
      15ms |      x 100 |  0.1ms avg

------------
Medium Model
------------
      34ms |      x 100 |  0.3ms avg
     325ms |    x 1,000 |  0.3ms avg
   1,661ms |   x 10,000 |  0.2ms avg
     295ms |    x 1,000 |  0.3ms avg
      43ms |      x 100 |  0.4ms avg

------------------------
Large Model - 0 children
------------------------
     110ms |      x 100 |  1.1ms avg
     665ms |    x 1,000 |  0.7ms avg
      97ms |      x 100 |  1.0ms avg

-------------------------------------------
Large Model - 10 small & 10 medium children
-------------------------------------------
      99ms |       x 50 |  2.0ms avg
     336ms |      x 250 |  1.3ms avg
      98ms |       x 50 |  2.0ms avg

-------------------------------------------
Large Model - 100 small & 0 medium children
-------------------------------------------
     113ms |       x 50 |  2.3ms avg
     314ms |      x 250 |  1.3ms avg
      51ms |       x 50 |  1.0ms avg

-------------------------------------------
Large Model - 0 small & 100 medium children
-------------------------------------------
     342ms |       x 50 |  6.8ms avg
   1,267ms |      x 250 |  5.1ms avg
     325ms |       x 50 |  6.5ms avg

20.60user 4.18system 0:11.89elapsed 208%CPU (0avgtext+0avgdata 264200maxresident)k
0inputs+0outputs (0major+197978minor)pagefaults 0swaps
Done in 42.04s.

before

-----------
Small Model
-----------
      34ms |      x 100 |  0.3ms avg
     177ms |    x 1,000 |  0.2ms avg
     838ms |   x 10,000 |  0.1ms avg
     170ms |    x 1,000 |  0.2ms avg
      12ms |      x 100 |  0.1ms avg

------------
Medium Model
------------
      41ms |      x 100 |  0.4ms avg
     363ms |    x 1,000 |  0.4ms avg
   1,804ms |   x 10,000 |  0.2ms avg
     308ms |    x 1,000 |  0.3ms avg
      37ms |      x 100 |  0.4ms avg

------------------------
Large Model - 0 children
------------------------
     114ms |      x 100 |  1.1ms avg
     696ms |    x 1,000 |  0.7ms avg
      83ms |      x 100 |  0.8ms avg

-------------------------------------------
Large Model - 10 small & 10 medium children
-------------------------------------------
     108ms |       x 50 |  2.2ms avg
     365ms |      x 250 |  1.5ms avg
     119ms |       x 50 |  2.4ms avg

-------------------------------------------
Large Model - 100 small & 0 medium children
-------------------------------------------
      88ms |       x 50 |  1.8ms avg
     343ms |      x 250 |  1.4ms avg
      90ms |       x 50 |  1.8ms avg

-------------------------------------------
Large Model - 0 small & 100 medium children
-------------------------------------------
     358ms |       x 50 |  7.2ms avg
   1,384ms |      x 250 |  5.5ms avg
     328ms |       x 50 |  6.6ms avg

21.26user 5.35system 0:12.59elapsed 211%CPU (0avgtext+0avgdata 260288maxresident)k
0inputs+0outputs (0major+206645minor)pagefaults 0swaps
Done in 43.47s.
```