### PR TITLE
Fixed typo in API README

### DIFF
--- a/docs/API/README.md
+++ b/docs/API/README.md
@@ -2981,7 +2981,7 @@ ___
 
 ▸ **onSnapshot**<`S`>(target: *`IStateTreeNode`<`any`, `S`>*, callback: *`function`*): [IDisposer](#idisposer)
 
-Registers a function that is invoked whenever a new snapshot for the given model instance is available. The listener will only be fire at the and of the current MobX (trans)action. See [snapshots](https://github.com/mobxjs/mobx-state-tree#snapshots) for more details.
+Registers a function that is invoked whenever a new snapshot for the given model instance is available. The listener will only be fire at the end of the current MobX (trans)action. See [snapshots](https://github.com/mobxjs/mobx-state-tree#snapshots) for more details.
 
 **Type parameters:**
 


### PR DESCRIPTION
Fixed typo: `and -> end`