### PR TITLE
fix undead nodes on array reconciliation / when using pop, shift, splice (ignore red x, it is coveralls)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+-   Fixed nodes being `pop`/`shift`/`splice` from an array not getting properly destroyed through [#1205](https://github.com/mobxjs/mobx-state-tree/pull/1205) by [@xaviergonz](https://github.com/xaviergonz). Not that this means that in order to access the returned dead nodes data without getting a liveliness error/warning then the returned dead nodes have to be either cloned (`clone`) or their snapshots (`getSnapshot`) have to be used first.
+
 # 3.11.0
 
 -   Added an optional third argument to `types.optional` that allows to set alternative optional values other than just `undefined` through [#1192](https://github.com/mobxjs/mobx-state-tree/pull/1192) by [@xaviergonz](https://github.com/xaviergonz)

--- a/packages/mobx-state-tree/__tests__/core/array.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/array.test.ts
@@ -464,9 +464,9 @@ test("it should return pop/shift'ed values for object arrays", () => {
     const bar = test.pop()!
     expect(isAlive(bar)).toBe(false)
 
-    // we have to use clone to access dead nodes data
+    // we have to use clone or getSnapshot to access dead nodes data
     expect(clone(foo)).toEqual({ id: "foo" })
-    expect(clone(bar)).toEqual({ id: "bar" })
+    expect(getSnapshot(bar)).toEqual({ id: "bar" })
 })
 
 test("#1173 - detaching an array should not eliminate its children", () => {

--- a/packages/mobx-state-tree/__tests__/core/array.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/array.test.ts
@@ -517,6 +517,7 @@ test("assigning filtered instances works", () => {
     expect(store.todos.every(t => isAlive(t)))
     store.clearFinishedTodos()
     expect(store.todos.length).toBe(1)
+    expect(store.todos[0]).toBe(notDone[0])
     expect(done.every(t => !isAlive(t))).toBe(true)
     expect(notDone.every(t => isAlive(t))).toBe(true)
 })

--- a/packages/mobx-state-tree/__tests__/core/array.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/array.test.ts
@@ -484,3 +484,11 @@ test("#1173 - detaching an array should not eliminate its children", () => {
     expect(detachedItems.length).toBe(3)
     expect(detachedItems[0]).toBe(n0)
 })
+
+test("initializing an array instance from another array instance should end up in the same instance", () => {
+    const A = types.array(types.number)
+    const a1 = A.create([1, 2, 3])
+    const a2 = A.create(a1)
+    expect(a1).toBe(a2)
+    expect(getSnapshot(a1)).toEqual([1, 2, 3])
+})

--- a/packages/mobx-state-tree/__tests__/core/array.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/array.test.ts
@@ -11,7 +11,8 @@ import {
     types,
     IJsonPatch,
     setLivelinessChecking,
-    detach
+    detach,
+    cast
 } from "../../src"
 import { observable, autorun } from "mobx"
 
@@ -491,4 +492,26 @@ test("initializing an array instance from another array instance should end up i
     const a2 = A.create(a1)
     expect(a1).toBe(a2)
     expect(getSnapshot(a1)).toEqual([1, 2, 3])
+})
+
+test("assigning filtered instances works", () => {
+    const Task = types.model("Task", {
+        done: false
+    })
+    const store = types
+        .model({
+            todos: types.array(Task)
+        })
+        .actions(self => ({
+            clearFinishedTodos() {
+                self.todos = cast(self.todos.filter(todo => !todo.done))
+            }
+        }))
+        .create({
+            todos: [{ done: true }, { done: false }, { done: true }]
+        })
+
+    expect(store.todos.length).toBe(3)
+    store.clearFinishedTodos()
+    expect(store.todos.length).toBe(1)
 })

--- a/packages/mobx-state-tree/__tests__/core/array.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/array.test.ts
@@ -512,6 +512,11 @@ test("assigning filtered instances works", () => {
         })
 
     expect(store.todos.length).toBe(3)
+    const done = store.todos.filter(t => t.done)
+    const notDone = store.todos.filter(t => t.done)
+    expect(store.todos.every(t => isAlive(t)))
     store.clearFinishedTodos()
     expect(store.todos.length).toBe(1)
+    expect(done.every(t => !isAlive(t)))
+    expect(notDone.every(t => isAlive(t)))
 })

--- a/packages/mobx-state-tree/__tests__/core/array.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/array.test.ts
@@ -513,10 +513,10 @@ test("assigning filtered instances works", () => {
 
     expect(store.todos.length).toBe(3)
     const done = store.todos.filter(t => t.done)
-    const notDone = store.todos.filter(t => t.done)
+    const notDone = store.todos.filter(t => !t.done)
     expect(store.todos.every(t => isAlive(t)))
     store.clearFinishedTodos()
     expect(store.todos.length).toBe(1)
-    expect(done.every(t => !isAlive(t)))
-    expect(notDone.every(t => isAlive(t)))
+    expect(done.every(t => !isAlive(t))).toBe(true)
+    expect(notDone.every(t => isAlive(t))).toBe(true)
 })

--- a/packages/mobx-state-tree/__tests__/core/array.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/array.test.ts
@@ -448,16 +448,25 @@ test("it should return pop/shift'ed values for object arrays", () => {
             return {
                 shift() {
                     return self.array.shift()
+                },
+                pop() {
+                    return self.array.pop()
                 }
             }
         })
 
     const test = ObjectArray.create({
-        array: [{ id: "foo" }, { id: "bar" }]
+        array: [{ id: "foo" }, { id: "mid" }, { id: "bar" }]
     })
 
-    expect(test.shift()).toEqual({ id: "foo" })
-    expect(test.shift()).toEqual({ id: "bar" })
+    const foo = test.shift()!
+    expect(isAlive(foo)).toBe(false)
+    const bar = test.pop()!
+    expect(isAlive(bar)).toBe(false)
+
+    // we have to use clone to access dead nodes data
+    expect(clone(foo)).toEqual({ id: "foo" })
+    expect(clone(bar)).toEqual({ id: "bar" })
 })
 
 test("#1173 - detaching an array should not eliminate its children", () => {

--- a/packages/mobx-state-tree/__tests__/core/hooks.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/hooks.test.ts
@@ -86,15 +86,9 @@ test("it should trigger lifecycle hooks", () => {
 
     events.push("--")
 
-    // access (new, attach) get biscuit
-    const oldBiscuit = store.todos[store.todos.length - 1]
-
-    // destroys the old get biscuit, news a new cloned biscuit
-    const clonedBiscuit = store.todos.pop()!
+    // access (new, attach), then destroy biscuit
+    const oldBiscuit = store.todos.pop()!
     expect(isAlive(oldBiscuit)).toBe(false)
-    expect(isAlive(clonedBiscuit)).toBe(true)
-    expect(hasParent(clonedBiscuit)).toBe(false)
-    expect(oldBiscuit).not.toBe(clonedBiscuit)
 
     events.push("---")
     // new and then attach "add sugar"
@@ -113,11 +107,6 @@ test("it should trigger lifecycle hooks", () => {
     destroy(talk)
     expect(isAlive(talk)).toBe(false)
 
-    events.push("------")
-    // destroy "Give biscuit"
-    destroy(clonedBiscuit)
-    expect(isAlive(clonedBiscuit)).toBe(false)
-
     expect(events).toEqual([
         "new store: 3",
         "-",
@@ -130,7 +119,6 @@ test("it should trigger lifecycle hooks", () => {
         "destroy todo: Get biscuit",
         "custom disposer 2 for Get biscuit",
         "custom disposer 1 for Get biscuit",
-        "new todo: Get biscuit",
         "---",
         "new todo: add sugar",
         "attach todo: add sugar",
@@ -143,11 +131,7 @@ test("it should trigger lifecycle hooks", () => {
         "-----",
         "destroy todo: Give talk",
         "custom disposer 2 for Give talk",
-        "custom disposer 1 for Give talk",
-        "------",
-        "destroy todo: Get biscuit",
-        "custom disposer 2 for Get biscuit",
-        "custom disposer 1 for Get biscuit"
+        "custom disposer 1 for Give talk"
     ])
 })
 

--- a/packages/mobx-state-tree/__tests__/core/hooks.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/hooks.test.ts
@@ -85,9 +85,6 @@ test("it should trigger lifecycle hooks", () => {
     expect(hasParent(talk)).toBe(false)
 
     events.push("--")
-    // "Get biscuit" never gets actually created upon removal
-    // no attach/detach since it didn't even get to be attached
-    // and since a clone is returned, then "new" and should be alive
 
     // access (new, attach) get biscuit
     const oldBiscuit = store.todos[store.todos.length - 1]

--- a/packages/mobx-state-tree/__tests__/core/hooks.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/hooks.test.ts
@@ -85,12 +85,19 @@ test("it should trigger lifecycle hooks", () => {
     expect(hasParent(talk)).toBe(false)
 
     events.push("--")
-    // access (new) but immediately destroy "Get biscuit"
+    // "Get biscuit" never gets actually created upon removal
     // no attach/detach since it didn't even get to be attached
-    // and since it is spawned "detached" it should be alive
-    const biscuit = store.todos.pop()!
-    expect(isAlive(biscuit)).toBe(true)
-    expect(hasParent(biscuit)).toBe(false)
+    // and since a clone is returned, then "new" and should be alive
+
+    // access (new, attach) get biscuit
+    const oldBiscuit = store.todos[store.todos.length - 1]
+
+    // destroys the old get biscuit, news a new cloned biscuit
+    const clonedBiscuit = store.todos.pop()!
+    expect(isAlive(oldBiscuit)).toBe(false)
+    expect(isAlive(clonedBiscuit)).toBe(true)
+    expect(hasParent(clonedBiscuit)).toBe(false)
+    expect(oldBiscuit).not.toBe(clonedBiscuit)
 
     events.push("---")
     // new and then attach "add sugar"
@@ -111,8 +118,8 @@ test("it should trigger lifecycle hooks", () => {
 
     events.push("------")
     // destroy "Give biscuit"
-    destroy(biscuit)
-    expect(isAlive(biscuit)).toBe(false)
+    destroy(clonedBiscuit)
+    expect(isAlive(clonedBiscuit)).toBe(false)
 
     expect(events).toEqual([
         "new store: 3",
@@ -121,6 +128,11 @@ test("it should trigger lifecycle hooks", () => {
         "attach todo: Give talk",
         "detach todo: Give talk",
         "--",
+        "new todo: Get biscuit",
+        "attach todo: Get biscuit",
+        "destroy todo: Get biscuit",
+        "custom disposer 2 for Get biscuit",
+        "custom disposer 1 for Get biscuit",
         "new todo: Get biscuit",
         "---",
         "new todo: add sugar",

--- a/packages/mobx-state-tree/__tests__/core/hooks.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/hooks.test.ts
@@ -6,7 +6,9 @@ import {
     unprotect,
     getSnapshot,
     applySnapshot,
-    onSnapshot
+    onSnapshot,
+    isAlive,
+    hasParent
 } from "../../src"
 
 function createTestStore(listener: (s: string) => void) {
@@ -73,36 +75,70 @@ function createTestStore(listener: (s: string) => void) {
 // some of original hooks do not fire at all
 test("it should trigger lifecycle hooks", () => {
     const events: string[] = []
+    // new store: 3
     const { store, Todo } = createTestStore(e => events.push(e))
-    const talk = detach(store.todos[2])
+
     events.push("-")
-    store.todos.pop()
+    // access (new, attach), then detach "Give Talk"
+    const talk = detach(store.todos[2])
+    expect(isAlive(talk)).toBe(true)
+    expect(hasParent(talk)).toBe(false)
+
     events.push("--")
-    const sugar = Todo.create({ title: "add sugar" })
-    store.todos.push(sugar)
+    // access (new) but immediately destroy "Get biscuit"
+    // no attach/detach since it didn't even get to be attached
+    // and since it is spawned "detached" it should be alive
+    const biscuit = store.todos.pop()!
+    expect(isAlive(biscuit)).toBe(true)
+    expect(hasParent(biscuit)).toBe(false)
+
     events.push("---")
+    // new and then attach "add sugar"
+    const sugar = Todo.create({
+        title: "add sugar"
+    })
+    store.todos.push(sugar)
+
+    events.push("----")
+    // destroy elements in the array ("add sugar"), then store
     destroy(store)
+    expect(isAlive(store)).toBe(false)
+
+    events.push("-----")
+    // destroy "Give talk"
     destroy(talk)
+    expect(isAlive(talk)).toBe(false)
+
+    events.push("------")
+    // destroy "Give biscuit"
+    destroy(biscuit)
+    expect(isAlive(biscuit)).toBe(false)
+
     expect(events).toEqual([
         "new store: 3",
+        "-",
         "new todo: Give talk",
         "attach todo: Give talk",
         "detach todo: Give talk",
-        "-",
-        "new todo: Get biscuit",
-        "attach todo: Get biscuit",
         "--",
+        "new todo: Get biscuit",
+        "---",
         "new todo: add sugar",
         "attach todo: add sugar",
-        "---",
+        "----",
         "destroy todo: add sugar",
         "custom disposer 2 for add sugar",
         "custom disposer 1 for add sugar",
         "destroy store: 2",
         "custom disposer for store",
+        "-----",
         "destroy todo: Give talk",
         "custom disposer 2 for Give talk",
-        "custom disposer 1 for Give talk"
+        "custom disposer 1 for Give talk",
+        "------",
+        "destroy todo: Get biscuit",
+        "custom disposer 2 for Get biscuit",
+        "custom disposer 1 for Get biscuit"
     ])
 })
 

--- a/packages/mobx-state-tree/src/core/flow.ts
+++ b/packages/mobx-state-tree/src/core/flow.ts
@@ -147,8 +147,10 @@ export function createFlowSpawner(name: string, generator: Function) {
                     return
                 }
                 // TODO: support more type of values? See https://github.com/tj/co/blob/249bbdc72da24ae44076afd716349d2089b31c4c/index.js#L100
-                if (!ret.value || typeof ret.value.then !== "function")
+                if (!ret.value || typeof ret.value.then !== "function") {
+                    // istanbul ignore next
                     throw fail("Only promises can be yielded to `async`, got: " + ret)
+                }
                 return ret.value.then(onFulfilled, onRejected)
             }
         })

--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -729,7 +729,7 @@ export function clone<T extends IAnyStateTreeNode>(
     return node.type.create(
         node.snapshot,
         keepEnvironment === true
-            ? node.root.environment
+            ? node.environment
             : keepEnvironment === false
             ? undefined
             : keepEnvironment
@@ -851,7 +851,7 @@ export function getEnv<T = any>(target: IAnyStateTreeNode): T {
             )
     }
     const node = getStateTreeNode(target)
-    const env = node.root.environment
+    const env = node.environment
     if (!!!env) return EMPTY_OBJECT as T
     return env
 }

--- a/packages/mobx-state-tree/src/core/node/BaseNode.ts
+++ b/packages/mobx-state-tree/src/core/node/BaseNode.ts
@@ -157,6 +157,12 @@ export abstract class BaseNode<C, S, T> {
     abstract finalizeCreation(): void
 
     protected baseFinalizeCreation(whenFinalized?: () => void) {
+        if (!this.isAlive) {
+            throw fail(
+                "assertion failed: cannot finalize the creation of a node that is already dead"
+            )
+        }
+
         // goal: afterCreate hooks runs depth-first. After attach runs parent first, so on afterAttach the parent has completed already
         if (this.state === NodeLifeCycle.CREATED) {
             if (this.parent) {

--- a/packages/mobx-state-tree/src/core/node/BaseNode.ts
+++ b/packages/mobx-state-tree/src/core/node/BaseNode.ts
@@ -157,11 +157,13 @@ export abstract class BaseNode<C, S, T> {
     abstract finalizeCreation(): void
 
     protected baseFinalizeCreation(whenFinalized?: () => void) {
-        if (!this.isAlive) {
-            // istanbul ignore next
-            throw fail(
-                "assertion failed: cannot finalize the creation of a node that is already dead"
-            )
+        if (process.env.NODE_ENV !== "production") {
+            if (!this.isAlive) {
+                // istanbul ignore next
+                throw fail(
+                    "assertion failed: cannot finalize the creation of a node that is already dead"
+                )
+            }
         }
 
         // goal: afterCreate hooks runs depth-first. After attach runs parent first, so on afterAttach the parent has completed already

--- a/packages/mobx-state-tree/src/core/node/BaseNode.ts
+++ b/packages/mobx-state-tree/src/core/node/BaseNode.ts
@@ -158,6 +158,7 @@ export abstract class BaseNode<C, S, T> {
 
     protected baseFinalizeCreation(whenFinalized?: () => void) {
         if (!this.isAlive) {
+            // istanbul ignore next
             throw fail(
                 "assertion failed: cannot finalize the creation of a node that is already dead"
             )

--- a/packages/mobx-state-tree/src/core/node/create-node.ts
+++ b/packages/mobx-state-tree/src/core/node/create-node.ts
@@ -23,7 +23,11 @@ export function createObjectNode<C, S, T>(
     const existingNode = getStateTreeNodeSafe(initialValue)
     if (existingNode) {
         if (existingNode.isRoot) {
-            existingNode.setParent(parent, subpath)
+            if (parent) {
+                existingNode.setParent(parent, subpath)
+            } else {
+                existingNode.clearParent()
+            }
             return existingNode
         }
 

--- a/packages/mobx-state-tree/src/core/node/create-node.ts
+++ b/packages/mobx-state-tree/src/core/node/create-node.ts
@@ -22,20 +22,25 @@ export function createObjectNode<C, S, T>(
 ): ObjectNode<C, S, T> {
     const existingNode = getStateTreeNodeSafe(initialValue)
     if (existingNode) {
-        if (existingNode.isRoot) {
-            if (parent) {
-                existingNode.setParent(parent, subpath)
-            } else {
-                existingNode.clearParent()
+        if (process.env.NODE_ENV !== "production") {
+            if (existingNode.parent) {
+                // istanbul ignore next
+                throw fail(
+                    `Cannot add an object to a state tree if it is already part of the same or another state tree. Tried to assign an object to '${
+                        parent ? parent.path : ""
+                    }/${subpath}', but it lives already at '${existingNode.path}'`
+                )
             }
-            return existingNode
+            if (!parent) {
+                // istanbul ignore next
+                throw fail(
+                    "assertion failed: an existing node with a parent cannot be reused to create a new node"
+                )
+            }
         }
 
-        throw fail(
-            `Cannot add an object to a state tree if it is already part of the same or another state tree. Tried to assign an object to '${
-                parent ? parent.path : ""
-            }/${subpath}', but it lives already at '${existingNode.path}'`
-        )
+        existingNode.setParent(parent!, subpath)
+        return existingNode
     }
 
     // not a node, a snapshot

--- a/packages/mobx-state-tree/src/core/node/create-node.ts
+++ b/packages/mobx-state-tree/src/core/node/create-node.ts
@@ -22,15 +22,14 @@ export function createObjectNode<C, S, T>(
 ): ObjectNode<C, S, T> {
     const existingNode = getStateTreeNodeSafe(initialValue)
     if (existingNode) {
+        if (existingNode.parent) {
+            throw fail(
+                `Cannot add an object to a state tree if it is already part of the same or another state tree. Tried to assign an object to '${
+                    parent ? parent.path : ""
+                }/${subpath}', but it lives already at '${existingNode.path}'`
+            )
+        }
         if (process.env.NODE_ENV !== "production") {
-            if (existingNode.parent) {
-                // istanbul ignore next
-                throw fail(
-                    `Cannot add an object to a state tree if it is already part of the same or another state tree. Tried to assign an object to '${
-                        parent ? parent.path : ""
-                    }/${subpath}', but it lives already at '${existingNode.path}'`
-                )
-            }
             if (!parent) {
                 // istanbul ignore next
                 throw fail(

--- a/packages/mobx-state-tree/src/core/node/create-node.ts
+++ b/packages/mobx-state-tree/src/core/node/create-node.ts
@@ -23,22 +23,19 @@ export function createObjectNode<C, S, T>(
     const existingNode = getStateTreeNodeSafe(initialValue)
     if (existingNode) {
         if (existingNode.parent) {
+            // istanbul ignore next
             throw fail(
                 `Cannot add an object to a state tree if it is already part of the same or another state tree. Tried to assign an object to '${
                     parent ? parent.path : ""
                 }/${subpath}', but it lives already at '${existingNode.path}'`
             )
         }
-        if (process.env.NODE_ENV !== "production") {
-            if (!parent) {
-                // istanbul ignore next
-                throw fail(
-                    "assertion failed: an existing node with a parent cannot be reused to create a new node"
-                )
-            }
-        }
 
-        existingNode.setParent(parent!, subpath)
+        if (parent) {
+            existingNode.setParent(parent, subpath)
+        }
+        // else it already has no parent since it is a pre-requisite
+
         return existingNode
     }
 

--- a/packages/mobx-state-tree/src/core/node/node-utils.ts
+++ b/packages/mobx-state-tree/src/core/node/node-utils.ts
@@ -76,8 +76,11 @@ export function isStateTreeNode<C = any, S = any>(value: any): value is IStateTr
  * @hidden
  */
 export function getStateTreeNode(value: IAnyStateTreeNode): AnyObjectNode {
-    if (isStateTreeNode(value)) return value.$treenode!
-    else throw fail(`Value ${value} is no MST Node`)
+    if (!isStateTreeNode(value)) {
+        // istanbul ignore next
+        throw fail(`Value ${value} is no MST Node`)
+    }
+    return value.$treenode!
 }
 
 /**
@@ -86,20 +89,6 @@ export function getStateTreeNode(value: IAnyStateTreeNode): AnyObjectNode {
  */
 export function getStateTreeNodeSafe(value: IAnyStateTreeNode): AnyObjectNode | null {
     return (value && value.$treenode) || null
-}
-
-/**
- * @internal
- * @hidden
- */
-export function canAttachNode(value: any) {
-    return (
-        value &&
-        typeof value === "object" &&
-        !(value instanceof Date) &&
-        !isStateTreeNode(value) &&
-        !Object.isFrozen(value)
-    )
 }
 
 /**

--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -416,16 +416,13 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
     }
 
     // bound on the constructor
-    unbox(childNode: AnyNode): AnyNode {
-        if (childNode) {
-            this.assertAlive({
-                subpath: childNode.subpath || childNode.subpathUponDeath
-            })
-            if (this._autoUnbox) {
-                return childNode.value
-            }
-        }
-        return childNode
+    unbox(childNode: AnyNode | undefined): AnyNode | undefined {
+        if (!childNode) return childNode
+
+        this.assertAlive({
+            subpath: childNode.subpath || childNode.subpathUponDeath
+        })
+        return this._autoUnbox ? childNode.value : childNode
     }
 
     toString(): string {

--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -422,14 +422,7 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
                 subpath: childNode.subpath || childNode.subpathUponDeath
             })
             if (this._autoUnbox) {
-                if (!childNode.isAlive && childNode instanceof ObjectNode) {
-                    // sometimes mobx de-enhancer might get a dead node even though the subpath still exists
-                    // (e.g. when using pop() / shift() from array in order to return the removed items)
-                    // in these cases, rather than trying to resurrect the dead node we clone it in a detached state
-                    return childNode.type.create(childNode.snapshot, childNode.environment)
-                } else {
-                    return childNode.value
-                }
+                return childNode.value
             }
         }
         return childNode

--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -175,9 +175,13 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
         if (this._observableInstanceState !== ObservableInstanceLifecycle.UNINITIALIZED) {
             return
         }
-        if (!this.isAlive) {
-            // istanbul ignore next
-            throw fail("assertion failed: a dead node cannot be re-created")
+        if (process.env.NODE_ENV !== "production") {
+            if (this.state !== NodeLifeCycle.INITIALIZING) {
+                // istanbul ignore next
+                throw fail(
+                    "assertion failed: the creation of the observable instance must be done on the initializing phase"
+                )
+            }
         }
         this._observableInstanceState = ObservableInstanceLifecycle.CREATING
 

--- a/packages/mobx-state-tree/src/core/node/scalar-node.ts
+++ b/packages/mobx-state-tree/src/core/node/scalar-node.ts
@@ -81,7 +81,7 @@ export class ScalarNode<C, S, T> extends BaseNode<C, S, T> {
 
     @action
     die(): void {
-        if (this.state === NodeLifeCycle.DETACHING) return
+        if (!this.isAlive || this.state === NodeLifeCycle.DETACHING) return
         this.aboutToDie()
         this.finalizeDeath()
     }

--- a/packages/mobx-state-tree/src/core/node/scalar-node.ts
+++ b/packages/mobx-state-tree/src/core/node/scalar-node.ts
@@ -53,18 +53,28 @@ export class ScalarNode<C, S, T> extends BaseNode<C, S, T> {
         return this.parent.root
     }
 
-    setParent(newParent: AnyObjectNode | null, subpath: string | null = null): void {
-        if (this.parent === newParent && this.subpath === subpath) return
-        if (this.parent && !newParent) {
-            this.die()
-        } else {
-            const newPath = subpath === null ? "" : subpath
-            if (newParent && newParent !== this.parent) {
+    setParent(newParent: AnyObjectNode, subpath: string): void {
+        const parentChanged = this.parent !== newParent
+        const subpathChanged = this.subpath !== subpath
+
+        if (!parentChanged && !subpathChanged) return
+
+        if (process.env.NODE_ENV !== "production") {
+            if (!subpath) {
+                // istanbul ignore next
+                throw fail("assertion failed: subpath expected")
+            }
+            if (!newParent) {
+                // istanbul ignore next
+                throw fail("assertion failed: parent expected")
+            }
+            if (parentChanged) {
+                // istanbul ignore next
                 throw fail("assertion failed: scalar nodes cannot change their parent")
-            } else if (this.subpath !== newPath) {
-                this.baseSetParent(this.parent, newPath)
             }
         }
+
+        this.baseSetParent(this.parent, subpath)
     }
 
     get snapshot(): S {

--- a/packages/mobx-state-tree/src/core/type/type-checker.ts
+++ b/packages/mobx-state-tree/src/core/type/type-checker.ts
@@ -39,6 +39,7 @@ function safeStringify(value: any) {
     try {
         return JSON.stringify(value)
     } catch (e) {
+        // istanbul ignore next
         return `<Unserializable: ${e}>`
     }
 }
@@ -97,14 +98,6 @@ function toErrorString(error: IValidationError): string {
                       : "")
             : `.`)
     )
-}
-
-/**
- * @internal
- * @hidden
- */
-export function getDefaultContext(type: IAnyType): IValidationContext {
-    return [{ type, path: "" }]
 }
 
 /**

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -325,8 +325,9 @@ export abstract class BaseType<C, S, T, N extends BaseNode<any, any, any> = Base
         return this.instantiate(null, "", environment, snapshot!).value
     }
 
-    getSnapshot(node: N, applyPostProcess: boolean = true): S {
-        return node.type.getSnapshot(node, applyPostProcess)
+    getSnapshot(node: N, applyPostProcess?: boolean): S {
+        // istanbul ignore next
+        throw fail("unimplemented method")
     }
 
     abstract reconcile(current: N, newValue: C | T): N
@@ -364,16 +365,19 @@ export abstract class BaseType<C, S, T, N extends BaseNode<any, any, any> = Base
     }
 
     get Type(): T {
+        // istanbul ignore next
         throw fail(
             "Factory.Type should not be actually called. It is just a Type signature that can be used at compile time with Typescript, by using `typeof type.Type`"
         )
     }
     get SnapshotType(): S {
+        // istanbul ignore next
         throw fail(
             "Factory.SnapshotType should not be actually called. It is just a Type signature that can be used at compile time with Typescript, by using `typeof type.SnapshotType`"
         )
     }
     get CreationType(): C {
+        // istanbul ignore next
         throw fail(
             "Factory.CreationType should not be actually called. It is just a Type signature that can be used at compile time with Typescript, by using `typeof type.CreationType`"
         )
@@ -465,7 +469,7 @@ export abstract class ComplexType<C, S, T> extends BaseType<C, S, T, ObjectNode<
         if (isStateTreeNode(newValue) && this.isAssignableFrom(getType(newValue))) {
             // newValue is a Node as well, move it here..
             const newNode = getStateTreeNode(newValue)
-            newNode.setParent(parent, subpath)
+            newNode.setParent(parent!, subpath)
             return newNode
         }
         // nothing to do, we have to create a new node
@@ -529,4 +533,17 @@ export abstract class SimpleType<C, S, T> extends BaseType<C, S, T, ScalarNode<C
  */
 export function isType(value: any): value is IAnyType {
     return typeof value === "object" && value && value.isType === true
+}
+
+/**
+ * @internal
+ * @hidden
+ */
+export function assertIsType(type: IAnyType) {
+    if (process.env.NODE_ENV !== "production") {
+        if (!isType(type)) {
+            // istanbul ignore next
+            throw fail("expected a mobx-state-tree type as argument, got " + type + " instead")
+        }
+    }
 }

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -341,6 +341,11 @@ function reconcileArrayChildren<TT>(
             // new one does not exists
             nothingChanged = false
             oldNodes.splice(i, 1)
+            if (oldNode instanceof ObjectNode) {
+                // since it is going to be returned by pop/splice/shift better create it before killing it
+                // so it doesn't end up in an undead state
+                oldNode.createObservableInstanceIfNeeded()
+            }
             oldNode.die()
             i--
         } else if (!oldNode) {
@@ -419,6 +424,11 @@ function valueAsNode(
 
     const newNode = getNewNode()
     if (oldNode && oldNode !== newNode) {
+        if (oldNode instanceof ObjectNode) {
+            // since it is going to be returned by pop/splice/shift better create it before killing it
+            // so it doesn't end up in an undead state
+            oldNode.createObservableInstanceIfNeeded()
+        }
         oldNode.die()
     }
     return newNode

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -44,7 +44,8 @@ import {
     IAnyStateTreeNode,
     AnyObjectNode,
     AnyNode,
-    createObjectNode
+    createObjectNode,
+    assertIsType
 } from "../../internal"
 
 /** @hidden */
@@ -306,12 +307,7 @@ export class ArrayType<IT extends IAnyType> extends ComplexType<
  * @returns
  */
 export function array<IT extends IAnyType>(subtype: IT): IArrayType<IT> {
-    if (process.env.NODE_ENV !== "production") {
-        if (!isType(subtype))
-            throw fail(
-                "expected a mobx-state-tree type as first argument, got " + subtype + " instead"
-            )
-    }
+    assertIsType(subtype)
     return new ArrayType<IT>(subtype.name + "[]", subtype)
 }
 

--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -163,7 +163,7 @@ class MSTMap<IT extends IAnyType> extends ObservableMap<string, any> {
     }
 
     put(value: ExtractCST<IT>): ExtractT<IT> {
-        if (!!!value) throw fail(`Map.put cannot be used to set empty values`)
+        if (!value) throw fail(`Map.put cannot be used to set empty values`)
         if (isStateTreeNode(value)) {
             const node = getStateTreeNode(value)
             if (process.env.NODE_ENV !== "production") {

--- a/packages/mobx-state-tree/src/types/utility-types/maybe.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/maybe.ts
@@ -11,7 +11,8 @@ import {
     ExtractS,
     ExtractT,
     IStateTreeNode,
-    RedefineIStateTreeNode
+    RedefineIStateTreeNode,
+    assertIsType
 } from "../../internal"
 
 const optionalUndefinedType = optional(undefinedType, undefined)
@@ -39,8 +40,7 @@ export interface IMaybeNull<IT extends IAnyType> extends IMaybeIType<IT, null | 
  * @returns
  */
 export function maybe<IT extends IAnyType>(type: IT): IMaybe<IT> {
-    if (process.env.NODE_ENV !== "production" && !isType(type))
-        throw fail("expected a mobx-state-tree type as first argument, got " + type + " instead")
+    assertIsType(type)
     return union(type, optionalUndefinedType)
 }
 
@@ -52,7 +52,6 @@ export function maybe<IT extends IAnyType>(type: IT): IMaybe<IT> {
  * @returns
  */
 export function maybeNull<IT extends IAnyType>(type: IT): IMaybeNull<IT> {
-    if (process.env.NODE_ENV !== "production" && !isType(type))
-        throw fail("expected a mobx-state-tree type as first argument, got " + type + " instead")
+    assertIsType(type)
     return union(type, optionalNullType)
 }

--- a/packages/mobx-state-tree/src/types/utility-types/optional.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/optional.ts
@@ -17,7 +17,8 @@ import {
     RedefineIStateTreeNode,
     IStateTreeNode,
     AnyObjectNode,
-    BaseType
+    BaseType,
+    assertIsType
 } from "../../internal"
 
 type IFunctionReturn<T> = () => T
@@ -149,12 +150,8 @@ function checkOptionalPreconditions<IT extends IAnyType>(
         )
     }
 
+    assertIsType(type)
     if (process.env.NODE_ENV !== "production") {
-        if (!isType(type))
-            throw fail(
-                "expected a mobx-state-tree type as first argument, got " + type + " instead"
-            )
-
         // we only check default values if they are passed directly
         // if they are generator functions they will be checked once they are generated
         // we don't check generator function results here to avoid generating a node just for type-checking purposes

--- a/packages/mobx-state-tree/src/types/utility-types/reference.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/reference.ts
@@ -28,7 +28,8 @@ import {
     applyPatch,
     AnyNode,
     AnyObjectNode,
-    SimpleType
+    SimpleType,
+    assertIsType
 } from "../../internal"
 
 export type OnReferenceInvalidatedEvent<STN extends IAnyStateTreeNode> = {
@@ -485,16 +486,14 @@ export function reference<IT extends IAnyComplexType>(
     subType: IT,
     options?: ReferenceOptions<IT>
 ): IReferenceType<IT> {
-    // check that a type is given
+    assertIsType(subType)
     if (process.env.NODE_ENV !== "production") {
-        if (!isType(subType))
-            throw fail(
-                "expected a mobx-state-tree type as first argument, got " + subType + " instead"
-            )
-        if (arguments.length === 2 && typeof arguments[1] === "string")
+        if (arguments.length === 2 && typeof arguments[1] === "string") {
+            // istanbul ignore next
             throw fail(
                 "References with base path are no longer supported. Please remove the base path."
             )
+        }
     }
 
     const getSetOptions = options ? (options as ReferenceOptionsGetSet<IT>) : undefined

--- a/packages/mobx-state-tree/src/types/utility-types/refinement.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/refinement.ts
@@ -14,7 +14,8 @@ import {
     BaseType,
     ExtractS,
     ExtractT,
-    ExtractNodeType
+    ExtractNodeType,
+    assertIsType
 } from "../../internal"
 
 class Refinement<IT extends IAnyType> extends BaseType<
@@ -104,19 +105,20 @@ export function refinement(...args: any[]): IAnyType {
         ? args[2]
         : (v: any) => "Value does not respect the refinement predicate"
     // ensures all parameters are correct
+    assertIsType(type)
     if (process.env.NODE_ENV !== "production") {
-        if (typeof name !== "string")
+        if (typeof name !== "string") {
+            // istanbul ignore next
             throw fail("expected a string as first argument, got " + name + " instead")
-        if (!isType(type))
-            throw fail(
-                "expected a mobx-state-tree type as first or second argument, got " +
-                    type +
-                    " instead"
-            )
-        if (typeof predicate !== "function")
+        }
+        if (typeof predicate !== "function") {
+            // istanbul ignore next
             throw fail("expected a function as third argument, got " + predicate + " instead")
-        if (typeof message !== "function")
+        }
+        if (typeof message !== "function") {
+            // istanbul ignore next
             throw fail("expected a function as fourth argument, got " + message + " instead")
+        }
     }
     return new Refinement(name, type, predicate, message)
 }

--- a/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
@@ -5,7 +5,6 @@ import {
     IAnyType,
     ExtractT,
     BaseType,
-    isType,
     isStateTreeNode,
     IValidationContext,
     IValidationResult,
@@ -13,7 +12,8 @@ import {
     RedefineIStateTreeNode,
     IStateTreeNode,
     TypeFlags,
-    ExtractNodeType
+    ExtractNodeType,
+    assertIsType
 } from "../../internal"
 
 /** @hidden */
@@ -202,16 +202,14 @@ export function snapshotProcessor<
     processors: ISnapshotProcessors<ExtractC<IT>, CustomC, ExtractS<IT>, CustomS>,
     name?: string
 ): ISnapshotProcessor<IT, CustomC, CustomS> {
+    assertIsType(type)
     if (process.env.NODE_ENV !== "production") {
-        if (!isType(type))
-            throw fail(
-                "expected a mobx-state-tree type as first argument, got " + type + " instead"
-            )
-
         if (processors.postProcessor && typeof processors.postProcessor !== "function") {
+            // istanbul ignore next
             throw fail("postSnapshotProcessor must be a function")
         }
         if (processors.preProcessor && typeof processors.preProcessor !== "function") {
+            // istanbul ignore next
             throw fail("preSnapshotProcessor must be a function")
         }
     }


### PR DESCRIPTION
I found out that sometimes while performing array reconciliation some dead nodes wouldn't actually die, this PR fixes this.

This is specially awkward when using array methods that remove a node and also return them (pop, shift, splice, etc). Before this PR it would return "undead nodes", this is, nodes that would be killed (with all the lifecycle being called) yet they would be resurrected by the mobx enhancer by calling createObservableIfNeeded again in order to return them from those methods.

After this PR these nodes will actually die, following their natural lifecycle, but if the dehancer tries to return them again what will be returned is a clone of such nodes. The bad side effect is that such auto-creation is done even when the user won't use the returned values (since it cannot know beforehand), but I still think that's better than returning a half-broken node in a inconsistent state as right now.

The second option is to disable pop/shift/splice from returning any complex values at all (for dead nodes) or alternatively return their snapshots, but maybe that'd be a breaking change? Though the good thing is that no nodes would be auto created when using such methods.

A third option would be to detach the node instead, but that'd mean that pop-ed nodes wouldn't die on their own and the user would need to call destroy on them manually :-/

Personally I like the second option best, but that's a breaking change for sure, so maybe add a new parameter option to types.array ('fast' | 'slow' defaulting to 'slow' for compatibility) that will change the pop/push/splice implementation to return nothing on fast mode?

**UPDATE:** **Ok, better idea implemented. pop/shift/etc will actually return dead nodes, but will ensure they are finalized before killing them, so the user will have to use clone/getSnapshot over them manually if he wants to access their data (or deal with the warning/error of liveliness data depending on the selected setting).**

This way the nodes will follow their proper life-cycle before dying, there's no auto cloning involved and liveliness error checking will kick in if they try to access their data for some reason.

@mweststrate @k-g-a thoughts on this?

Additionally:
* added extra assertions to check everything is ok (not hit by coveralls, that's why the coverage decreased)
* fixed some nodes not actually following the proper lifecycle when dying
* uses node.environment rather than node.root.environment wherever possible for a very slight speed boost (no need to traverse the tree to the root all the time, since environments are already on the node itself)