### PR TITLE
getValue small refactor

### DIFF
--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -295,11 +295,6 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
         }
     }
 
-    get value(): T {
-        this.createObservableInstanceIfNeeded()
-        return this.type.getValue(this)
-    }
-
     private _snapshotUponDeath?: S
 
     // advantage of using computed for a snapshot is that nicely respects transactions etc.

--- a/packages/mobx-state-tree/src/core/node/scalar-node.ts
+++ b/packages/mobx-state-tree/src/core/node/scalar-node.ts
@@ -67,15 +67,6 @@ export class ScalarNode<C, S, T> extends BaseNode<C, S, T> {
         }
     }
 
-    get value(): T {
-        // if we ever find a case where scalar nodes can be accessed without iterating through its parent
-        // uncomment this to make sure the parent chain is created when this is accessed
-        // if (this.parent) {
-        //     this.parent.createObservableInstanceIfNeeded()
-        // }
-        return this.type.getValue(this)
-    }
-
     get snapshot(): S {
         return freeze(this.getSnapshot())
     }

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -474,16 +474,16 @@ export abstract class SimpleType<C, S, T> extends BaseType<C, S, T, ScalarNode<C
         return snapshot as any
     }
 
-    getSnapshot(node: this["N"]): S {
-        return node.storedValue
-    }
-
     getValue(node: this["N"]): T {
         // if we ever find a case where scalar nodes can be accessed without iterating through its parent
         // uncomment this to make sure the parent chain is created when this is accessed
         // if (node.parent) {
         //     node.parent.createObservableInstanceIfNeeded()
         // }
+        return node.storedValue
+    }
+
+    getSnapshot(node: this["N"]): S {
         return node.storedValue
     }
 

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -177,11 +177,6 @@ export interface IType<C, S, T> {
      * @internal
      * @hidden
      */
-    getValue(node: BaseNode<C, S, T>): T
-    /**
-     * @internal
-     * @hidden
-     */
     getSnapshot(node: BaseNode<C, S, T>, applyPostProcess?: boolean): S
     /**
      * @internal
@@ -315,10 +310,6 @@ export abstract class BaseType<C, S, T, N extends BaseNode<any, any, any> = Base
         return node.type.getSnapshot(node, applyPostProcess)
     }
 
-    getValue(node: N): T {
-        return node.type.getValue(node)
-    }
-
     abstract reconcile(current: N, newValue: C | T): N
 
     abstract instantiate(
@@ -404,6 +395,11 @@ export abstract class ComplexType<C, S, T> extends BaseType<C, S, T, ObjectNode<
         return super.create(snapshot, environment)
     }
 
+    getValue(node: this["N"]): T {
+        node.createObservableInstanceIfNeeded()
+        return node.storedValue
+    }
+
     abstract getDefaultSnapshot(): C
 
     abstract createNewInstance(node: this["N"], childNodes: IChildNodesMap, snapshot: C): T
@@ -478,11 +474,16 @@ export abstract class SimpleType<C, S, T> extends BaseType<C, S, T, ScalarNode<C
         return snapshot as any
     }
 
-    getValue(node: this["N"]): T {
+    getSnapshot(node: this["N"]): S {
         return node.storedValue
     }
 
-    getSnapshot(node: this["N"]): S {
+    getValue(node: this["N"]): T {
+        // if we ever find a case where scalar nodes can be accessed without iterating through its parent
+        // uncomment this to make sure the parent chain is created when this is accessed
+        // if (node.parent) {
+        //     node.parent.createObservableInstanceIfNeeded()
+        // }
         return node.storedValue
     }
 

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -181,10 +181,6 @@ export class ArrayType<IT extends IAnyType> extends ComplexType<
         return change
     }
 
-    getValue(node: this["N"]): this["T"] {
-        return node.storedValue
-    }
-
     getSnapshot(node: this["N"]): this["S"] {
         return node.getChildren().map(childNode => childNode.snapshot)
     }

--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -167,17 +167,15 @@ class MSTMap<IT extends IAnyType> extends ObservableMap<string, any> {
             if (process.env.NODE_ENV !== "production") {
                 if (!node.identifierAttribute) throw fail(needsIdentifierError)
             }
-            let key = node.identifier!
-            this.set(key, node.value)
-            return node.value
+            this.set(node.identifier!, value)
+            return value as any
         } else if (!isMutable(value)) {
             throw fail(`Map.put can only be used to store complex values`)
         } else {
-            let key: string
             const mapType = getStateTreeNode(this as IAnyStateTreeNode).type as MapType<any>
             if (mapType.identifierMode === MapIdentifierMode.NO) throw fail(needsIdentifierError)
             if (mapType.identifierMode === MapIdentifierMode.YES) {
-                key = normalizeIdentifier(value[mapType.mapIdentifierAttribute!])
+                const key = normalizeIdentifier(value[mapType.mapIdentifierAttribute!])
                 this.set(key, value)
                 return this.get(key) as any
             }
@@ -316,10 +314,6 @@ export class MapType<IT extends IAnyType> extends ComplexType<
                     `A map of objects containing an identifier should always store the object under their own identifier. Trying to store key '${identifier}', but expected: '${expected}'`
                 )
         }
-    }
-
-    getValue(node: this["N"]): this["T"] {
-        return node.storedValue
     }
 
     getSnapshot(node: this["N"]): this["S"] {

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -646,10 +646,6 @@ export class ModelType<
         return childNode
     }
 
-    getValue(node: this["N"]): this["T"] {
-        return node.storedValue
-    }
-
     getSnapshot(node: this["N"], applyPostProcess = true): this["S"] {
         const res = {} as any
         this.forAllProps((name, type) => {

--- a/packages/mobx-state-tree/src/types/utility-types/custom.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/custom.ts
@@ -104,10 +104,6 @@ export class CustomType<S, T> extends SimpleType<S | T, S, T> {
         return typeCheckSuccess()
     }
 
-    getValue(node: this["N"]): T {
-        return node.storedValue
-    }
-
     getSnapshot(node: this["N"]): S {
         return this.options.toSnapshot(node.storedValue)
     }


### PR DESCRIPTION
A small refactor around getValue, moving its main implementation to the simple/complex type implementation rather than to the single types themselves

Also fixes a possible issue where createObservableInstanceIfNeeded was not getting called for any complex types other than model
