### PR TITLE
add mstRunInAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,12 +465,7 @@ someModel.actions(self => {
 })
 ```
 
-Note that, since MST v3.9, TypeScript correctly infers `flow` arguments and usually infers correctly `flow` return types,
-but one exception to this case is when a `Promise` is returned as final value. In this case (and only in this case) this construct needs to be used:
-
-```ts
-return castFlowReturn(somePromise)
-```
+Note that, since MST v3.9, TypeScript correctly infers `flow` arguments and usually infers correctly `flow` final return types, however intermediate yielsd will have `any` as type.
 
 #### Action listeners versus middleware
 
@@ -1126,7 +1121,6 @@ See the [full API docs](docs/API/README.md) for more details.
 | [`destroy(node)`](docs/API/README.md#destroy)                                                                         | Kills `node`, making it unusable. Removes it from any parent in the process                                                                                                                                                                           |
 | [`detach(node)`](docs/API/README.md#detach)                                                                           | Removes `node` from its current parent, and lets it live on as standalone tree                                                                                                                                                                        |
 | [`flow(generator)`](docs/API/README.md#flow)                                                                          | Creates an asynchronous flow based on a generator function                                                                                                                                                                                            |
-| [`castFlowReturn(value)`](docs/API/README.md#castflowreturn)                                                          | Casts a flow return value so it can be correctly inferred as return type. Only needed when using TypeScript and when returning a Promise.                                                                                                             |
 | [`getChildType(node, property?)`](docs/API/README.md#getchildtype)                                                    | Returns the declared type of the given `property` of `node`. For arrays and maps `property` can be omitted as they all have the same type                                                                                                             |
 | [`getEnv(node)`](docs/API/README.md#getenv)                                                                           | Returns the environment of `node`, see [environments](#environments)                                                                                                                                                                                  |
 | [`getParent(node, depth=1)`](docs/API/README.md#getparent)                                                            | Returns the intermediate parent of the `node`, or a higher one if `depth > 1`                                                                                                                                                                         |
@@ -1147,6 +1141,7 @@ See the [full API docs](docs/API/README.md) for more details.
 | [`isValidReference(() => node \| null \| undefined, checkIfAlive = true)`](docs/API/README.md#isvalidreference)       | Tests if a reference is valid (pointing to an existing node and optionally if alive) and returns if the check passes or not.                                                                                                                          |
 | [`isRoot(node)`](docs/API/README.md#isroot)                                                                           | Returns true if `node` has no parents                                                                                                                                                                                                                 |
 | [`joinJsonPath(parts)`](docs/API/README.md#joinjsonpath)                                                              | Joins and escapes the given path `parts` into a JSON path                                                                                                                                                                                             |
+| [`mstRunInAction<T>(node, name?: string, thunk: () => T): T`](docs/API/README.md#mstruninaction)                      | Similar to mobx `runInAction`, it allows you to run an anonymous action as if it were part of a given type instance.                                                                                                                                  |
 | [`onAction(node, (actionDescription) => void)`](docs/API/README.md#onaction)                                          | A built-in middleware that calls the provided callback with an action description upon each invocation. Returns disposer                                                                                                                              |
 | [`onPatch(node, (patch) => void)`](docs/API/README.md#onpatch)                                                        | Attach a JSONPatch listener, that is invoked for each change in the tree. Returns disposer                                                                                                                                                            |
 | [`onSnapshot(node, (snapshot) => void)`](docs/API/README.md#onsnapshot)                                               | Attach a snapshot listener, that is invoked for each change in the tree. Returns disposer                                                                                                                                                             |
@@ -1369,7 +1364,7 @@ Actually, the more strict options that are enabled, the better the type system w
 
 We recommend using TypeScript together with MST, but since the type system of MST is more dynamic than the TypeScript system, there are cases that cannot be expressed neatly and occasionally you will need to fallback to `any` or manually adding type annotations.
 
-Flow is not supported.
+Flow is partially supported.
 
 #### Using a MST type at design time
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- Added `mstRunInAction`, similar to mobx's `runInAction` but for MST node instances.
+- Removed `castFlowReturn` since when a flow returns a promise what is actually returned from the flow is the resolved value.
 - Through PR [#1196](https://github.com/mobxjs/mobx-state-tree/pull/1196) by [@xaviergonz](https://github.com/xaviergonz)
   - Added `createActionTrackerMiddleware2`, a more easy to use version of the first one, which makes creating middlewares for both sync and async actions more universal.
   - Added an optional filter to `recordPatches` to be able to skip recording certain patches.

--- a/docs/API/README.md
+++ b/docs/API/README.md
@@ -74,7 +74,6 @@ _This reference guide lists all methods exposed by MST. Contributions like lingu
 * [applySnapshot](#applysnapshot)
 * [array](#array)
 * [cast](#cast)
-* [castFlowReturn](#castflowreturn)
 * [castToReferenceSnapshot](#casttoreferencesnapshot)
 * [castToSnapshot](#casttosnapshot)
 * [clone](#clone)
@@ -131,6 +130,7 @@ _This reference guide lists all methods exposed by MST. Contributions like lingu
 * [maybe](#maybe)
 * [maybeNull](#maybenull)
 * [model](#model)
+* [mstRunInAction](#mstruninaction)
 * [onAction](#onaction)
 * [onPatch](#onpatch)
 * [onSnapshot](#onsnapshot)
@@ -788,26 +788,6 @@ const ModelB = types.model({
 
 **Returns:** `O`
 The same object casted as an instance
-
-___
-<a id="castflowreturn"></a>
-
-###  castFlowReturn
-
-▸ **castFlowReturn**<`T`>(val: *`T`*): `FlowReturn`<`T`>
-
-Used for TypeScript to make flows that return a promise return the actual promise result.
-
-**Type parameters:**
-
-#### T 
-**Parameters:**
-
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| val | `T` |  \- |
-
-**Returns:** `FlowReturn`<`T`>
 
 ___
 <a id="casttoreferencesnapshot"></a>
@@ -2922,6 +2902,44 @@ See the [model type](https://github.com/mobxjs/mobx-state-tree#creating-models) 
 | `Optional` properties | [P]() |
 
 **Returns:** [IModelType](interfaces/imodeltype.md)<`ModelPropertiesDeclarationToProperties`<`P`>, `__type`>
+
+___
+<a id="mstruninaction"></a>
+
+###  mstRunInAction
+
+▸ **mstRunInAction**<`T`>(node: *`IAnyStateTreeNode`*, name: *`string`*, thunk: *`function`*): `T`
+
+▸ **mstRunInAction**<`T`>(node: *`IAnyStateTreeNode`*, thunk: *`function`*): `T`
+
+Similar to mobx `runInAction`, it allows you to run an anonymous action as if it were part of a given type instance.
+
+**Type parameters:**
+
+#### T 
+**Parameters:**
+
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| node | `IAnyStateTreeNode` |  \- |
+| name | `string` |
+| thunk | `function` |
+
+**Returns:** `T`
+
+Similar to mobx `runInAction`, it allows you to run an anonymous action as if it were part of a given type instance.
+
+**Type parameters:**
+
+#### T 
+**Parameters:**
+
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| node | `IAnyStateTreeNode` |  \- |
+| thunk | `function` |
+
+**Returns:** `T`
 
 ___
 <a id="onaction"></a>

--- a/packages/mobx-state-tree/__tests__/core/action.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/action.test.ts
@@ -10,9 +10,9 @@ import {
     cast,
     IMiddlewareEvent,
     ISerializedActionCall,
-    Instance
+    Instance,
+    mstRunInAction
 } from "../../src"
-import { mstRunInAction } from "../../src/internal"
 
 /// Simple action replay and invocation
 const Task = types

--- a/packages/mobx-state-tree/__tests__/core/api.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/api.test.ts
@@ -15,7 +15,6 @@ const METHODS_AND_INTERNAL_TYPES = stringToArray(`
     addMiddleware,
     isStateTreeNode,
     flow,
-    castFlowReturn,
     applyAction,
     onAction,
     recordActions,
@@ -75,6 +74,7 @@ const METHODS_AND_INTERNAL_TYPES = stringToArray(`
     isValidReference,
     tryReference,
     getNodeId,
+    mstRunInAction,
 
     types
 `)

--- a/packages/mobx-state-tree/__tests__/core/async.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/async.test.ts
@@ -7,8 +7,7 @@ import {
     destroy,
     IMiddlewareHandler,
     IMiddlewareEvent,
-    IMiddlewareEventType,
-    castFlowReturn
+    IMiddlewareEventType
     // TODO: export IRawActionCall
 } from "../../src"
 import { reaction, configure } from "mobx"
@@ -24,9 +23,7 @@ function delay<TV>(time: number, value: TV, shouldThrow = false): Promise<TV> {
 
 function testCoffeeTodo(
     done: () => void,
-    generator: (
-        self: any
-    ) => ((str: string) => IterableIterator<Promise<any> | string | undefined>),
+    generator: (self: any) => (str: string) => IterableIterator<Promise<any> | string | undefined>,
     shouldError: boolean,
     resultValue: string | undefined,
     producedCoffees: any[]
@@ -334,10 +331,10 @@ test("flow typings", async () => {
         numberToNumber: flow(function*(val: number) {
             yield promise
             return val
-        }), // should be () => Promise<number>
+        }), // should be () => Promise<2>
         voidToNumber: flow(function*() {
             yield promise
-            return castFlowReturn(Promise.resolve(2))
+            return 2
         })
     }))
 

--- a/packages/mobx-state-tree/src/core/flow.ts
+++ b/packages/mobx-state-tree/src/core/flow.ts
@@ -46,16 +46,6 @@ export function flow<R, Args extends any[]>(
 }
 
 /**
- *  Used for TypeScript to make flows that return a promise return the actual promise result.
- *
- * @param val
- * @returns
- */
-export function castFlowReturn<T>(val: T): FlowReturn<T> {
-    return val as any
-}
-
-/**
  * @internal
  * @hidden
  */

--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -40,7 +40,6 @@ export {
     IStateTreeNode,
     IAnyStateTreeNode,
     flow,
-    castFlowReturn,
     applyAction,
     onAction,
     IActionRecorder,
@@ -144,5 +143,6 @@ export {
     ISnapshotProcessor,
     ISnapshotProcessors,
     getNodeId,
+    mstRunInAction,
     types
 } from "./internal"

--- a/packages/mobx-state-tree/src/utils.ts
+++ b/packages/mobx-state-tree/src/utils.ts
@@ -456,6 +456,6 @@ export function assertIsNumber(
 export function assertIsString(value: string, argNumber: number | number[], canBeEmpty = true) {
     assertArg(value, s => typeof s === "string", "string", argNumber)
     if (!canBeEmpty) {
-        assertArg(value, s => s !== "", "not empty string", argNumber)
+        assertArg(value, s => s !== "", "non-empty string", argNumber)
     }
 }


### PR DESCRIPTION
- Added `mstRunInAction`, similar to mobx's `runInAction` but for MST node instances.
- Removed `castFlowReturn` since when a flow returns a promise what is actually returned from the flow is the resolved value. (this makes mobx and mst flow defs similar)

`mstRunInAction(node, name?, thunk)`

Usually used to do async/await actions without the need for superfluous actions. Not as good as flow, but has better type inference.

That being said I'm really looking forward [Strongly typed iterators and generators](https://github.com/Microsoft/TypeScript/issues/2983) in the roadmap for TS 3.5 to finally fix the typings for flow
