### PR TITLE
fix snapshot processor cloning

### DIFF
--- a/packages/mobx-state-tree/src/core/node/BaseNode.ts
+++ b/packages/mobx-state-tree/src/core/node/BaseNode.ts
@@ -59,7 +59,6 @@ export abstract class BaseNode<C, S, T> {
     }
 
     readonly type: IAnyType
-    validationType?: IAnyType
 
     private _hookSubscribers?: EventHandlers<HookSubscribers>
 

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -345,10 +345,9 @@ export abstract class BaseType<C, S, T, N extends BaseNode<any, any, any> = Base
         const node = getStateTreeNodeSafe(value)
         if (node) {
             const valueType = getType(value)
-            const assignable = node.validationType
-                ? node.validationType.isAssignableFrom(valueType)
-                : this.isAssignableFrom(valueType)
-            return assignable ? typeCheckSuccess() : typeCheckFailure(context, value)
+            return this.isAssignableFrom(valueType)
+                ? typeCheckSuccess()
+                : typeCheckFailure(context, value)
             // it is tempting to compare snapshots, but in that case we should always clone on assignments...
         }
         return this.isValidSnapshot(value as C, context)

--- a/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
@@ -76,7 +76,9 @@ class SnapshotProcessor<IT extends IAnyType, CustomC, CustomS> extends BaseType<
     }
 
     private _fixNode(node: this["N"]): void {
-        node.validationType = this
+        // the node has to use these methods rather than the original type ones
+        proxyNodeTypeMethods(node.type, this, "isAssignableFrom", "create")
+
         const oldGetSnapshot = node.getSnapshot
         node.getSnapshot = () => {
             return this.postProcessSnapshot(oldGetSnapshot.call(node)) as any
@@ -120,6 +122,16 @@ class SnapshotProcessor<IT extends IAnyType, CustomC, CustomS> extends BaseType<
 
     getSubTypes() {
         return this._subtype
+    }
+}
+
+function proxyNodeTypeMethods(
+    nodeType: any,
+    snapshotProcessorType: any,
+    ...methods: (keyof SnapshotProcessor<any, any, any>)[]
+) {
+    for (const method of methods) {
+        nodeType[method] = snapshotProcessorType[method].bind(snapshotProcessorType)
     }
 }
 


### PR DESCRIPTION
Cloning was not working right for snapshot processor since it was using the subtype create method, which did not account for the preprocessor