### PR TITLE
add more output formats (umd min, cjs min)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
--   Added more output formats for the library (common-js minified version and umd minified version). Note that now the umd version will be the development version while the new umd.min version will be the production version. This change is to keep it in sync with the parent mobx package.
+# 3.12.2
+
+-   Added more output formats for the library (common-js minified version and umd minified version). Note that now the umd version will be the development version while the new umd.min version will be the production version. This change is to keep it in sync with the parent mobx package. Also the npm package is now leaner since it mistakenly included separatedly compiled js files and source maps.
 
 # 3.12.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+-   Added more output formats for the library (common-js minified version and umd minified version). Note that now the umd version will be the development version while the new umd.min version will be the production version. This change is to keep it in sync with the parent mobx package.
+
 # 3.12.1
 
 -   Fixed a regression with `getEnv` sometimes not returning the proper environment.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "dependencies": {},
     "scripts": {
-        "clean": "lerna clean",
+        "clean": "lerna run clean --stream",
         "build": "lerna run build --stream",
         "test": "lerna run test --stream",
         "test:mst:dev": "cd packages/mobx-state-tree && yarn test:dev",
@@ -11,7 +11,8 @@
         "test:mst-middlewares:dev": "cd packages/mst-middlewares && yarn test:dev",
         "test:mst-middlewares:prod": "cd packages/mst-middlewares && yarn test:prod",
         "coverage": "lerna run coverage --stream",
-        "release": "yarn build && lerna publish"
+        "release": "yarn build && lerna publish",
+        "tag-new-version": "lerna version"
     },
     "workspaces": [
         "packages/mobx-state-tree",

--- a/packages/mobx-state-tree/__tests__/core/api.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/api.test.ts
@@ -147,7 +147,7 @@ test("all methods mentioned in API docs", () => {
 })
 
 test("only accepted dependencies", () => {
-    const validDeps = ["tslib"]
+    const validDeps: string[] = []
 
     const deps = JSON.parse(readFileSync(__dirname + "/../../package.json", "utf8")).dependencies
 

--- a/packages/mobx-state-tree/package.json
+++ b/packages/mobx-state-tree/package.json
@@ -14,8 +14,8 @@
     "react-native": "dist/mobx-state-tree.module.js",
     "typings": "dist/index.d.ts",
     "scripts": {
-        "build": "shx cp ../../README.md . && tsc && cpr lib dist --delete-first --filter=\\\\.js && yarn rollup",
-        "rollup": "rollup -c",
+        "clean": "shx rm -rf dist && shx rm -rf lib",
+        "build": "yarn clean && shx cp ../../README.md . && tsc && cpr lib dist --filter=.*\\.js && rollup -c",
         "jest": "jest --testPathPattern=/__tests__/core/",
         "jest:perf": "jest --testPathPattern=/__tests__/perf/",
         "test:perf": "yarn build && yarn jest:perf && TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' /usr/bin/time node --expose-gc --require ts-node/register __tests__/perf/report.ts",

--- a/packages/mobx-state-tree/package.json
+++ b/packages/mobx-state-tree/package.json
@@ -64,7 +64,8 @@
         "tslint": "^5.14.0",
         "typedoc": "^0.14.2",
         "typedoc-plugin-markdown": "^1.1.27",
-        "typescript": "^3.3.3333"
+        "typescript": "^3.3.3333",
+        "tslib": "^1.9.3"
     },
     "peerDependencies": {
         "mobx": ">=4.8.0 <5.0.0 || >=5.8.0 <6.0.0"
@@ -78,7 +79,5 @@
         "functional-reactive-programming",
         "state management"
     ],
-    "dependencies": {
-        "tslib": "^1.9.3"
-    }
+    "dependencies": {}
 }

--- a/packages/mobx-state-tree/package.json
+++ b/packages/mobx-state-tree/package.json
@@ -15,7 +15,7 @@
     "typings": "dist/index.d.ts",
     "scripts": {
         "clean": "shx rm -rf dist && shx rm -rf lib",
-        "build": "yarn clean && shx cp ../../README.md . && tsc && cpr lib dist --filter=.*\\.js && rollup -c",
+        "build": "yarn clean && shx cp ../../README.md . && tsc && cpr lib dist --filter=\\.js$ && rollup -c",
         "jest": "jest --testPathPattern=/__tests__/core/",
         "jest:perf": "jest --testPathPattern=/__tests__/perf/",
         "test:perf": "yarn build && yarn jest:perf && TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' /usr/bin/time node --expose-gc --require ts-node/register __tests__/perf/report.ts",

--- a/packages/mobx-state-tree/package.json
+++ b/packages/mobx-state-tree/package.json
@@ -5,6 +5,13 @@
     "main": "dist/mobx-state-tree.js",
     "umd:main": "dist/mobx-state-tree.umd.js",
     "module": "dist/mobx-state-tree.module.js",
+    "browser": {
+        "./dist/mobx-state-tree.js": "./dist/mobx-state-tree.js",
+        "./dist/mobx-state-tree.module.js": "./dist/mobx-state-tree.module.js"
+    },
+    "unpkg": "dist/mobx-state-tree.umd.min.js",
+    "jsnext:main": "dist/mobx-state-tree.module.js",
+    "react-native": "dist/mobx-state-tree.module.js",
     "typings": "dist/index.d.ts",
     "scripts": {
         "build": "shx cp ../../README.md . && tsc && cpr lib dist --delete-first --filter=\\\\.js && yarn rollup",

--- a/packages/mobx-state-tree/rollup.config.js
+++ b/packages/mobx-state-tree/rollup.config.js
@@ -1,48 +1,25 @@
-import filesize from "rollup-plugin-filesize"
-import resolve from "rollup-plugin-node-resolve"
-import { uglify } from "rollup-plugin-uglify"
-import replace from "rollup-plugin-replace"
+import { baseConfig } from "../../rollup.base-config"
 
-function getEnvVariables(production) {
-    return { "process.env.NODE_ENV": production ? "'production'" : "'development'" }
-}
+const config = (outFile, format, mode) =>
+    baseConfig({
+        outFile,
+        format,
+        mode,
 
-const input = "./lib/index.js"
-const externals = ["mobx"]
-const globals = {
-    mobx: "mobx"
-}
+        input: "./lib/index.js",
+        globals: {
+            mobx: "mobx"
+        },
+        umdName: "mobxStateTree",
+        external: ["mobx"]
+    })
 
 export default [
-    {
-        input: input,
-        output: {
-            file: "./dist/mobx-state-tree.js",
-            format: "cjs",
-            globals: globals
-        },
-        external: externals,
-        plugins: [resolve(), filesize()]
-    },
-    {
-        input: input,
-        output: {
-            file: "./dist/mobx-state-tree.umd.js",
-            format: "umd",
-            globals: globals,
-            name: "mobxStateTree"
-        },
-        external: externals,
-        plugins: [resolve(), replace(getEnvVariables(true)), uglify(), filesize()]
-    },
-    {
-        input: input,
-        output: {
-            file: "./dist/mobx-state-tree.module.js",
-            format: "es",
-            globals: globals
-        },
-        external: externals,
-        plugins: [resolve(), filesize()]
-    }
+    config("mobx-state-tree.js", "cjs", "development"),
+    config("mobx-state-tree.min.js", "cjs", "production"),
+
+    config("mobx-state-tree.umd.js", "umd", "development"),
+    config("mobx-state-tree.umd.min.js", "umd", "production"),
+
+    config("mobx-state-tree.module.js", "es", "development")
 ]

--- a/packages/mobx-state-tree/tsconfig.json
+++ b/packages/mobx-state-tree/tsconfig.json
@@ -1,24 +1,7 @@
 {
-    "version": "2.0.0",
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es5",
-        "sourceMap": true,
-        "declaration": true,
-        "module": "es2015",
-        "removeComments": false,
-        "outDir": "lib/",
-        "moduleResolution": "node",
-        "experimentalDecorators": true,
-        "strict": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
-        "noImplicitAny": true,
-        "noFallthroughCasesInSwitch": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "importHelpers": true,
-        "stripInternal": true,
-        "lib": ["es6"]
+        "outDir": "lib/"
     },
     "files": ["src/index.ts"]
 }

--- a/packages/mst-middlewares/package.json
+++ b/packages/mst-middlewares/package.json
@@ -14,11 +14,12 @@
     "react-native": "dist/mst-middlewares.module.js",
     "typings": "dist/index.d.ts",
     "scripts": {
+        "clean": "shx rm -rf dist && shx rm -rf lib",
+        "build": "yarn clean && tsc && cpr lib dist --filter=.*\\.js && rollup -c",
         "jest": "jest",
         "test": "yarn test:dev && yarn test:prod",
         "test:dev": "cross-env NODE_ENV=development JEST_JUNIT_OUTPUT=../../test-results/mst-middlewares/dev.xml yarn jest",
         "test:prod": "cross-env NODE_ENV=production JEST_JUNIT_OUTPUT=../../test-results/mst-middlewares/prod.xml yarn jest",
-        "build": "tsc && cpr lib dist --delete-first --filter=\\\\.js && rollup -c",
         "lint": "tslint -c ./tslint.json 'src/**/*.ts'"
     },
     "author": "",

--- a/packages/mst-middlewares/package.json
+++ b/packages/mst-middlewares/package.json
@@ -40,7 +40,8 @@
         "rollup-plugin-replace": "^2.1.0",
         "rollup-plugin-uglify": "^6.0.2",
         "ts-jest": "^24.0.0",
-        "typescript": "^3.3.3333"
+        "typescript": "^3.3.3333",
+        "tslib": "^1.9.3"
     },
     "peerDependencies": {
         "mobx-state-tree": "^3.11.0"
@@ -48,7 +49,5 @@
     "files": [
         "dist/"
     ],
-    "dependencies": {
-        "tslib": "^1.9.3"
-    }
+    "dependencies": {}
 }

--- a/packages/mst-middlewares/package.json
+++ b/packages/mst-middlewares/package.json
@@ -15,7 +15,7 @@
     "typings": "dist/index.d.ts",
     "scripts": {
         "clean": "shx rm -rf dist && shx rm -rf lib",
-        "build": "yarn clean && tsc && cpr lib dist --filter=.*\\.js && rollup -c",
+        "build": "yarn clean && tsc && cpr lib dist --filter=\\.js$ && rollup -c",
         "jest": "jest",
         "test": "yarn test:dev && yarn test:prod",
         "test:dev": "cross-env NODE_ENV=development JEST_JUNIT_OUTPUT=../../test-results/mst-middlewares/dev.xml yarn jest",

--- a/packages/mst-middlewares/package.json
+++ b/packages/mst-middlewares/package.json
@@ -5,6 +5,13 @@
     "main": "dist/mst-middlewares.js",
     "umd:main": "dist/mst-middlewares.umd.js",
     "module": "dist/mst-middlewares.module.js",
+    "browser": {
+        "./dist/mst-middlewares.js": "./dist/mst-middlewares.js",
+        "./dist/mst-middlewares.module.js": "./dist/mst-middlewares.module.js"
+    },
+    "unpkg": "dist/mst-middlewares.umd.min.js",
+    "jsnext:main": "dist/mst-middlewares.module.js",
+    "react-native": "dist/mst-middlewares.module.js",
     "typings": "dist/index.d.ts",
     "scripts": {
         "jest": "jest",
@@ -24,10 +31,12 @@
         "jest": "^24.5.0",
         "jest-junit": "^6.3.0",
         "mobx": "^5.9.0",
-        "mobx-state-tree": "^3.12.1",
+        "mobx-state-tree": "3.12.1",
         "rollup": "^1.6.0",
         "rollup-plugin-commonjs": "^9.2.1",
+        "rollup-plugin-filesize": "^6.0.1",
         "rollup-plugin-node-resolve": "^4.0.1",
+        "rollup-plugin-replace": "^2.1.0",
         "rollup-plugin-uglify": "^6.0.2",
         "ts-jest": "^24.0.0",
         "typescript": "^3.3.3333"

--- a/packages/mst-middlewares/rollup.config.js
+++ b/packages/mst-middlewares/rollup.config.js
@@ -1,43 +1,26 @@
-import resolve from "rollup-plugin-node-resolve"
-import { uglify } from "rollup-plugin-uglify"
+import { baseConfig } from "../../rollup.base-config"
 
-const input = "./lib/index.js"
-const externals = ["mobx", "mobx-state-tree"]
-const globals = {
-    mobx: "mobx",
-    "mobx-state-tree": "mobxStateTree"
-}
+const config = (outFile, format, mode) =>
+    baseConfig({
+        outFile,
+        format,
+        mode,
+
+        input: "./lib/index.js",
+        globals: {
+            mobx: "mobx",
+            "mobx-state-tree": "mobxStateTree"
+        },
+        umdName: "mstMiddlewares",
+        external: ["mobx", "mobx-state-tree"]
+    })
 
 export default [
-    {
-        input: input,
-        output: {
-            file: "./dist/mst-middlewares.js",
-            format: "cjs",
-            globals: globals
-        },
-        external: externals,
-        plugins: [resolve()]
-    },
-    {
-        input: input,
-        output: {
-            file: "./dist/mst-middlewares.umd.js",
-            format: "umd",
-            globals: globals,
-            name: "mobxStateTree"
-        },
-        external: externals,
-        plugins: [resolve(), uglify()]
-    },
-    {
-        input: input,
-        output: {
-            file: "./dist/mst-middlewares.module.js",
-            format: "es",
-            globals: globals
-        },
-        external: externals,
-        plugins: [resolve()]
-    }
+    config("mst-middlewares.js", "cjs", "development"),
+    config("mst-middlewares.min.js", "cjs", "production"),
+
+    config("mst-middlewares.umd.js", "umd", "development"),
+    config("mst-middlewares.umd.min.js", "umd", "production"),
+
+    config("mst-middlewares.module.js", "es", "development")
 ]

--- a/packages/mst-middlewares/tsconfig.json
+++ b/packages/mst-middlewares/tsconfig.json
@@ -1,24 +1,7 @@
 {
-    "version": "2.0.0",
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es5",
-        "sourceMap": true,
-        "declaration": true,
-        "module": "es2015",
-        "removeComments": false,
-        "outDir": "lib/",
-        "moduleResolution": "node",
-        "experimentalDecorators": true,
-        "strict": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
-        "noImplicitAny": true,
-        "noFallthroughCasesInSwitch": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "importHelpers": true,
-        "stripInternal": true,
-        "lib": ["es6"]
+        "outDir": "lib/"
     },
     "files": ["src/index.ts"]
 }

--- a/rollup.base-config.js
+++ b/rollup.base-config.js
@@ -1,0 +1,26 @@
+import * as path from "path"
+import filesize from "rollup-plugin-filesize"
+import resolve from "rollup-plugin-node-resolve"
+import { uglify } from "rollup-plugin-uglify"
+import replace from "rollup-plugin-replace"
+
+const devPlugins = () => [resolve(), filesize()]
+
+const prodPlugins = () => [
+    resolve(),
+    replace({ "process.env.NODE_ENV": "production" }),
+    uglify(),
+    filesize()
+]
+
+export const baseConfig = ({ input, globals, umdName, external, outFile, format, mode }) => ({
+    input,
+    output: {
+        file: path.join("./dist", outFile),
+        format: format,
+        globals,
+        name: format === "umd" ? umdName : undefined
+    },
+    external,
+    plugins: mode === "production" ? prodPlugins() : devPlugins()
+})

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "sourceMap": false,
+        "declaration": true,
+        "module": "es2015",
+        "removeComments": false,
+        "moduleResolution": "node",
+        "experimentalDecorators": true,
+        "strict": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "noImplicitAny": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
+        "importHelpers": true,
+        "stripInternal": true,
+        "downlevelIteration": true,
+        "lib": ["es6"]
+    }
+}


### PR DESCRIPTION
Adds more output formats to be in sync with the main mobx package.
Also adds some missing fields to package.json (like the ones mobx uses)
Fixes umd name for mst-middlewares mistakenly set to mobxStateTree rather than mstMiddlewares
Fixes .js and .js.map files being mistakenly copied to dist folders (thus confusing/allowing ides to import stuff from the internals)

Changelog:
-   Added more output formats for the library (common-js minified version and umd minified version). Note that now the umd version will be the development version while the new umd.min version will be the production version. This change is to keep it in sync with the parent mobx package.


Fixes #1038 