### PR TITLE
Fix: Type instantiation is excessively deep and possibly infinite. TS2589 (TS3.4)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-- Reduced type nesting to avoid Typescript 3.4 errors about infinite types. Sadly due to this change `types.create` is no longer smart enough in TS to know skipping the create parameter is valid or not.
+- Reduced type nesting to avoid Typescript 3.4 errors about infinite types. Sadly due to this change `types.create` is no longer smart enough in TS to know skipping the create parameter is valid or not. Through [#1251](https://github.com/mobxjs/mobx-state-tree/pull/1251) by [@xaviergonz](https://github.com/xaviergonz).
 
 # 3.13.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- Reduced type nesting to avoid Typescript 3.4 errors about infinite types. Sadly due to this change `types.create` is no longer smart enough in TS to know skipping the create parameter is valid or not.
+
 # 3.13.0
 
 - Fixed `Instance<typeof variable>` not giving the proper type in Typescript when the type included both objects and primitives.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-- Reduced type nesting to avoid Typescript 3.4 errors about infinite types. Sadly due to this change `types.create` is no longer smart enough in TS to know skipping the create parameter is valid or not. Through [#1251](https://github.com/mobxjs/mobx-state-tree/pull/1251) by [@xaviergonz](https://github.com/xaviergonz).
+- Reduced type nesting to avoid Typescript 3.4 errors about infinite types. Sadly due to this change `types.create` is no longer smart enough in TS to know if skipping the parameter is valid or not. Through [#1251](https://github.com/mobxjs/mobx-state-tree/pull/1251) by [@xaviergonz](https://github.com/xaviergonz).
 
 # 3.13.0
 

--- a/docs/API/README.md
+++ b/docs/API/README.md
@@ -717,7 +717,7 @@ ___
 
 ▸ **cast**<`O`>(snapshotOrInstance: *`O`*): `O`
 
-▸ **cast**<`O`>(snapshotOrInstance: *`ExtractC`<`TypeOfValue`<`O`>> \| `ExtractS`<`TypeOfValue`<`O`>> \| `ExtractTWithSTN`<`TypeOfValue`<`O`>>*): `O`
+▸ **cast**<`O`>(snapshotOrInstance: *`TypeOfValue<O>["CreationType"]` \| `TypeOfValue<O>["SnapshotType"]` \| `TypeOfValue<O>["Type"]`*): `O`
 
 Casts a node snapshot or instance type to an instance type so it can be assigned to a type instance. Note that this is just a cast for the type system, this is, it won't actually convert a snapshot to an instance, but just fool typescript into thinking so. Either way, casting when outside an assignation operation won't compile.
 
@@ -784,7 +784,7 @@ const ModelB = types.model({
 
 | Name | Type | Description |
 | ------ | ------ | ------ |
-| snapshotOrInstance | `ExtractC`<`TypeOfValue`<`O`>> \| `ExtractS`<`TypeOfValue`<`O`>> \| `ExtractTWithSTN`<`TypeOfValue`<`O`>> |  Snapshot or instance |
+| snapshotOrInstance | `TypeOfValue<O>["CreationType"]` \| `TypeOfValue<O>["SnapshotType"]` \| `TypeOfValue<O>["Type"]` |  Snapshot or instance |
 
 **Returns:** `O`
 The same object casted as an instance
@@ -856,7 +856,7 @@ ___
 
 ###  castToSnapshot
 
-▸ **castToSnapshot**<`I`>(snapshotOrInstance: *`I`*): `Extract<I, IAnyStateTreeNode> extends never ? I : ExtractC<TypeOfValue<I>>`
+▸ **castToSnapshot**<`I`>(snapshotOrInstance: *`I`*): `Extract<I, IAnyStateTreeNode> extends never ? I : TypeOfValue<I>["CreationType"]`
 
 Casts a node instance type to an snapshot type so it can be assigned to a type snapshot (e.g. to be used inside a create call). Note that this is just a cast for the type system, this is, it won't actually convert an instance to a snapshot, but just fool typescript into thinking so.
 
@@ -889,7 +889,7 @@ const b = ModelB.create({ innerModel: castToSnapshot(a)})
 | ------ | ------ | ------ |
 | snapshotOrInstance | `I` |  Snapshot or instance |
 
-**Returns:** `Extract<I, IAnyStateTreeNode> extends never ? I : ExtractC<TypeOfValue<I>>`
+**Returns:** `Extract<I, IAnyStateTreeNode> extends never ? I : TypeOfValue<I>["CreationType"]`
 The same object casted as an input (creation) snapshot
 
 ___
@@ -2165,7 +2165,7 @@ ___
 
 ###  getParentOfType
 
-▸ **getParentOfType**<`IT`>(target: *`IAnyStateTreeNode`*, type: *`IT`*): `ExtractTWithSTN`<`IT`>
+▸ **getParentOfType**<`IT`>(target: *`IAnyStateTreeNode`*, type: *`IT`*): `IT["Type"]`
 
 Returns the target's parent of a given type, or throws.
 
@@ -2179,7 +2179,7 @@ Returns the target's parent of a given type, or throws.
 | target | `IAnyStateTreeNode` |  \- |
 | type | `IT` |  \- |
 
-**Returns:** `ExtractTWithSTN`<`IT`>
+**Returns:** `IT["Type"]`
 
 ___
 <a id="getpath"></a>
@@ -3259,7 +3259,7 @@ ___
 
 ###  resolveIdentifier
 
-▸ **resolveIdentifier**<`IT`>(type: *`IT`*, target: *`IAnyStateTreeNode`*, identifier: *[ReferenceIdentifier](#referenceidentifier)*): `ExtractTWithSTN`<`IT`> \| `undefined`
+▸ **resolveIdentifier**<`IT`>(type: *`IT`*, target: *`IAnyStateTreeNode`*, identifier: *[ReferenceIdentifier](#referenceidentifier)*): `IT["Type"]` \| `undefined`
 
 Resolves a model instance given a root target, the type and the identifier you are searching for. Returns undefined if no value can be found.
 
@@ -3274,7 +3274,7 @@ Resolves a model instance given a root target, the type and the identifier you a
 | target | `IAnyStateTreeNode` |  \- |
 | identifier | [ReferenceIdentifier](#referenceidentifier) |  \- |
 
-**Returns:** `ExtractTWithSTN`<`IT`> \| `undefined`
+**Returns:** `IT["Type"]` \| `undefined`
 
 ___
 <a id="resolvepath"></a>
@@ -3339,7 +3339,7 @@ ___
 
 ###  snapshotProcessor
 
-▸ **snapshotProcessor**<`IT`,`CustomC`,`CustomS`>(type: *`IT`*, processors: *[ISnapshotProcessors](interfaces/isnapshotprocessors.md)<`ExtractC`<`IT`>, `CustomC`, `ExtractS`<`IT`>, `CustomS`>*, name?: *`undefined` \| `string`*): [ISnapshotProcessor](interfaces/isnapshotprocessor.md)<`IT`, `CustomC`, `CustomS`>
+▸ **snapshotProcessor**<`IT`,`CustomC`,`CustomS`>(type: *`IT`*, processors: *[ISnapshotProcessors](interfaces/isnapshotprocessors.md)<`IT["CreationType"]`, `CustomC`, `IT["SnapshotType"]`, `CustomS`>*, name?: *`undefined` \| `string`*): [ISnapshotProcessor](interfaces/isnapshotprocessor.md)<`IT`, `CustomC`, `CustomS`>
 
 `types.snapshotProcessor` - Runs a pre/post snapshot processor before/after serializing a given type.
 
@@ -3377,7 +3377,7 @@ const Todo2 = types.snapshotProcessor(Todo1, {
 | Name | Type | Description |
 | ------ | ------ | ------ |
 | type | `IT` |  Type to run the processors over. |
-| processors | [ISnapshotProcessors](interfaces/isnapshotprocessors.md)<`ExtractC`<`IT`>, `CustomC`, `ExtractS`<`IT`>, `CustomS`> |  Processors to run. |
+| processors | [ISnapshotProcessors](interfaces/isnapshotprocessors.md)<`IT["CreationType"]`, `CustomC`, `IT["SnapshotType"]`, `CustomS`> |  Processors to run. |
 | `Optional` name | `undefined` \| `string` |  Type name, or undefined to inherit the inner type one. |
 
 **Returns:** [ISnapshotProcessor](interfaces/isnapshotprocessor.md)<`IT`, `CustomC`, `CustomS`>

--- a/docs/API/interfaces/ianymodeltype.md
+++ b/docs/API/interfaces/ianymodeltype.md
@@ -87,17 +87,7 @@ ___
 
 ###  create
 
-▸ **create**(...args: *`CreateParams`<`ModelCreationType2`<`any`, `any`>>*): `STNValue`<`ModelInstanceType`<`any`, `any`>, `this`>
-
-▸ **create**(snapshot: *`ModelCreationType2`<`any`, `any`>*, env?: *`any`*): `STNValue`<`ModelInstanceType`<`any`, `any`>, `this`>
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| `Rest` args | `CreateParams`<`ModelCreationType2`<`any`, `any`>> |
-
-**Returns:** `STNValue`<`ModelInstanceType`<`any`, `any`>, `this`>
+▸ **create**(snapshot?: *[C]()*, env?: *`any`*): `this["Type"]`
 
 Creates an instance for the type given an snapshot input.
 
@@ -105,10 +95,10 @@ Creates an instance for the type given an snapshot input.
 
 | Name | Type |
 | ------ | ------ |
-| snapshot | `ModelCreationType2`<`any`, `any`> |
+| `Optional` snapshot | [C]() |
 | `Optional` env | `any` |
 
-**Returns:** `STNValue`<`ModelInstanceType`<`any`, `any`>, `this`>
+**Returns:** `this["Type"]`
 An instance of that type.
 
 ___

--- a/docs/API/interfaces/imodeltype.md
+++ b/docs/API/interfaces/imodeltype.md
@@ -92,17 +92,7 @@ ___
 
 ###  create
 
-▸ **create**(...args: *`CreateParams`<`ModelCreationType2`<`PROPS`, `CustomC`>>*): `STNValue`<`ModelInstanceType`<`PROPS`, `OTHERS`>, `this`>
-
-▸ **create**(snapshot: *`ModelCreationType2`<`PROPS`, `CustomC`>*, env?: *`any`*): `STNValue`<`ModelInstanceType`<`PROPS`, `OTHERS`>, `this`>
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| `Rest` args | `CreateParams`<`ModelCreationType2`<`PROPS`, `CustomC`>> |
-
-**Returns:** `STNValue`<`ModelInstanceType`<`PROPS`, `OTHERS`>, `this`>
+▸ **create**(snapshot?: *[C]()*, env?: *`any`*): `this["Type"]`
 
 Creates an instance for the type given an snapshot input.
 
@@ -110,10 +100,10 @@ Creates an instance for the type given an snapshot input.
 
 | Name | Type |
 | ------ | ------ |
-| snapshot | `ModelCreationType2`<`PROPS`, `CustomC`> |
+| `Optional` snapshot | [C]() |
 | `Optional` env | `any` |
 
-**Returns:** `STNValue`<`ModelInstanceType`<`PROPS`, `OTHERS`>, `this`>
+**Returns:** `this["Type"]`
 An instance of that type.
 
 ___

--- a/docs/API/interfaces/isimpletype.md
+++ b/docs/API/interfaces/isimpletype.md
@@ -55,17 +55,7 @@ ___
 
 ###  create
 
-▸ **create**(...args: *`CreateParams`<`T`>*): `STNValue`<`T`, `this`>
-
-▸ **create**(snapshot: *`T`*, env?: *`any`*): `STNValue`<`T`, `this`>
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| `Rest` args | `CreateParams`<`T`> |
-
-**Returns:** `STNValue`<`T`, `this`>
+▸ **create**(snapshot?: *[C]()*, env?: *`any`*): `this["Type"]`
 
 Creates an instance for the type given an snapshot input.
 
@@ -73,10 +63,10 @@ Creates an instance for the type given an snapshot input.
 
 | Name | Type |
 | ------ | ------ |
-| snapshot | `T` |
+| `Optional` snapshot | [C]() |
 | `Optional` env | `any` |
 
-**Returns:** `STNValue`<`T`, `this`>
+**Returns:** `this["Type"]`
 An instance of that type.
 
 ___

--- a/docs/API/interfaces/isnapshotprocessor.md
+++ b/docs/API/interfaces/isnapshotprocessor.md
@@ -10,7 +10,7 @@ A type that has its snapshots processed.
 #### CustomS 
 ## Hierarchy
 
- [IType](itype.md)<`_CustomOrOther`<`CustomC`, `ExtractC`<`IT`>>, `_CustomOrOther`<`CustomS`, `ExtractS`<`IT`>>, `ExtractTWithoutSTN`<`IT`>>
+ [IType](itype.md)<`_CustomOrOther`<`CustomC`, `IT["CreationType"]`>, `_CustomOrOther`<`CustomS`, `IT["SnapshotType"]`>, `IT["TypeWithoutSTN"]`>
 
 **↳ ISnapshotProcessor**
 
@@ -57,17 +57,7 @@ ___
 
 ###  create
 
-▸ **create**(...args: *`CreateParams`<`_CustomOrOther`<`CustomC`, `ExtractC`<`IT`>>>*): `STNValue`<`ExtractTWithoutSTN`<`IT`>, `this`>
-
-▸ **create**(snapshot: *`_CustomOrOther`<`CustomC`, `ExtractC`<`IT`>>*, env?: *`any`*): `STNValue`<`ExtractTWithoutSTN`<`IT`>, `this`>
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| `Rest` args | `CreateParams`<`_CustomOrOther`<`CustomC`, `ExtractC`<`IT`>>> |
-
-**Returns:** `STNValue`<`ExtractTWithoutSTN`<`IT`>, `this`>
+▸ **create**(snapshot?: *[C]()*, env?: *`any`*): `this["Type"]`
 
 Creates an instance for the type given an snapshot input.
 
@@ -75,10 +65,10 @@ Creates an instance for the type given an snapshot input.
 
 | Name | Type |
 | ------ | ------ |
-| snapshot | `_CustomOrOther`<`CustomC`, `ExtractC`<`IT`>> |
+| `Optional` snapshot | [C]() |
 | `Optional` env | `any` |
 
-**Returns:** `STNValue`<`ExtractTWithoutSTN`<`IT`>, `this`>
+**Returns:** `this["Type"]`
 An instance of that type.
 
 ___
@@ -115,7 +105,7 @@ ___
 
 ###  validate
 
-▸ **validate**(thing: *`_CustomOrOther`<`CustomC`, `ExtractC`<`IT`>>*, context: *[IValidationContext](../#ivalidationcontext)*): [IValidationResult](../#ivalidationresult)
+▸ **validate**(thing: *`_CustomOrOther`<`CustomC`, `IT["CreationType"]`>*, context: *[IValidationContext](../#ivalidationcontext)*): [IValidationResult](../#ivalidationresult)
 
 Run's the type's typechecker on the given value with the given validation context.
 
@@ -123,7 +113,7 @@ Run's the type's typechecker on the given value with the given validation contex
 
 | Name | Type | Description |
 | ------ | ------ | ------ |
-| thing | `_CustomOrOther`<`CustomC`, `ExtractC`<`IT`>> |  Value to be checked, either a snapshot or an instance. |
+| thing | `_CustomOrOther`<`CustomC`, `IT["CreationType"]`> |  Value to be checked, either a snapshot or an instance. |
 | context | [IValidationContext](../#ivalidationcontext) |  Validation context, an array of { subpaths, subtypes } that should be validated |
 
 **Returns:** [IValidationResult](../#ivalidationresult)

--- a/docs/API/interfaces/itype.md
+++ b/docs/API/interfaces/itype.md
@@ -61,17 +61,7 @@ ___
 
 ###  create
 
-▸ **create**(...args: *`CreateParams`<`C`>*): `STNValue`<`T`, `this`>
-
-▸ **create**(snapshot: *`C`*, env?: *`any`*): `STNValue`<`T`, `this`>
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| `Rest` args | `CreateParams`<`C`> |
-
-**Returns:** `STNValue`<`T`, `this`>
+▸ **create**(snapshot?: *[C]()*, env?: *`any`*): `this["Type"]`
 
 Creates an instance for the type given an snapshot input.
 
@@ -79,10 +69,10 @@ Creates an instance for the type given an snapshot input.
 
 | Name | Type |
 | ------ | ------ |
-| snapshot | `C` |
+| `Optional` snapshot | [C]() |
 | `Optional` env | `any` |
 
-**Returns:** `STNValue`<`T`, `this`>
+**Returns:** `this["Type"]`
 An instance of that type.
 
 ___

--- a/packages/mobx-state-tree/__tests__/core/env.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/env.test.ts
@@ -10,15 +10,13 @@ import {
     hasParent,
     Instance,
     destroy,
-    IStateTreeNode,
     getParent,
     IAnyStateTreeNode,
     isStateTreeNode,
-    getSnapshot,
-    isAlive,
-    getType,
-    isOptionalType
+    isAlive
 } from "../../src"
+
+// tslint:disable: no-unused-expression
 
 const Todo = types
     .model({

--- a/packages/mobx-state-tree/__tests__/core/snapshotProcessor.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/snapshotProcessor.test.ts
@@ -88,7 +88,7 @@ describe("snapshotProcessor", () => {
             expect(model.m.x).toBe("5")
             expect(getSnapshot(model).m.x).toBe(5)
             // reconciliation
-            model.m = cast({ x: "6" })
+            model.m = cast({ x: 6 })
             expect(model.m.x).toBe("6")
             expect(getSnapshot(model).m.x).toBe(6)
             // cloning

--- a/packages/mobx-state-tree/__tests__/core/type-system.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/type-system.test.ts
@@ -854,7 +854,8 @@ test("castToSnapshot", () => {
     // appMod.create({ aaa: castToSnapshot(5) }) // should not compile
 })
 
-test("create correctly chooses if the snapshot is needed or not - #920", () => {
+// disabled due to TS3.4 nesting issue
+test.skip("create correctly chooses if the snapshot is needed or not - #920", () => {
     const X = types.model({
         test: types.string
     })

--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -24,10 +24,7 @@ import {
     AnyModelType,
     assertIsType,
     assertIsStateTreeNode,
-    ExtractC,
     TypeOfValue,
-    ExtractTWithSTN,
-    ExtractS,
     assertIsFunction,
     assertIsNumber,
     assertIsString,
@@ -425,7 +422,7 @@ export function hasParentOfType(target: IAnyStateTreeNode, type: IAnyType): bool
 export function getParentOfType<IT extends IAnyType>(
     target: IAnyStateTreeNode,
     type: IT
-): ExtractTWithSTN<IT> {
+): IT["Type"] {
     // check all arguments
     assertIsStateTreeNode(target, 1)
     assertIsType(type, 2)
@@ -525,7 +522,7 @@ export function resolveIdentifier<IT extends IAnyType>(
     type: IT,
     target: IAnyStateTreeNode,
     identifier: ReferenceIdentifier
-): ExtractTWithSTN<IT> | undefined {
+): IT["Type"] | undefined {
     // check all arguments
     assertIsType(type, 1)
     assertIsStateTreeNode(target, 2)
@@ -871,9 +868,9 @@ export function cast<O extends string | number | boolean | null | undefined = ne
 ): O
 export function cast<O = never>(
     snapshotOrInstance:
-        | ExtractC<TypeOfValue<O>>
-        | ExtractS<TypeOfValue<O>>
-        | ExtractTWithSTN<TypeOfValue<O>>
+        | TypeOfValue<O>["CreationType"]
+        | TypeOfValue<O>["SnapshotType"]
+        | TypeOfValue<O>["Type"]
 ): O
 /**
  * Casts a node snapshot or instance type to an instance type so it can be assigned to a type instance.
@@ -937,7 +934,7 @@ export function cast(snapshotOrInstance: any): any {
  */
 export function castToSnapshot<I>(
     snapshotOrInstance: I
-): Extract<I, IAnyStateTreeNode> extends never ? I : ExtractC<TypeOfValue<I>> {
+): Extract<I, IAnyStateTreeNode> extends never ? I : TypeOfValue<I>["CreationType"] {
     return snapshotOrInstance as any
 }
 

--- a/packages/mobx-state-tree/src/core/node/identifier-cache.ts
+++ b/packages/mobx-state-tree/src/core/node/identifier-cache.ts
@@ -1,14 +1,5 @@
 import { IObservableArray, values, observable, entries } from "mobx"
-import {
-    fail,
-    ObjectNode,
-    mobxShallow,
-    AnyObjectNode,
-    ExtractS,
-    ExtractC,
-    IAnyComplexType,
-    ExtractTWithoutSTN
-} from "../../internal"
+import { fail, ObjectNode, mobxShallow, AnyObjectNode, IAnyComplexType } from "../../internal"
 
 let identifierCacheId = 0
 
@@ -105,7 +96,7 @@ export class IdentifierCache {
     resolve<IT extends IAnyComplexType>(
         type: IT,
         identifier: string
-    ): ObjectNode<ExtractC<IT>, ExtractS<IT>, ExtractTWithoutSTN<IT>> | null {
+    ): ObjectNode<IT["CreationType"], IT["SnapshotType"], IT["TypeWithoutSTN"]> | null {
         const set = this.cache.get(identifier)
         if (!set) return null
         const matches = set.filter(candidate => type.isAssignableFrom(candidate.type))

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -61,9 +61,9 @@ export const cannotDetermineSubtype = "cannotDetermine"
 /**
  * @hidden
  */
-export type STNValue<T, IT extends IAnyType> = T extends object // an object plus maybe primitives?
-    ? (Extract<T, object> & IStateTreeNode<IT>) | Exclude<T, object> // add STN to the object plus maybe the primitives
-    : T // no, use the primitives
+export type STNValue<T, IT extends IAnyType> =
+    | (Extract<T, object> & IStateTreeNode<IT>) // add STN to the object (which will be never if not an object)
+    | Exclude<T, object> // plus then the primitives if any
 
 /**
  * A type, either complex or simple.

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -84,7 +84,7 @@ export interface IType<C, S, T> {
      *
      * @returns An instance of that type.
      */
-    create(snapshot?: C, env?: any): STNValue<T, this>
+    create(snapshot?: C, env?: any): this["Type"]
 
     /**
      * Checks if a given snapshot / instance is of the given type.
@@ -92,7 +92,7 @@ export interface IType<C, S, T> {
      * @param thing Snapshot or instance to be checked.
      * @returns true if the value is of the current type, false otherwise.
      */
-    is(thing: any): thing is C | STNValue<T, this>
+    is(thing: any): thing is C | this["Type"]
 
     /**
      * Run's the type's typechecker on the given value with the given validation context.

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -65,10 +65,17 @@ export type STNValue<T, IT extends IAnyType> =
     | (Extract<T, object> & IStateTreeNode<IT>) // add STN to the object (which will be never if not an object)
     | Exclude<T, object> // plus then the primitives if any
 
+/** @hidden */
+declare const $type: unique symbol
+
 /**
  * A type, either complex or simple.
  */
 export interface IType<C, S, T> {
+    // fake, will never be present, just for typing
+    /** @hidden */
+    readonly [$type]: undefined
+
     /**
      * Friendly type name.
      */
@@ -181,11 +188,10 @@ export interface IType<C, S, T> {
     getSubTypes(): IAnyType[] | IAnyType | null | typeof cannotDetermineSubtype
 }
 
-// do not convert to an interface
 /**
  * Any kind of type.
  */
-export type IAnyType = IType<any, any, any>
+export interface IAnyType extends IType<any, any, any> {}
 
 /**
  * A simple type, this is, a type where the instance and the snapshot representation are the same.
@@ -202,32 +208,29 @@ export type Primitives = ModelPrimitive | null | undefined
  */
 export interface IComplexType<C, S, T> extends IType<C, S, T & object> {}
 
-// do not convert to an interface
 /**
  * Any kind of complex type.
  */
-export type IAnyComplexType = IType<any, any, object>
+export interface IAnyComplexType extends IType<any, any, object> {}
 
 /** @hidden */
-export type ExtractCSTWithoutSTN<IT extends IAnyType> =
-    | IT["CreationType"]
-    | IT["SnapshotType"]
-    | IT["TypeWithoutSTN"]
+export type ExtractCSTWithoutSTN<
+    IT extends { [$type]: undefined; CreationType: any; SnapshotType: any; TypeWithoutSTN: any }
+> = IT["CreationType"] | IT["SnapshotType"] | IT["TypeWithoutSTN"]
 /** @hidden */
-export type ExtractCSTWithSTN<IT extends IAnyType> =
-    | IT["CreationType"]
-    | IT["SnapshotType"]
-    | IT["Type"]
+export type ExtractCSTWithSTN<
+    IT extends { [$type]: undefined; CreationType: any; SnapshotType: any; Type: any }
+> = IT["CreationType"] | IT["SnapshotType"] | IT["Type"]
 
 /**
  * The instance representation of a given type.
  */
-export type Instance<T> = T extends IAnyType ? T["Type"] : T
+export type Instance<T> = T extends { [$type]: undefined; Type: any } ? T["Type"] : T
 
 /**
  * The input (creation) snapshot representation of a given type.
  */
-export type SnapshotIn<T> = T extends IAnyType
+export type SnapshotIn<T> = T extends { [$type]: undefined; CreationType: any }
     ? T["CreationType"]
     : T extends IStateTreeNode<infer IT>
     ? IT["CreationType"]
@@ -236,7 +239,7 @@ export type SnapshotIn<T> = T extends IAnyType
 /**
  * The output snapshot representation of a given type.
  */
-export type SnapshotOut<T> = T extends IAnyType
+export type SnapshotOut<T> = T extends { [$type]: undefined; SnapshotType: any }
     ? T["SnapshotType"]
     : T extends IStateTreeNode<infer IT>
     ? IT["SnapshotType"]
@@ -278,6 +281,8 @@ export type SnapshotOrInstance<T> = SnapshotIn<T> | Instance<T>
  */
 export abstract class BaseType<C, S, T, N extends BaseNode<any, any, any> = BaseNode<C, S, T>>
     implements IType<C, S, T> {
+    [$type]!: undefined
+
     // these are just to make inner types avaialable to inherited classes
     readonly C!: C
     readonly S!: S

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -115,6 +115,12 @@ export interface IType<C, S, T> {
     readonly Type: STNValue<T, this>
 
     /**
+     * @deprecated do not use.
+     * @hidden
+     */
+    readonly TypeWithoutSTN: T
+
+    /**
      * @deprecated use `SnapshotOut<typeof MyType>` instead.
      * @hidden
      */
@@ -203,47 +209,37 @@ export interface IComplexType<C, S, T> extends IType<C, S, T & object> {}
 export type IAnyComplexType = IType<any, any, object>
 
 /** @hidden */
-export type ExtractC<T extends IAnyType> = T extends IType<infer C, any, any> ? C : never
+export type ExtractCSTWithoutSTN<IT extends IAnyType> =
+    | IT["CreationType"]
+    | IT["SnapshotType"]
+    | IT["TypeWithoutSTN"]
 /** @hidden */
-export type ExtractS<T extends IAnyType> = T extends IType<any, infer S, any> ? S : never
-/** @hidden */
-export type ExtractTWithoutSTN<T extends IAnyType> = T extends IType<any, any, infer X> ? X : never
-/** @hidden */
-export type ExtractTWithSTN<T extends IAnyType> = InstanceWithDefault<T, never>
-/** @hidden */
-export type ExtractCSTWithoutSTN<IT extends IAnyType> = IT extends IType<infer C, infer S, infer T>
-    ? C | S | T
-    : never
-/** @hidden */
-export type ExtractCSTWithSTN<IT extends IAnyType> = IT extends IType<infer C, infer S, any>
-    ? C | S | ExtractTWithSTN<IT>
-    : never
-
-type InstanceWithDefault<T, DEFAULT> = T extends IType<any, any, infer TT>
-    ? STNValue<TT, T>
-    : DEFAULT
+export type ExtractCSTWithSTN<IT extends IAnyType> =
+    | IT["CreationType"]
+    | IT["SnapshotType"]
+    | IT["Type"]
 
 /**
  * The instance representation of a given type.
  */
-export type Instance<T> = InstanceWithDefault<T, T>
+export type Instance<T> = T extends IAnyType ? T["Type"] : T
 
 /**
  * The input (creation) snapshot representation of a given type.
  */
-export type SnapshotIn<T> = T extends IType<infer TC, any, any>
-    ? TC
-    : T extends IStateTreeNode<IType<infer STNC, any, any>>
-    ? STNC
+export type SnapshotIn<T> = T extends IAnyType
+    ? T["CreationType"]
+    : T extends IStateTreeNode<infer IT>
+    ? IT["CreationType"]
     : T
 
 /**
  * The output snapshot representation of a given type.
  */
-export type SnapshotOut<T> = T extends IType<any, infer TS, any>
-    ? TS
-    : T extends IStateTreeNode<IType<any, infer STNS, any>>
-    ? STNS
+export type SnapshotOut<T> = T extends IAnyType
+    ? T["SnapshotType"]
+    : T extends IStateTreeNode<infer IT>
+    ? IT["SnapshotType"]
     : T
 
 /**
@@ -344,6 +340,12 @@ export abstract class BaseType<C, S, T, N extends BaseNode<any, any, any> = Base
         // istanbul ignore next
         throw fail(
             "Factory.Type should not be actually called. It is just a Type signature that can be used at compile time with Typescript, by using `typeof type.Type`"
+        )
+    }
+    get TypeWithoutSTN(): any {
+        // istanbul ignore next
+        throw fail(
+            "Factory.TypeWithoutSTN should not be actually called. It is just a Type signature that can be used at compile time with Typescript, by using `typeof type.TypeWithoutSTN`"
         )
     }
     get SnapshotType(): any {

--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -128,7 +128,6 @@ export {
     isMapType,
     isModelType,
     isOptionalType,
-    IsOptionalType,
     isPrimitiveType,
     isReferenceType,
     isRefinementType,

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -34,8 +34,6 @@ import {
     typecheckInternal,
     typeCheckFailure,
     TypeFlags,
-    ExtractS,
-    ExtractC,
     normalizeIdentifier,
     EMPTY_OBJECT,
     IAnyStateTreeNode,
@@ -43,54 +41,41 @@ import {
     AnyNode,
     createObjectNode,
     assertIsType,
-    ExtractTWithSTN,
     ExtractCSTWithSTN,
     IStateTreeNode
 } from "../../internal"
 
 /** @hidden */
-export interface IMSTArray<IT extends IAnyType> extends IObservableArray<ExtractTWithSTN<IT>> {
+export interface IMSTArray<IT extends IAnyType> extends IObservableArray<IT["Type"]> {
     // needs to be split or else it will complain about not being compatible with the array interface
-    push(...items: ExtractTWithSTN<IT>[]): number
+    push(...items: IT["Type"][]): number
     push(...items: ExtractCSTWithSTN<IT>[]): number
 
-    concat(...items: ConcatArray<ExtractTWithSTN<IT>>[]): ExtractTWithSTN<IT>[]
-    concat(...items: ConcatArray<ExtractCSTWithSTN<IT>>[]): ExtractTWithSTN<IT>[]
+    concat(...items: ConcatArray<IT["Type"]>[]): IT["Type"][]
+    concat(...items: ConcatArray<ExtractCSTWithSTN<IT>>[]): IT["Type"][]
 
-    concat(
-        ...items: (ExtractTWithSTN<IT> | ConcatArray<ExtractTWithSTN<IT>>)[]
-    ): ExtractTWithSTN<IT>[]
-    concat(
-        ...items: (ExtractCSTWithSTN<IT> | ConcatArray<ExtractCSTWithSTN<IT>>)[]
-    ): ExtractTWithSTN<IT>[]
+    concat(...items: (IT["Type"] | ConcatArray<IT["Type"]>)[]): IT["Type"][]
+    concat(...items: (ExtractCSTWithSTN<IT> | ConcatArray<ExtractCSTWithSTN<IT>>)[]): IT["Type"][]
 
-    splice(start: number, deleteCount?: number): ExtractTWithSTN<IT>[]
-    splice(
-        start: number,
-        deleteCount: number,
-        ...items: ExtractTWithSTN<IT>[]
-    ): ExtractTWithSTN<IT>[]
-    splice(
-        start: number,
-        deleteCount: number,
-        ...items: ExtractCSTWithSTN<IT>[]
-    ): ExtractTWithSTN<IT>[]
+    splice(start: number, deleteCount?: number): IT["Type"][]
+    splice(start: number, deleteCount: number, ...items: IT["Type"][]): IT["Type"][]
+    splice(start: number, deleteCount: number, ...items: ExtractCSTWithSTN<IT>[]): IT["Type"][]
 
-    unshift(...items: ExtractTWithSTN<IT>[]): number
+    unshift(...items: IT["Type"][]): number
     unshift(...items: ExtractCSTWithSTN<IT>[]): number
 }
 
 /** @hidden */
 export interface IArrayType<IT extends IAnyType>
-    extends IType<ExtractC<IT>[] | undefined, ExtractS<IT>[], IMSTArray<IT>> {}
+    extends IType<IT["CreationType"][] | undefined, IT["SnapshotType"][], IMSTArray<IT>> {}
 
 /**
  * @internal
  * @hidden
  */
 export class ArrayType<IT extends IAnyType> extends ComplexType<
-    ExtractC<IT>[] | undefined,
-    ExtractS<IT>[],
+    IT["CreationType"][] | undefined,
+    IT["SnapshotType"][],
     IMSTArray<IT>
 > {
     readonly flags = TypeFlags.Array

--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -37,8 +37,6 @@ import {
     typeCheckFailure,
     TypeFlags,
     EMPTY_OBJECT,
-    ExtractC,
-    ExtractS,
     normalizeIdentifier,
     AnyObjectNode,
     AnyNode,
@@ -47,17 +45,15 @@ import {
     cannotDetermineSubtype,
     getSnapshot,
     isValidIdentifier,
-    ExtractTWithSTN,
     ExtractCSTWithSTN,
-    ExtractTWithoutSTN,
     devMode
 } from "../../internal"
 
 /** @hidden */
 export interface IMapType<IT extends IAnyType>
     extends IType<
-        IKeyValueMap<ExtractC<IT>> | undefined,
-        IKeyValueMap<ExtractS<IT>>,
+        IKeyValueMap<IT["CreationType"]> | undefined,
+        IKeyValueMap<IT["SnapshotType"]>,
         IMSTMap<IT>
     > {}
 
@@ -67,29 +63,26 @@ export interface IMSTMap<IT extends IAnyType> {
 
     clear(): void
     delete(key: string): boolean
-    forEach(
-        callbackfn: (value: ExtractTWithSTN<IT>, key: string, map: this) => void,
-        thisArg?: any
-    ): void
-    get(key: string): ExtractTWithSTN<IT> | undefined
+    forEach(callbackfn: (value: IT["Type"], key: string, map: this) => void, thisArg?: any): void
+    get(key: string): IT["Type"] | undefined
     has(key: string): boolean
     set(key: string, value: ExtractCSTWithSTN<IT>): this
     readonly size: number
-    put(value: ExtractCSTWithSTN<IT>): ExtractTWithSTN<IT>
+    put(value: ExtractCSTWithSTN<IT>): IT["Type"]
     keys(): IterableIterator<string>
-    values(): IterableIterator<ExtractTWithSTN<IT>>
-    entries(): IterableIterator<[string, ExtractTWithSTN<IT>]>
-    [Symbol.iterator](): IterableIterator<[string, ExtractTWithSTN<IT>]>
+    values(): IterableIterator<IT["Type"]>
+    entries(): IterableIterator<[string, IT["Type"]]>
+    [Symbol.iterator](): IterableIterator<[string, IT["Type"]]>
     /** Merge another object into this map, returns self. */
     merge(
         other:
-            | IMSTMap<IType<any, any, ExtractTWithoutSTN<IT>>>
+            | IMSTMap<IType<any, any, IT["TypeWithoutSTN"]>>
             | IKeyValueMap<ExtractCSTWithSTN<IT>>
             | any
     ): this
     replace(
         values:
-            | IMSTMap<IType<any, any, ExtractTWithoutSTN<IT>>>
+            | IMSTMap<IType<any, any, IT["TypeWithoutSTN"]>>
             | IKeyValueMap<ExtractCSTWithSTN<IT>>
             | any
     ): this
@@ -99,14 +92,14 @@ export interface IMSTMap<IT extends IAnyType> {
      * Note that all the keys being stringified.
      * If there are duplicating keys after converting them to strings, behaviour is undetermined.
      */
-    toPOJO(): IKeyValueMap<ExtractS<IT>>
-    toJSON(): IKeyValueMap<ExtractS<IT>>
+    toPOJO(): IKeyValueMap<IT["SnapshotType"]>
+    toJSON(): IKeyValueMap<IT["SnapshotType"]>
 
     /**
      * Returns a shallow non observable object clone of this map.
      * Note that the values migth still be observable. For a deep clone use mobx.toJS.
      */
-    toJS(): Map<string, ExtractTWithSTN<IT>>
+    toJS(): Map<string, IT["Type"]>
 
     toString(): string
     [Symbol.toStringTag]: "Map"
@@ -117,10 +110,10 @@ export interface IMSTMap<IT extends IAnyType> {
      * for callback details
      */
     observe(
-        listener: (changes: IMapDidChange<string, ExtractTWithSTN<IT>>) => void,
+        listener: (changes: IMapDidChange<string, IT["Type"]>) => void,
         fireImmediately?: boolean
     ): Lambda
-    intercept(handler: IInterceptor<IMapWillChange<string, ExtractTWithSTN<IT>>>): Lambda
+    intercept(handler: IInterceptor<IMapWillChange<string, IT["Type"]>>): Lambda
 }
 
 const needsIdentifierError = `Map.put can only be used to store complex values that have an identifier type attribute`
@@ -157,7 +150,7 @@ class MSTMap<IT extends IAnyType> extends ObservableMap<string, any> {
         super(initialData, observable.ref.enhancer)
     }
 
-    get(key: string): ExtractTWithSTN<IT> | undefined {
+    get(key: string): IT["Type"] | undefined {
         // maybe this is over-enthousiastic? normalize numeric keys to strings
         return super.get("" + key)
     }
@@ -174,7 +167,7 @@ class MSTMap<IT extends IAnyType> extends ObservableMap<string, any> {
         return super.set("" + key, value)
     }
 
-    put(value: ExtractCSTWithSTN<IT>): ExtractTWithSTN<IT> {
+    put(value: ExtractCSTWithSTN<IT>): IT["Type"] {
         if (!value) throw fail(`Map.put cannot be used to set empty values`)
         if (isStateTreeNode(value)) {
             const node = getStateTreeNode(value)
@@ -199,7 +192,7 @@ class MSTMap<IT extends IAnyType> extends ObservableMap<string, any> {
             }
 
             const idAttr = mapType.mapIdentifierAttribute!
-            const id = value[idAttr]
+            const id = (value as any)[idAttr]
             if (!isValidIdentifier(id)) {
                 // try again but this time after creating a node for the value
                 // since it might be an optional identifier
@@ -218,8 +211,8 @@ class MSTMap<IT extends IAnyType> extends ObservableMap<string, any> {
  * @hidden
  */
 export class MapType<IT extends IAnyType> extends ComplexType<
-    IKeyValueMap<ExtractC<IT>> | undefined,
-    IKeyValueMap<ExtractS<IT>>,
+    IKeyValueMap<IT["CreationType"]> | undefined,
+    IKeyValueMap<IT["SnapshotType"]>,
     IMSTMap<IT>
 > {
     identifierMode: MapIdentifierMode = MapIdentifierMode.UNKNOWN

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -44,14 +44,11 @@ import {
     typecheckInternal,
     typeCheckFailure,
     TypeFlags,
-    ExtractC,
-    ExtractS,
     Hook,
     AnyObjectNode,
     AnyNode,
     _CustomOrOther,
     _NotCustomized,
-    ExtractTWithSTN,
     Instance,
     devMode,
     assertIsString,
@@ -139,7 +136,7 @@ type DefinablePropsNames<T> = {
 }[keyof T]
 
 /** @hidden */
-export type ExtractCFromProps<P extends ModelProperties> = { [k in keyof P]: ExtractC<P[k]> }
+export type ExtractCFromProps<P extends ModelProperties> = { [k in keyof P]: P[k]["CreationType"] }
 
 /** @hidden */
 export type ModelCreationType<PC> = { [P in DefinablePropsNames<PC>]: PC[P] } & Partial<PC>
@@ -151,7 +148,7 @@ export type ModelCreationType2<P extends ModelProperties, CustomC> = _CustomOrOt
 >
 
 /** @hidden */
-export type ModelSnapshotType<P extends ModelProperties> = { [K in keyof P]: ExtractS<P[K]> }
+export type ModelSnapshotType<P extends ModelProperties> = { [K in keyof P]: P[K]["SnapshotType"] }
 
 /** @hidden */
 export type ModelSnapshotType2<P extends ModelProperties, CustomS> = _CustomOrOther<
@@ -163,9 +160,7 @@ export type ModelSnapshotType2<P extends ModelProperties, CustomS> = _CustomOrOt
  * @hidden
  * we keep this separate from ModelInstanceType to shorten model instance types generated declarations
  */
-export type ModelInstanceTypeProps<P extends ModelProperties> = {
-    [K in keyof P]: ExtractTWithSTN<P[K]>
-}
+export type ModelInstanceTypeProps<P extends ModelProperties> = { [K in keyof P]: P[K]["Type"] }
 
 /**
  * @hidden

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -79,19 +79,23 @@ export interface ModelPropertiesDeclaration {
  *
  * @hidden
  */
-export type ModelPropertiesDeclarationToProperties<T extends ModelPropertiesDeclaration> = {
-    [K in keyof T]: T[K] extends IAnyType
-        ? T[K]
-        : T[K] extends string
-        ? IType<string | undefined, string, string>
-        : T[K] extends number
-        ? IType<number | undefined, number, number>
-        : T[K] extends boolean
-        ? IType<boolean | undefined, boolean, boolean>
-        : T[K] extends Date
-        ? IType<number | Date | undefined, number, Date>
-        : never
-}
+export type ModelPropertiesDeclarationToProperties<
+    T extends ModelPropertiesDeclaration
+> = T extends { [k: string]: IAnyType } // optimization to reduce nesting
+    ? T
+    : {
+          [K in keyof T]: T[K] extends IAnyType // keep IAnyType check on the top to reduce nesting
+              ? T[K]
+              : T[K] extends string
+              ? IType<string | undefined, string, string>
+              : T[K] extends number
+              ? IType<number | undefined, number, number>
+              : T[K] extends boolean
+              ? IType<boolean | undefined, boolean, boolean>
+              : T[K] extends Date
+              ? IType<number | Date | undefined, number, Date>
+              : never
+      }
 
 /**
  * Checks if a type is any or unknown

--- a/packages/mobx-state-tree/src/types/utility-types/late.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/late.ts
@@ -8,18 +8,15 @@ import {
     IAnyType,
     typeCheckSuccess,
     AnyObjectNode,
-    ExtractC,
-    ExtractS,
     ExtractNodeType,
     cannotDetermineSubtype,
-    ExtractTWithoutSTN,
     devMode
 } from "../../internal"
 
 class Late<IT extends IAnyType> extends BaseType<
-    ExtractC<IT>,
-    ExtractS<IT>,
-    ExtractTWithoutSTN<IT>,
+    IT["CreationType"],
+    IT["SnapshotType"],
+    IT["TypeWithoutSTN"],
     ExtractNodeType<IT>
 > {
     private _subType?: IT

--- a/packages/mobx-state-tree/src/types/utility-types/maybe.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/maybe.ts
@@ -5,10 +5,7 @@ import {
     undefinedType,
     nullType,
     IAnyType,
-    ExtractC,
-    ExtractS,
-    assertIsType,
-    ExtractTWithoutSTN
+    assertIsType
 } from "../../internal"
 
 const optionalUndefinedType = optional(undefinedType, undefined)
@@ -16,7 +13,7 @@ const optionalNullType = optional(nullType, null)
 
 /** @hidden */
 export interface IMaybeIType<IT extends IAnyType, C, O>
-    extends IType<ExtractC<IT> | C, ExtractS<IT> | O, ExtractTWithoutSTN<IT> | O> {}
+    extends IType<IT["CreationType"] | C, IT["SnapshotType"] | O, IT["TypeWithoutSTN"] | O> {}
 
 /** @hidden */
 export interface IMaybe<IT extends IAnyType> extends IMaybeIType<IT, undefined, undefined> {}

--- a/packages/mobx-state-tree/src/types/utility-types/optional.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/optional.ts
@@ -9,14 +9,10 @@ import {
     typeCheckSuccess,
     fail,
     IAnyType,
-    ExtractS,
-    ExtractC,
     AnyObjectNode,
     BaseType,
     assertIsType,
     ExtractCSTWithSTN,
-    ExtractTWithoutSTN,
-    ExtractTWithSTN,
     devMode
 } from "../../internal"
 
@@ -37,14 +33,18 @@ export type ValidOptionalValues = [ValidOptionalValue, ...ValidOptionalValue[]]
 export class OptionalValue<
     IT extends IAnyType,
     OptionalVals extends ValidOptionalValues
-> extends BaseType<ExtractC<IT> | OptionalVals[number], ExtractS<IT>, ExtractTWithoutSTN<IT>> {
+> extends BaseType<
+    IT["CreationType"] | OptionalVals[number],
+    IT["SnapshotType"],
+    IT["TypeWithoutSTN"]
+> {
     get flags() {
         return this._subtype.flags | TypeFlags.Optional
     }
 
     constructor(
         private readonly _subtype: IT,
-        private readonly _defaultValue: IOptionalValue<ExtractC<IT>, ExtractTWithSTN<IT>>,
+        private readonly _defaultValue: IOptionalValue<IT["CreationType"], IT["Type"]>,
         readonly optionalValues: OptionalVals
     ) {
         super(_subtype.name)
@@ -123,13 +123,17 @@ export class OptionalValue<
 
 /** @hidden */
 export type OptionalDefaultValueOrFunction<IT extends IAnyType> =
-    | ExtractC<IT>
-    | ExtractS<IT>
+    | IT["CreationType"]
+    | IT["SnapshotType"]
     | (() => ExtractCSTWithSTN<IT>)
 
 /** @hidden */
 export interface IOptionalIType<IT extends IAnyType, OptionalVals extends ValidOptionalValues>
-    extends IType<ExtractC<IT> | OptionalVals[number], ExtractS<IT>, ExtractTWithoutSTN<IT>> {}
+    extends IType<
+        IT["CreationType"] | OptionalVals[number],
+        IT["SnapshotType"],
+        IT["TypeWithoutSTN"]
+    > {}
 
 function checkOptionalPreconditions<IT extends IAnyType>(
     type: IAnyType,

--- a/packages/mobx-state-tree/src/types/utility-types/reference.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/reference.ts
@@ -27,7 +27,6 @@ import {
     SimpleType,
     assertIsType,
     isValidIdentifier,
-    ExtractTWithoutSTN,
     IStateTreeNode,
     devMode
 } from "../../internal"
@@ -57,7 +56,7 @@ function getInvalidationCause(hook: Hook): "detach" | "destroy" | undefined {
 }
 
 /** @hidden */
-export type ReferenceT<IT extends IAnyType> = ExtractTWithoutSTN<IT> &
+export type ReferenceT<IT extends IAnyType> = IT["TypeWithoutSTN"] &
     IStateTreeNode<IReferenceType<IT>>
 
 class StoredReference<IT extends IAnyType> {
@@ -141,7 +140,7 @@ export class InvalidReferenceError extends Error {
 export abstract class BaseReferenceType<IT extends IAnyComplexType> extends SimpleType<
     ReferenceIdentifier,
     ReferenceIdentifier,
-    ExtractTWithoutSTN<IT>
+    IT["TypeWithoutSTN"]
 > {
     readonly flags = TypeFlags.Reference
 
@@ -358,7 +357,7 @@ export class IdentifierReferenceType<IT extends IAnyComplexType> extends BaseRef
         const identifier = isStateTreeNode(initialValue)
             ? getIdentifier(initialValue)!
             : initialValue
-        const storedRef = new StoredReference(initialValue, this.targetType)
+        const storedRef = new StoredReference(initialValue, this.targetType as any)
         const storedRefNode: this["N"] = createScalarNode(
             this,
             parent,
@@ -480,7 +479,7 @@ export type ReferenceOptions<IT extends IAnyComplexType> =
 
 /** @hidden */
 export interface IReferenceType<IT extends IAnyComplexType>
-    extends IType<ReferenceIdentifier, ReferenceIdentifier, ExtractTWithoutSTN<IT>> {}
+    extends IType<ReferenceIdentifier, ReferenceIdentifier, IT["TypeWithoutSTN"]> {}
 
 /**
  * `types.reference` - Creates a reference to another type, which should have defined an identifier.

--- a/packages/mobx-state-tree/src/types/utility-types/refinement.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/refinement.ts
@@ -9,21 +9,18 @@ import {
     fail,
     TypeFlags,
     IAnyType,
-    ExtractC,
     AnyObjectNode,
     BaseType,
-    ExtractS,
     ExtractNodeType,
     assertIsType,
-    ExtractTWithoutSTN,
     devMode
 } from "../../internal"
 import { assertIsString, assertIsFunction } from "../../utils"
 
 class Refinement<IT extends IAnyType> extends BaseType<
-    ExtractC<IT>,
-    ExtractS<IT>,
-    ExtractTWithoutSTN<IT>,
+    IT["CreationType"],
+    IT["SnapshotType"],
+    IT["TypeWithoutSTN"],
     ExtractNodeType<IT>
 > {
     get flags() {
@@ -33,8 +30,8 @@ class Refinement<IT extends IAnyType> extends BaseType<
     constructor(
         name: string,
         private readonly _subtype: IT,
-        private readonly _predicate: (v: ExtractC<IT>) => boolean,
-        private readonly _message: (v: ExtractC<IT>) => string
+        private readonly _predicate: (v: IT["CreationType"]) => boolean,
+        private readonly _message: (v: IT["CreationType"]) => string
     ) {
         super(name)
     }
@@ -87,13 +84,13 @@ class Refinement<IT extends IAnyType> extends BaseType<
 export function refinement<IT extends IAnyType>(
     name: string,
     type: IT,
-    predicate: (snapshot: ExtractC<IT>) => boolean,
-    message?: string | ((v: ExtractC<IT>) => string)
+    predicate: (snapshot: IT["CreationType"]) => boolean,
+    message?: string | ((v: IT["CreationType"]) => string)
 ): IT
 export function refinement<IT extends IAnyType>(
     type: IT,
-    predicate: (snapshot: ExtractC<IT>) => boolean,
-    message?: string | ((v: ExtractC<IT>) => string)
+    predicate: (snapshot: IT["CreationType"]) => boolean,
+    message?: string | ((v: IT["CreationType"]) => string)
 ): IT
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,16 +10,16 @@
     "@babel/highlight" "^7.0.0"
 
 "@babel/core@^7.1.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.0.tgz#248fd6874b7d755010bfe61f557461d4f446d9e9"
-  integrity sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.3.tgz#198d6d3af4567be3989550d97e068de94503074f"
+  integrity sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/generator" "^7.4.0"
-    "@babel/helpers" "^7.4.0"
-    "@babel/parser" "^7.4.0"
+    "@babel/helpers" "^7.4.3"
+    "@babel/parser" "^7.4.3"
     "@babel/template" "^7.4.0"
-    "@babel/traverse" "^7.4.0"
+    "@babel/traverse" "^7.4.3"
     "@babel/types" "^7.4.0"
     convert-source-map "^1.1.0"
     debug "^4.1.0"
@@ -68,13 +68,13 @@
   dependencies:
     "@babel/types" "^7.4.0"
 
-"@babel/helpers@^7.4.0":
-  version "7.4.2"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.4.2.tgz#3bdfa46a552ca77ef5a0f8551be5f0845ae989be"
-  integrity sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==
+"@babel/helpers@^7.4.3":
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.4.3.tgz#7b1d354363494b31cb9a2417ae86af32b7853a3b"
+  integrity sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==
   dependencies:
     "@babel/template" "^7.4.0"
-    "@babel/traverse" "^7.4.0"
+    "@babel/traverse" "^7.4.3"
     "@babel/types" "^7.4.0"
 
 "@babel/highlight@^7.0.0":
@@ -86,10 +86,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.0":
-  version "7.4.2"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.2.tgz#b4521a400cb5a871eab3890787b4bc1326d38d91"
-  integrity sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.0", "@babel/parser@^7.4.3":
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.3.tgz#eb3ac80f64aa101c907d4ce5406360fe75b7895b"
+  integrity sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==
 
 "@babel/plugin-syntax-object-rest-spread@^7.0.0":
   version "7.2.0"
@@ -114,16 +114,16 @@
     "@babel/parser" "^7.4.0"
     "@babel/types" "^7.4.0"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.0.tgz#14006967dd1d2b3494cdd650c686db9daf0ddada"
-  integrity sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3":
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.3.tgz#1a01f078fc575d589ff30c0f71bf3c3d9ccbad84"
+  integrity sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/generator" "^7.4.0"
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-split-export-declaration" "^7.4.0"
-    "@babel/parser" "^7.4.0"
+    "@babel/parser" "^7.4.3"
     "@babel/types" "^7.4.0"
     debug "^4.1.0"
     globals "^11.1.0"
@@ -146,42 +146,41 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@jest/console@^24.3.0":
-  version "24.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.3.0.tgz#7bd920d250988ba0bf1352c4493a48e1cb97671e"
-  integrity sha512-NaCty/OOei6rSDcbPdMiCbYCI0KGFGPgGO6B09lwWt5QTxnkuhKYET9El5u5z1GAcSxkQmSMtM63e24YabCWqA==
+"@jest/console@^24.7.1":
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"
+  integrity sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==
   dependencies:
     "@jest/source-map" "^24.3.0"
-    "@types/node" "*"
     chalk "^2.0.1"
     slash "^2.0.0"
 
-"@jest/core@^24.5.0":
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-24.5.0.tgz#2cefc6a69e9ebcae1da8f7c75f8a257152ba1ec0"
-  integrity sha512-RDZArRzAs51YS7dXG1pbXbWGxK53rvUu8mCDYsgqqqQ6uSOaTjcVyBl2Jce0exT2rSLk38ca7az7t2f3b0/oYQ==
+"@jest/core@^24.7.1":
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-24.7.1.tgz#6707f50db238d0c5988860680e2e414df0032024"
+  integrity sha512-ivlZ8HX/FOASfHcb5DJpSPFps8ydfUYzLZfgFFqjkLijYysnIEOieg72YRhO4ZUB32xu40hsSMmaw+IGYeKONA==
   dependencies:
-    "@jest/console" "^24.3.0"
-    "@jest/reporters" "^24.5.0"
-    "@jest/test-result" "^24.5.0"
-    "@jest/transform" "^24.5.0"
-    "@jest/types" "^24.5.0"
+    "@jest/console" "^24.7.1"
+    "@jest/reporters" "^24.7.1"
+    "@jest/test-result" "^24.7.1"
+    "@jest/transform" "^24.7.1"
+    "@jest/types" "^24.7.0"
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
     exit "^0.1.2"
     graceful-fs "^4.1.15"
-    jest-changed-files "^24.5.0"
-    jest-config "^24.5.0"
-    jest-haste-map "^24.5.0"
-    jest-message-util "^24.5.0"
+    jest-changed-files "^24.7.0"
+    jest-config "^24.7.1"
+    jest-haste-map "^24.7.1"
+    jest-message-util "^24.7.1"
     jest-regex-util "^24.3.0"
-    jest-resolve-dependencies "^24.5.0"
-    jest-runner "^24.5.0"
-    jest-runtime "^24.5.0"
-    jest-snapshot "^24.5.0"
-    jest-util "^24.5.0"
-    jest-validate "^24.5.0"
-    jest-watcher "^24.5.0"
+    jest-resolve-dependencies "^24.7.1"
+    jest-runner "^24.7.1"
+    jest-runtime "^24.7.1"
+    jest-snapshot "^24.7.1"
+    jest-util "^24.7.1"
+    jest-validate "^24.7.0"
+    jest-watcher "^24.7.1"
     micromatch "^3.1.10"
     p-each-series "^1.0.0"
     pirates "^4.0.1"
@@ -189,36 +188,34 @@
     rimraf "^2.5.4"
     strip-ansi "^5.0.0"
 
-"@jest/environment@^24.5.0":
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-24.5.0.tgz#a2557f7808767abea3f9e4cc43a172122a63aca8"
-  integrity sha512-tzUHR9SHjMXwM8QmfHb/EJNbF0fjbH4ieefJBvtwO8YErLTrecc1ROj0uo2VnIT6SlpEGZnvdCK6VgKYBo8LsA==
+"@jest/environment@^24.7.1":
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-24.7.1.tgz#9b9196bc737561f67ac07817d4c5ece772e33135"
+  integrity sha512-wmcTTYc4/KqA+U5h1zQd5FXXynfa7VGP2NfF+c6QeGJ7c+2nStgh65RQWNX62SC716dTtqheTRrZl0j+54oGHw==
   dependencies:
-    "@jest/fake-timers" "^24.5.0"
-    "@jest/transform" "^24.5.0"
-    "@jest/types" "^24.5.0"
-    "@types/node" "*"
-    jest-mock "^24.5.0"
+    "@jest/fake-timers" "^24.7.1"
+    "@jest/transform" "^24.7.1"
+    "@jest/types" "^24.7.0"
+    jest-mock "^24.7.0"
 
-"@jest/fake-timers@^24.5.0":
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-24.5.0.tgz#4a29678b91fd0876144a58f8d46e6c62de0266f0"
-  integrity sha512-i59KVt3QBz9d+4Qr4QxsKgsIg+NjfuCjSOWj3RQhjF5JNy+eVJDhANQ4WzulzNCHd72srMAykwtRn5NYDGVraw==
+"@jest/fake-timers@^24.7.1":
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-24.7.1.tgz#56e5d09bdec09ee81050eaff2794b26c71d19db2"
+  integrity sha512-4vSQJDKfR2jScOe12L9282uiwuwQv9Lk7mgrCSZHA9evB9efB/qx8i0KJxsAKtp8fgJYBJdYY7ZU6u3F4/pyjA==
   dependencies:
-    "@jest/types" "^24.5.0"
-    "@types/node" "*"
-    jest-message-util "^24.5.0"
-    jest-mock "^24.5.0"
+    "@jest/types" "^24.7.0"
+    jest-message-util "^24.7.1"
+    jest-mock "^24.7.0"
 
-"@jest/reporters@^24.5.0":
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-24.5.0.tgz#9363a210d0daa74696886d9cb294eb8b3ad9b4d9"
-  integrity sha512-vfpceiaKtGgnuC3ss5czWOihKOUSyjJA4M4udm6nH8xgqsuQYcyDCi4nMMcBKsHXWgz9/V5G7iisnZGfOh1w6Q==
+"@jest/reporters@^24.7.1":
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-24.7.1.tgz#38ac0b096cd691bbbe3051ddc25988d42e37773a"
+  integrity sha512-bO+WYNwHLNhrjB9EbPL4kX/mCCG4ZhhfWmO3m4FSpbgr7N83MFejayz30kKjgqr7smLyeaRFCBQMbXpUgnhAJw==
   dependencies:
-    "@jest/environment" "^24.5.0"
-    "@jest/test-result" "^24.5.0"
-    "@jest/transform" "^24.5.0"
-    "@jest/types" "^24.5.0"
+    "@jest/environment" "^24.7.1"
+    "@jest/test-result" "^24.7.1"
+    "@jest/transform" "^24.7.1"
+    "@jest/types" "^24.7.0"
     chalk "^2.0.1"
     exit "^0.1.2"
     glob "^7.1.2"
@@ -226,11 +223,11 @@
     istanbul-lib-coverage "^2.0.2"
     istanbul-lib-instrument "^3.0.1"
     istanbul-lib-source-maps "^3.0.1"
-    jest-haste-map "^24.5.0"
-    jest-resolve "^24.5.0"
-    jest-runtime "^24.5.0"
-    jest-util "^24.5.0"
-    jest-worker "^24.4.0"
+    jest-haste-map "^24.7.1"
+    jest-resolve "^24.7.1"
+    jest-runtime "^24.7.1"
+    jest-util "^24.7.1"
+    jest-worker "^24.6.0"
     node-notifier "^5.2.1"
     slash "^2.0.0"
     source-map "^0.6.0"
@@ -245,42 +242,52 @@
     graceful-fs "^4.1.15"
     source-map "^0.6.0"
 
-"@jest/test-result@^24.5.0":
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-24.5.0.tgz#ab66fb7741a04af3363443084e72ea84861a53f2"
-  integrity sha512-u66j2vBfa8Bli1+o3rCaVnVYa9O8CAFZeqiqLVhnarXtreSXG33YQ6vNYBogT7+nYiFNOohTU21BKiHlgmxD5A==
+"@jest/test-result@^24.7.1":
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-24.7.1.tgz#19eacdb29a114300aed24db651e5d975f08b6bbe"
+  integrity sha512-3U7wITxstdEc2HMfBX7Yx3JZgiNBubwDqQMh+BXmZXHa3G13YWF3p6cK+5g0hGkN3iufg/vGPl3hLxQXD74Npg==
   dependencies:
-    "@jest/console" "^24.3.0"
-    "@jest/types" "^24.5.0"
-    "@types/istanbul-lib-coverage" "^1.1.0"
+    "@jest/console" "^24.7.1"
+    "@jest/types" "^24.7.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
 
-"@jest/transform@^24.5.0":
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-24.5.0.tgz#6709fc26db918e6af63a985f2cc3c464b4cf99d9"
-  integrity sha512-XSsDz1gdR/QMmB8UCKlweAReQsZrD/DK7FuDlNo/pE8EcKMrfi2kqLRk8h8Gy/PDzgqJj64jNEzOce9pR8oj1w==
+"@jest/test-sequencer@^24.7.1":
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-24.7.1.tgz#9c18e428e1ad945fa74f6233a9d35745ca0e63e0"
+  integrity sha512-84HQkCpVZI/G1zq53gHJvSmhUer4aMYp9tTaffW28Ih5OxfCg8hGr3nTSbL1OhVDRrFZwvF+/R9gY6JRkDUpUA==
+  dependencies:
+    "@jest/test-result" "^24.7.1"
+    jest-haste-map "^24.7.1"
+    jest-runner "^24.7.1"
+    jest-runtime "^24.7.1"
+
+"@jest/transform@^24.7.1":
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-24.7.1.tgz#872318f125bcfab2de11f53b465ab1aa780789c2"
+  integrity sha512-EsOUqP9ULuJ66IkZQhI5LufCHlTbi7hrcllRMUEV/tOgqBVQi93+9qEvkX0n8mYpVXQ8VjwmICeRgg58mrtIEw==
   dependencies:
     "@babel/core" "^7.1.0"
-    "@jest/types" "^24.5.0"
+    "@jest/types" "^24.7.0"
     babel-plugin-istanbul "^5.1.0"
     chalk "^2.0.1"
     convert-source-map "^1.4.0"
     fast-json-stable-stringify "^2.0.0"
     graceful-fs "^4.1.15"
-    jest-haste-map "^24.5.0"
+    jest-haste-map "^24.7.1"
     jest-regex-util "^24.3.0"
-    jest-util "^24.5.0"
+    jest-util "^24.7.1"
     micromatch "^3.1.10"
     realpath-native "^1.1.0"
     slash "^2.0.0"
     source-map "^0.6.1"
     write-file-atomic "2.4.1"
 
-"@jest/types@^24.5.0":
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.5.0.tgz#feee214a4d0167b0ca447284e95a57aa10b3ee95"
-  integrity sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==
+"@jest/types@^24.5.0", "@jest/types@^24.7.0":
+  version "24.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.7.0.tgz#c4ec8d1828cdf23234d9b4ee31f5482a3f04f48b"
+  integrity sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==
   dependencies:
-    "@types/istanbul-lib-coverage" "^1.1.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/yargs" "^12.0.9"
 
 "@lerna/add@3.13.1":
@@ -1038,10 +1045,10 @@
   resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.3.tgz#b672cfaac25cbbc634a0fd92c515f66faa18dbca"
   integrity sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==
 
-"@types/istanbul-lib-coverage@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#2cc2ca41051498382b43157c8227fea60363f94a"
-  integrity sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==
+"@types/istanbul-lib-coverage@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz#1eb8c033e98cf4e1a4cedcaf8bcafe8cb7591e85"
+  integrity sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==
 
 "@types/jest-diff@*":
   version "20.0.1"
@@ -1070,10 +1077,17 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/node@*", "@types/node@^11.11.3", "@types/node@^11.11.6":
-  version "11.12.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.12.2.tgz#d7f302e74b10e9801d52852137f652d9ee235da8"
-  integrity sha512-c82MtnqWB/CqqK7/zit74Ob8H1dBdV7bK+BcErwtXbe0+nUGkgzq5NTDmRW/pAv2lFtmeNmW95b0zK2hxpeklg==
+"@types/node@*", "@types/node@^11.11.3", "@types/node@^11.13.0":
+  version "11.13.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.0.tgz#b0df8d6ef9b5001b2be3a94d909ce3c29a80f9e1"
+  integrity sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng==
+
+"@types/resolve@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
+  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/shelljs@^0.8.0":
   version "0.8.3"
@@ -1089,9 +1103,9 @@
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
 "@types/yargs@^12.0.2", "@types/yargs@^12.0.9":
-  version "12.0.10"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.10.tgz#17a8ec65cd8e88f51b418ceb271af18d3137df67"
-  integrity sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ==
+  version "12.0.11"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.11.tgz#a090d88e1f40a910e6443c95493c1c035c76ebdc"
+  integrity sha512-IsU1TD+8cQCyG76ZqxP0cVFnofvfzT8p/wO8ENT4jbN/KKN3grsHFgHNl/U+08s33ayX4LwI85cEhYXCOlOkMw==
 
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"
@@ -1372,16 +1386,16 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-jest@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.5.0.tgz#0ea042789810c2bec9065f7c8ab4dc18e1d28559"
-  integrity sha512-0fKCXyRwxFTJL0UXDJiT2xYxO9Lu2vBd9n+cC+eDjESzcVG3s2DRGAxbzJX21fceB1WYoBjAh8pQ83dKcl003g==
+babel-jest@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.7.1.tgz#73902c9ff15a7dfbdc9994b0b17fcefd96042178"
+  integrity sha512-GPnLqfk8Mtt0i4OemjWkChi73A3ALs4w2/QbG64uAj8b5mmwzxc7jbJVRZt8NJkxi6FopVHog9S3xX6UJKb2qg==
   dependencies:
-    "@jest/transform" "^24.5.0"
-    "@jest/types" "^24.5.0"
+    "@jest/transform" "^24.7.1"
+    "@jest/types" "^24.7.0"
     "@types/babel__core" "^7.1.0"
     babel-plugin-istanbul "^5.1.0"
-    babel-preset-jest "^24.3.0"
+    babel-preset-jest "^24.6.0"
     chalk "^2.4.2"
     slash "^2.0.0"
 
@@ -1394,20 +1408,20 @@ babel-plugin-istanbul@^5.1.0:
     istanbul-lib-instrument "^3.0.0"
     test-exclude "^5.0.0"
 
-babel-plugin-jest-hoist@^24.3.0:
-  version "24.3.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.3.0.tgz#f2e82952946f6e40bb0a75d266a3790d854c8b5b"
-  integrity sha512-nWh4N1mVH55Tzhx2isvUN5ebM5CDUvIpXPZYMRazQughie/EqGnbR+czzoQlhUmJG9pPJmYDRhvocotb2THl1w==
+babel-plugin-jest-hoist@^24.6.0:
+  version "24.6.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz#f7f7f7ad150ee96d7a5e8e2c5da8319579e78019"
+  integrity sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
-babel-preset-jest@^24.3.0:
-  version "24.3.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.3.0.tgz#db88497e18869f15b24d9c0e547d8e0ab950796d"
-  integrity sha512-VGTV2QYBa/Kn3WCOKdfS31j9qomaXSgJqi65B6o05/1GsJyj9LVhSljM9ro4S+IBGj/ENhNBuH9bpqzztKAQSw==
+babel-preset-jest@^24.6.0:
+  version "24.6.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz#66f06136eefce87797539c0d63f1769cc3915984"
+  integrity sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==
   dependencies:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
-    babel-plugin-jest-hoist "^24.3.0"
+    babel-plugin-jest-hoist "^24.6.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -1643,9 +1657,9 @@ callsites@^2.0.0:
   integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
 callsites@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
-  integrity sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 camelcase-keys@^2.0.0:
   version "2.1.0"
@@ -1675,9 +1689,9 @@ camelcase@^4.1.0:
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
 camelcase@^5.0.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.0.tgz#0a110882cbeba41f72f99fcf918f4a0a92a13ebf"
-  integrity sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg==
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -1838,7 +1852,12 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.12.1, commander@^2.14.1, commander@^2.19.0, commander@^2.9.0, commander@~2.19.0:
+commander@^2.12.1:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+
+commander@^2.14.1, commander@^2.19.0, commander@^2.9.0, commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
@@ -2132,7 +2151,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^2.2.0, debug@^2.3.3:
+debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -2285,7 +2304,7 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-detect-libc@^1.0.3:
+detect-libc@^1.0.2, detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -2548,16 +2567,16 @@ expand-template@^2.0.3:
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
   integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
 
-expect@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-24.5.0.tgz#492fb0df8378d8474cc84b827776b069f46294ed"
-  integrity sha512-p2Gmc0CLxOgkyA93ySWmHFYHUPFIHG6XZ06l7WArWAsrqYVaVEkOU5NtT5i68KUyGKbkQgDCkiT65bWmdoL6Bw==
+expect@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-24.7.1.tgz#d91defbab4e627470a152feaf35b3c31aa1c7c14"
+  integrity sha512-mGfvMTPduksV3xoI0xur56pQsg2vJjNf5+a+bXOjqCkiCBbmCayrBbHS/75y9K430cfqyocPr2ZjiNiRx4SRKw==
   dependencies:
-    "@jest/types" "^24.5.0"
+    "@jest/types" "^24.7.0"
     ansi-styles "^3.2.0"
     jest-get-type "^24.3.0"
-    jest-matcher-utils "^24.5.0"
-    jest-message-util "^24.5.0"
+    jest-matcher-utils "^24.7.0"
+    jest-message-util "^24.7.1"
     jest-regex-util "^24.3.0"
 
 extend-shallow@^2.0.1:
@@ -2799,6 +2818,14 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+fsevents@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.7.tgz#4851b664a3783e52003b3c66eb0eee1074933aa4"
+  integrity sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==
+  dependencies:
+    nan "^2.9.2"
+    node-pre-gyp "^0.10.0"
 
 fstream@^1.0.0, fstream@^1.0.2:
   version "1.0.11"
@@ -3188,7 +3215,7 @@ husky@^1.3.1:
     run-node "^1.0.0"
     slash "^2.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -3459,9 +3486,9 @@ is-fullwidth-code-point@^2.0.0:
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
 is-generator-fn@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.0.0.tgz#038c31b774709641bda678b1f06a4e3227c10b3e"
-  integrity sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
+  integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
 is-glob@^3.1.0:
   version "3.1.0"
@@ -3698,65 +3725,66 @@ istanbul-reports@^2.1.1:
   dependencies:
     handlebars "^4.1.0"
 
-jest-changed-files@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.5.0.tgz#4075269ee115d87194fd5822e642af22133cf705"
-  integrity sha512-Ikl29dosYnTsH9pYa1Tv9POkILBhN/TLZ37xbzgNsZ1D2+2n+8oEZS2yP1BrHn/T4Rs4Ggwwbp/x8CKOS5YJOg==
+jest-changed-files@^24.7.0:
+  version "24.7.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.7.0.tgz#39d723a11b16ed7b373ac83adc76a69464b0c4fa"
+  integrity sha512-33BgewurnwSfJrW7T5/ZAXGE44o7swLslwh8aUckzq2e17/2Os1V0QU506ZNik3hjs8MgnEMKNkcud442NCDTw==
   dependencies:
-    "@jest/types" "^24.5.0"
+    "@jest/types" "^24.7.0"
     execa "^1.0.0"
     throat "^4.0.0"
 
-jest-cli@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-24.5.0.tgz#598139d3446d1942fb7dc93944b9ba766d756d4b"
-  integrity sha512-P+Jp0SLO4KWN0cGlNtC7JV0dW1eSFR7eRpoOucP2UM0sqlzp/bVHeo71Omonvigrj9AvCKy7NtQANtqJ7FXz8g==
+jest-cli@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-24.7.1.tgz#6093a539073b6f4953145abeeb9709cd621044f1"
+  integrity sha512-32OBoSCVPzcTslGFl6yVCMzB2SqX3IrWwZCY5mZYkb0D2WsogmU3eV2o8z7+gRQa4o4sZPX/k7GU+II7CxM6WQ==
   dependencies:
-    "@jest/core" "^24.5.0"
-    "@jest/test-result" "^24.5.0"
-    "@jest/types" "^24.5.0"
+    "@jest/core" "^24.7.1"
+    "@jest/test-result" "^24.7.1"
+    "@jest/types" "^24.7.0"
     chalk "^2.0.1"
     exit "^0.1.2"
     import-local "^2.0.0"
     is-ci "^2.0.0"
-    jest-config "^24.5.0"
-    jest-util "^24.5.0"
-    jest-validate "^24.5.0"
+    jest-config "^24.7.1"
+    jest-util "^24.7.1"
+    jest-validate "^24.7.0"
     prompts "^2.0.1"
     realpath-native "^1.1.0"
     yargs "^12.0.2"
 
-jest-config@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-24.5.0.tgz#404d1bc6bb81aed6bd1890d07e2dca9fbba2e121"
-  integrity sha512-t2UTh0Z2uZhGBNVseF8wA2DS2SuBiLOL6qpLq18+OZGfFUxTM7BzUVKyHFN/vuN+s/aslY1COW95j1Rw81huOQ==
+jest-config@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-24.7.1.tgz#6c1dd4db82a89710a3cf66bdba97827c9a1cf052"
+  integrity sha512-8FlJNLI+X+MU37j7j8RE4DnJkvAghXmBWdArVzypW6WxfGuxiL/CCkzBg0gHtXhD2rxla3IMOSUAHylSKYJ83g==
   dependencies:
     "@babel/core" "^7.1.0"
-    "@jest/types" "^24.5.0"
-    babel-jest "^24.5.0"
+    "@jest/test-sequencer" "^24.7.1"
+    "@jest/types" "^24.7.0"
+    babel-jest "^24.7.1"
     chalk "^2.0.1"
     glob "^7.1.1"
-    jest-environment-jsdom "^24.5.0"
-    jest-environment-node "^24.5.0"
+    jest-environment-jsdom "^24.7.1"
+    jest-environment-node "^24.7.1"
     jest-get-type "^24.3.0"
-    jest-jasmine2 "^24.5.0"
+    jest-jasmine2 "^24.7.1"
     jest-regex-util "^24.3.0"
-    jest-resolve "^24.5.0"
-    jest-util "^24.5.0"
-    jest-validate "^24.5.0"
+    jest-resolve "^24.7.1"
+    jest-util "^24.7.1"
+    jest-validate "^24.7.0"
     micromatch "^3.1.10"
-    pretty-format "^24.5.0"
+    pretty-format "^24.7.0"
     realpath-native "^1.1.0"
 
-jest-diff@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.5.0.tgz#a2d8627964bb06a91893c0fbcb28ab228c257652"
-  integrity sha512-mCILZd9r7zqL9Uh6yNoXjwGQx0/J43OD2vvWVKwOEOLZliQOsojXwqboubAQ+Tszrb6DHGmNU7m4whGeB9YOqw==
+jest-diff@^24.7.0:
+  version "24.7.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.7.0.tgz#5d862899be46249754806f66e5729c07fcb3580f"
+  integrity sha512-ULQZ5B1lWpH70O4xsANC4tf4Ko6RrpwhE3PtG6ERjMg1TiYTC2Wp4IntJVGro6a8HG9luYHhhmF4grF0Pltckg==
   dependencies:
     chalk "^2.0.1"
     diff-sequences "^24.3.0"
     jest-get-type "^24.3.0"
-    pretty-format "^24.5.0"
+    pretty-format "^24.7.0"
 
 jest-docblock@^24.3.0:
   version "24.3.0"
@@ -3765,80 +3793,84 @@ jest-docblock@^24.3.0:
   dependencies:
     detect-newline "^2.1.0"
 
-jest-each@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-24.5.0.tgz#da14d017a1b7d0f01fb458d338314cafe7f72318"
-  integrity sha512-6gy3Kh37PwIT5sNvNY2VchtIFOOBh8UCYnBlxXMb5sr5wpJUDPTUATX2Axq1Vfk+HWTMpsYPeVYp4TXx5uqUBw==
+jest-each@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-24.7.1.tgz#fcc7dda4147c28430ad9fb6dc7211cd17ab54e74"
+  integrity sha512-4fsS8fEfLa3lfnI1Jw6NxjhyRTgfpuOVTeUZZFyVYqeTa4hPhr2YkToUhouuLTrL2eMGOfpbdMyRx0GQ/VooKA==
   dependencies:
-    "@jest/types" "^24.5.0"
+    "@jest/types" "^24.7.0"
     chalk "^2.0.1"
     jest-get-type "^24.3.0"
-    jest-util "^24.5.0"
-    pretty-format "^24.5.0"
+    jest-util "^24.7.1"
+    pretty-format "^24.7.0"
 
-jest-environment-jsdom@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-24.5.0.tgz#1c3143063e1374100f8c2723a8b6aad23b6db7eb"
-  integrity sha512-62Ih5HbdAWcsqBx2ktUnor/mABBo1U111AvZWcLKeWN/n/gc5ZvDBKe4Og44fQdHKiXClrNGC6G0mBo6wrPeGQ==
+jest-environment-jsdom@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-24.7.1.tgz#a40e004b4458ebeb8a98082df135fd501b9fbbd6"
+  integrity sha512-Gnhb+RqE2JuQGb3kJsLF8vfqjt3PHKSstq4Xc8ic+ax7QKo4Z0RWGucU3YV+DwKR3T9SYc+3YCUQEJs8r7+Jxg==
   dependencies:
-    "@jest/environment" "^24.5.0"
-    "@jest/fake-timers" "^24.5.0"
-    "@jest/types" "^24.5.0"
-    jest-mock "^24.5.0"
-    jest-util "^24.5.0"
+    "@jest/environment" "^24.7.1"
+    "@jest/fake-timers" "^24.7.1"
+    "@jest/types" "^24.7.0"
+    jest-mock "^24.7.0"
+    jest-util "^24.7.1"
     jsdom "^11.5.1"
 
-jest-environment-node@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-24.5.0.tgz#763eebdf529f75b60aa600c6cf8cb09873caa6ab"
-  integrity sha512-du6FuyWr/GbKLsmAbzNF9mpr2Iu2zWSaq/BNHzX+vgOcts9f2ayXBweS7RAhr+6bLp6qRpMB6utAMF5Ygktxnw==
+jest-environment-node@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-24.7.1.tgz#fa2c047a31522a48038d26ee4f7c8fd9c1ecfe12"
+  integrity sha512-GJJQt1p9/C6aj6yNZMvovZuxTUd+BEJprETdvTKSb4kHcw4mFj8777USQV0FJoJ4V3djpOwA5eWyPwfq//PFBA==
   dependencies:
-    "@jest/environment" "^24.5.0"
-    "@jest/fake-timers" "^24.5.0"
-    "@jest/types" "^24.5.0"
-    jest-mock "^24.5.0"
-    jest-util "^24.5.0"
+    "@jest/environment" "^24.7.1"
+    "@jest/fake-timers" "^24.7.1"
+    "@jest/types" "^24.7.0"
+    jest-mock "^24.7.0"
+    jest-util "^24.7.1"
 
 jest-get-type@^24.3.0:
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.3.0.tgz#582cfd1a4f91b5cdad1d43d2932f816d543c65da"
   integrity sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==
 
-jest-haste-map@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.5.0.tgz#3f17d0c548b99c0c96ed2893f9c0ccecb2eb9066"
-  integrity sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==
+jest-haste-map@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.7.1.tgz#772e215cd84080d4bbcb759cfb668ad649a21471"
+  integrity sha512-g0tWkzjpHD2qa03mTKhlydbmmYiA2KdcJe762SbfFo/7NIMgBWAA0XqQlApPwkWOF7Cxoi/gUqL0i6DIoLpMBw==
   dependencies:
-    "@jest/types" "^24.5.0"
+    "@jest/types" "^24.7.0"
+    anymatch "^2.0.0"
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.15"
     invariant "^2.2.4"
     jest-serializer "^24.4.0"
-    jest-util "^24.5.0"
-    jest-worker "^24.4.0"
+    jest-util "^24.7.1"
+    jest-worker "^24.6.0"
     micromatch "^3.1.10"
     sane "^4.0.3"
+    walker "^1.0.7"
+  optionalDependencies:
+    fsevents "^1.2.7"
 
-jest-jasmine2@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-24.5.0.tgz#e6af4d7f73dc527d007cca5a5b177c0bcc29d111"
-  integrity sha512-sfVrxVcx1rNUbBeyIyhkqZ4q+seNKyAG6iM0S2TYBdQsXjoFDdqWFfsUxb6uXSsbimbXX/NMkJIwUZ1uT9+/Aw==
+jest-jasmine2@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-24.7.1.tgz#01398686dabe46553716303993f3be62e5d9d818"
+  integrity sha512-Y/9AOJDV1XS44wNwCaThq4Pw3gBPiOv/s6NcbOAkVRRUEPu+36L2xoPsqQXsDrxoBerqeyslpn2TpCI8Zr6J2w==
   dependencies:
     "@babel/traverse" "^7.1.0"
-    "@jest/environment" "^24.5.0"
-    "@jest/test-result" "^24.5.0"
-    "@jest/types" "^24.5.0"
+    "@jest/environment" "^24.7.1"
+    "@jest/test-result" "^24.7.1"
+    "@jest/types" "^24.7.0"
     chalk "^2.0.1"
     co "^4.6.0"
-    expect "^24.5.0"
+    expect "^24.7.1"
     is-generator-fn "^2.0.0"
-    jest-each "^24.5.0"
-    jest-matcher-utils "^24.5.0"
-    jest-message-util "^24.5.0"
-    jest-runtime "^24.5.0"
-    jest-snapshot "^24.5.0"
-    jest-util "^24.5.0"
-    pretty-format "^24.5.0"
+    jest-each "^24.7.1"
+    jest-matcher-utils "^24.7.0"
+    jest-message-util "^24.7.1"
+    jest-runtime "^24.7.1"
+    jest-snapshot "^24.7.1"
+    jest-util "^24.7.1"
+    pretty-format "^24.7.0"
     throat "^4.0.0"
 
 jest-junit@^6.3.0:
@@ -3851,43 +3883,43 @@ jest-junit@^6.3.0:
     strip-ansi "^4.0.0"
     xml "^1.0.1"
 
-jest-leak-detector@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.5.0.tgz#21ae2b3b0da252c1171cd494f75696d65fb6fa89"
-  integrity sha512-LZKBjGovFRx3cRBkqmIg+BZnxbrLqhQl09IziMk3oeh1OV81Hg30RUIx885mq8qBv1PA0comB9bjKcuyNO1bCQ==
+jest-leak-detector@^24.7.0:
+  version "24.7.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.7.0.tgz#323ff93ed69be12e898f5b040952f08a94288ff9"
+  integrity sha512-zV0qHKZGXtmPVVzT99CVEcHE9XDf+8LwiE0Ob7jjezERiGVljmqKFWpV2IkG+rkFIEUHFEkMiICu7wnoPM/RoQ==
   dependencies:
-    pretty-format "^24.5.0"
+    pretty-format "^24.7.0"
 
-jest-matcher-utils@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.5.0.tgz#5995549dcf09fa94406e89526e877b094dad8770"
-  integrity sha512-QM1nmLROjLj8GMGzg5VBra3I9hLpjMPtF1YqzQS3rvWn2ltGZLrGAO1KQ9zUCVi5aCvrkbS5Ndm2evIP9yZg1Q==
+jest-matcher-utils@^24.7.0:
+  version "24.7.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.7.0.tgz#bbee1ff37bc8b2e4afcaabc91617c1526af4bcd4"
+  integrity sha512-158ieSgk3LNXeUhbVJYRXyTPSCqNgVXOp/GT7O94mYd3pk/8+odKTyR1JLtNOQSPzNi8NFYVONtvSWA/e1RDXg==
   dependencies:
     chalk "^2.0.1"
-    jest-diff "^24.5.0"
+    jest-diff "^24.7.0"
     jest-get-type "^24.3.0"
-    pretty-format "^24.5.0"
+    pretty-format "^24.7.0"
 
-jest-message-util@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.5.0.tgz#181420a65a7ef2e8b5c2f8e14882c453c6d41d07"
-  integrity sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==
+jest-message-util@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.7.1.tgz#f1dc3a6c195647096a99d0f1dadbc447ae547018"
+  integrity sha512-dk0gqVtyqezCHbcbk60CdIf+8UHgD+lmRHifeH3JRcnAqh4nEyPytSc9/L1+cQyxC+ceaeP696N4ATe7L+omcg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@jest/test-result" "^24.5.0"
-    "@jest/types" "^24.5.0"
+    "@jest/test-result" "^24.7.1"
+    "@jest/types" "^24.7.0"
     "@types/stack-utils" "^1.0.1"
     chalk "^2.0.1"
     micromatch "^3.1.10"
     slash "^2.0.0"
     stack-utils "^1.0.1"
 
-jest-mock@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.5.0.tgz#976912c99a93f2a1c67497a9414aa4d9da4c7b76"
-  integrity sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==
+jest-mock@^24.7.0:
+  version "24.7.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.7.0.tgz#e49ce7262c12d7f5897b0d8af77f6db8e538023b"
+  integrity sha512-6taW4B4WUcEiT2V9BbOmwyGuwuAFT2G8yghF7nyNW1/2gq5+6aTqSPcS9lS6ArvEkX55vbPAS/Jarx5LSm4Fng==
   dependencies:
-    "@jest/types" "^24.5.0"
+    "@jest/types" "^24.7.0"
 
 jest-pnp-resolver@^1.2.1:
   version "1.2.1"
@@ -3899,75 +3931,75 @@ jest-regex-util@^24.3.0:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.3.0.tgz#d5a65f60be1ae3e310d5214a0307581995227b36"
   integrity sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==
 
-jest-resolve-dependencies@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-24.5.0.tgz#1a0dae9cdd41349ca4a84148b3e78da2ba33fd4b"
-  integrity sha512-dRVM1D+gWrFfrq2vlL5P9P/i8kB4BOYqYf3S7xczZ+A6PC3SgXYSErX/ScW/469pWMboM1uAhgLF+39nXlirCQ==
+jest-resolve-dependencies@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-24.7.1.tgz#cf93bbef26999488a96a2b2012f9fe7375aa378f"
+  integrity sha512-2Eyh5LJB2liNzfk4eo7bD1ZyBbqEJIyyrFtZG555cSWW9xVHxII2NuOkSl1yUYTAYCAmM2f2aIT5A7HzNmubyg==
   dependencies:
-    "@jest/types" "^24.5.0"
+    "@jest/types" "^24.7.0"
     jest-regex-util "^24.3.0"
-    jest-snapshot "^24.5.0"
+    jest-snapshot "^24.7.1"
 
-jest-resolve@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-24.5.0.tgz#8c16ba08f60a1616c3b1cd7afb24574f50a24d04"
-  integrity sha512-ZIfGqLX1Rg8xJpQqNjdoO8MuxHV1q/i2OO1hLXjgCWFWs5bsedS8UrOdgjUqqNae6DXA+pCyRmdcB7lQEEbXew==
+jest-resolve@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-24.7.1.tgz#e4150198299298380a75a9fd55043fa3b9b17fde"
+  integrity sha512-Bgrc+/UUZpGJ4323sQyj85hV9d+ANyPNu6XfRDUcyFNX1QrZpSoM0kE4Mb2vZMAYTJZsBFzYe8X1UaOkOELSbw==
   dependencies:
-    "@jest/types" "^24.5.0"
+    "@jest/types" "^24.7.0"
     browser-resolve "^1.11.3"
     chalk "^2.0.1"
     jest-pnp-resolver "^1.2.1"
     realpath-native "^1.1.0"
 
-jest-runner@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-24.5.0.tgz#9be26ece4fd4ab3dfb528b887523144b7c5ffca8"
-  integrity sha512-oqsiS9TkIZV5dVkD+GmbNfWBRPIvxqmlTQ+AQUJUQ07n+4xTSDc40r+aKBynHw9/tLzafC00DIbJjB2cOZdvMA==
+jest-runner@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-24.7.1.tgz#41c8a02a06aa23ea82d8bffd69d7fa98d32f85bf"
+  integrity sha512-aNFc9liWU/xt+G9pobdKZ4qTeG/wnJrJna3VqunziDNsWT3EBpmxXZRBMKCsNMyfy+A/XHiV+tsMLufdsNdgCw==
   dependencies:
-    "@jest/console" "^24.3.0"
-    "@jest/environment" "^24.5.0"
-    "@jest/test-result" "^24.5.0"
-    "@jest/types" "^24.5.0"
+    "@jest/console" "^24.7.1"
+    "@jest/environment" "^24.7.1"
+    "@jest/test-result" "^24.7.1"
+    "@jest/types" "^24.7.0"
     chalk "^2.4.2"
     exit "^0.1.2"
     graceful-fs "^4.1.15"
-    jest-config "^24.5.0"
+    jest-config "^24.7.1"
     jest-docblock "^24.3.0"
-    jest-haste-map "^24.5.0"
-    jest-jasmine2 "^24.5.0"
-    jest-leak-detector "^24.5.0"
-    jest-message-util "^24.5.0"
-    jest-resolve "^24.5.0"
-    jest-runtime "^24.5.0"
-    jest-util "^24.5.0"
-    jest-worker "^24.4.0"
+    jest-haste-map "^24.7.1"
+    jest-jasmine2 "^24.7.1"
+    jest-leak-detector "^24.7.0"
+    jest-message-util "^24.7.1"
+    jest-resolve "^24.7.1"
+    jest-runtime "^24.7.1"
+    jest-util "^24.7.1"
+    jest-worker "^24.6.0"
     source-map-support "^0.5.6"
     throat "^4.0.0"
 
-jest-runtime@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-24.5.0.tgz#3a76e0bfef4db3896d5116e9e518be47ba771aa2"
-  integrity sha512-GTFHzfLdwpaeoDPilNpBrorlPoNZuZrwKKzKJs09vWwHo+9TOsIIuszK8cWOuKC7ss07aN1922Ge8fsGdsqCuw==
+jest-runtime@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-24.7.1.tgz#2ffd70b22dd03a5988c0ab9465c85cdf5d25c597"
+  integrity sha512-0VAbyBy7tll3R+82IPJpf6QZkokzXPIS71aDeqh+WzPRXRCNz6StQ45otFariPdJ4FmXpDiArdhZrzNAC3sj6A==
   dependencies:
-    "@jest/console" "^24.3.0"
-    "@jest/environment" "^24.5.0"
+    "@jest/console" "^24.7.1"
+    "@jest/environment" "^24.7.1"
     "@jest/source-map" "^24.3.0"
-    "@jest/transform" "^24.5.0"
-    "@jest/types" "^24.5.0"
+    "@jest/transform" "^24.7.1"
+    "@jest/types" "^24.7.0"
     "@types/yargs" "^12.0.2"
     chalk "^2.0.1"
     exit "^0.1.2"
     glob "^7.1.3"
     graceful-fs "^4.1.15"
-    jest-config "^24.5.0"
-    jest-haste-map "^24.5.0"
-    jest-message-util "^24.5.0"
-    jest-mock "^24.5.0"
+    jest-config "^24.7.1"
+    jest-haste-map "^24.7.1"
+    jest-message-util "^24.7.1"
+    jest-mock "^24.7.0"
     jest-regex-util "^24.3.0"
-    jest-resolve "^24.5.0"
-    jest-snapshot "^24.5.0"
-    jest-util "^24.5.0"
-    jest-validate "^24.5.0"
+    jest-resolve "^24.7.1"
+    jest-snapshot "^24.7.1"
+    jest-util "^24.7.1"
+    jest-validate "^24.7.0"
     realpath-native "^1.1.0"
     slash "^2.0.0"
     strip-bom "^3.0.0"
@@ -3978,35 +4010,34 @@ jest-serializer@^24.4.0:
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-24.4.0.tgz#f70c5918c8ea9235ccb1276d232e459080588db3"
   integrity sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==
 
-jest-snapshot@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-24.5.0.tgz#e5d224468a759fd19e36f01217aac912f500f779"
-  integrity sha512-eBEeJb5ROk0NcpodmSKnCVgMOo+Qsu5z9EDl3tGffwPzK1yV37mjGWF2YeIz1NkntgTzP+fUL4s09a0+0dpVWA==
+jest-snapshot@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-24.7.1.tgz#bd5a35f74aedff070975e9e9c90024f082099568"
+  integrity sha512-8Xk5O4p+JsZZn4RCNUS3pxA+ORKpEKepE+a5ejIKrId9CwrVN0NY+vkqEkXqlstA5NMBkNahXkR/4qEBy0t5yA==
   dependencies:
     "@babel/types" "^7.0.0"
-    "@jest/types" "^24.5.0"
+    "@jest/types" "^24.7.0"
     chalk "^2.0.1"
-    expect "^24.5.0"
-    jest-diff "^24.5.0"
-    jest-matcher-utils "^24.5.0"
-    jest-message-util "^24.5.0"
-    jest-resolve "^24.5.0"
+    expect "^24.7.1"
+    jest-diff "^24.7.0"
+    jest-matcher-utils "^24.7.0"
+    jest-message-util "^24.7.1"
+    jest-resolve "^24.7.1"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    pretty-format "^24.5.0"
+    pretty-format "^24.7.0"
     semver "^5.5.0"
 
-jest-util@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.5.0.tgz#9d9cb06d9dcccc8e7cc76df91b1635025d7baa84"
-  integrity sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==
+jest-util@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.7.1.tgz#b4043df57b32a23be27c75a2763d8faf242038ff"
+  integrity sha512-/KilOue2n2rZ5AnEBYoxOXkeTu6vi7cjgQ8MXEkih0oeAXT6JkS3fr7/j8+engCjciOU1Nq5loMSKe0A1oeX0A==
   dependencies:
-    "@jest/console" "^24.3.0"
-    "@jest/fake-timers" "^24.5.0"
+    "@jest/console" "^24.7.1"
+    "@jest/fake-timers" "^24.7.1"
     "@jest/source-map" "^24.3.0"
-    "@jest/test-result" "^24.5.0"
-    "@jest/types" "^24.5.0"
-    "@types/node" "*"
+    "@jest/test-result" "^24.7.1"
+    "@jest/types" "^24.7.0"
     callsites "^3.0.0"
     chalk "^2.0.1"
     graceful-fs "^4.1.15"
@@ -4015,7 +4046,7 @@ jest-util@^24.5.0:
     slash "^2.0.0"
     source-map "^0.6.0"
 
-jest-validate@^24.0.0, jest-validate@^24.5.0:
+jest-validate@^24.0.0:
   version "24.5.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-24.5.0.tgz#62fd93d81214c070bb2d7a55f329a79d8057c7de"
   integrity sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==
@@ -4027,21 +4058,32 @@ jest-validate@^24.0.0, jest-validate@^24.5.0:
     leven "^2.1.0"
     pretty-format "^24.5.0"
 
-jest-watcher@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-24.5.0.tgz#da7bd9cb5967e274889b42078c8f501ae1c47761"
-  integrity sha512-/hCpgR6bg0nKvD3nv4KasdTxuhwfViVMHUATJlnGCD0r1QrmIssimPbmc5KfAQblAVxkD8xrzuij9vfPUk1/rA==
+jest-validate@^24.7.0:
+  version "24.7.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-24.7.0.tgz#70007076f338528ee1b1c8a8258b1b0bb982508d"
+  integrity sha512-cgai/gts9B2chz1rqVdmLhzYxQbgQurh1PEQSvSgPZ8KGa1AqXsqC45W5wKEwzxKrWqypuQrQxnF4+G9VejJJA==
   dependencies:
-    "@jest/test-result" "^24.5.0"
-    "@jest/types" "^24.5.0"
-    "@types/node" "*"
+    "@jest/types" "^24.7.0"
+    camelcase "^5.0.0"
+    chalk "^2.0.1"
+    jest-get-type "^24.3.0"
+    leven "^2.1.0"
+    pretty-format "^24.7.0"
+
+jest-watcher@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-24.7.1.tgz#e161363d7f3f4e1ef3d389b7b3a0aad247b673f5"
+  integrity sha512-Wd6TepHLRHVKLNPacEsBwlp9raeBIO+01xrN24Dek4ggTS8HHnOzYSFnvp+6MtkkJ3KfMzy220KTi95e2rRkrw==
+  dependencies:
+    "@jest/test-result" "^24.7.1"
+    "@jest/types" "^24.7.0"
     "@types/yargs" "^12.0.9"
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
-    jest-util "^24.5.0"
+    jest-util "^24.7.1"
     string-length "^2.0.0"
 
-jest-worker@^24.0.0, jest-worker@^24.4.0:
+jest-worker@^24.0.0:
   version "24.4.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.4.0.tgz#fbc452b0120bb5c2a70cdc88fa132b48eeb11dd0"
   integrity sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==
@@ -4050,13 +4092,21 @@ jest-worker@^24.0.0, jest-worker@^24.4.0:
     merge-stream "^1.0.1"
     supports-color "^6.1.0"
 
+jest-worker@^24.6.0:
+  version "24.6.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.6.0.tgz#7f81ceae34b7cde0c9827a6980c35b7cdc0161b3"
+  integrity sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==
+  dependencies:
+    merge-stream "^1.0.1"
+    supports-color "^6.1.0"
+
 jest@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-24.5.0.tgz#38f11ae2c2baa2f86c2bc4d8a91d2b51612cd19a"
-  integrity sha512-lxL+Fq5/RH7inxxmfS2aZLCf8MsS+YCUBfeiNO6BWz/MmjhDGaIEA/2bzEf9q4Q0X+mtFHiinHFvQ0u+RvW/qQ==
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-24.7.1.tgz#0d94331cf510c75893ee32f87d7321d5bf8f2501"
+  integrity sha512-AbvRar5r++izmqo5gdbAjTeA6uNRGoNRuj5vHB0OnDXo2DXWZJVuaObiGgtlvhKb+cWy2oYbQSfxv7Q7GjnAtA==
   dependencies:
     import-local "^2.0.0"
-    jest-cli "^24.5.0"
+    jest-cli "^24.7.1"
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -4068,10 +4118,18 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.11.0, js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.7.0:
+js-yaml@^3.11.0, js-yaml@^3.13.0:
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.0.tgz#38ee7178ac0eea2c97ff6d96fff4b18c7d8cf98e"
   integrity sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.12.0:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -4809,7 +4867,7 @@ mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.12.1:
+nan@^2.12.1, nan@^2.9.2:
   version "2.13.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
   integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
@@ -4840,6 +4898,15 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+needle@^2.2.1:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"
+  integrity sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==
+  dependencies:
+    debug "^2.1.2"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
 
 neo-async@^2.6.0:
   version "2.6.0"
@@ -4911,6 +4978,22 @@ node-notifier@^5.2.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
+node-pre-gyp@^0.10.0:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
+  integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
+
 noop-logger@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
@@ -4922,6 +5005,14 @@ noop-logger@^0.1.1:
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
+
+nopt@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
+  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
+  dependencies:
+    abbrev "1"
+    osenv "^0.1.4"
 
 normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5, normalize-package-data@^2.4.0:
   version "2.5.0"
@@ -4974,7 +5065,7 @@ npm-lifecycle@^2.1.0:
     semver "^5.5.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.12, npm-packlist@^1.4.1:
+npm-packlist@^1.1.12, npm-packlist@^1.1.6, npm-packlist@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.1.tgz#19064cdf988da80ea3cee45533879d90192bbfbc"
   integrity sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==
@@ -5026,7 +5117,7 @@ npm-which@^3.0.1:
     npm-path "^2.0.2"
     which "^1.2.10"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.1, npmlog@^4.1.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.1, npmlog@^4.0.2, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -5158,7 +5249,7 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@0, osenv@^0.1.5:
+osenv@0, osenv@^0.1.4, osenv@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -5184,9 +5275,9 @@ p-finally@^1.0.0:
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
 p-is-promise@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.0.0.tgz#7554e3d572109a87e1f3f53f6a7d85d1b194f4c5"
-  integrity sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
+  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -5500,12 +5591,12 @@ prettier@^1.16.4:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
   integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
 
-pretty-format@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.5.0.tgz#cc69a0281a62cd7242633fc135d6930cd889822d"
-  integrity sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==
+pretty-format@^24.5.0, pretty-format@^24.7.0:
+  version "24.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.7.0.tgz#d23106bc2edcd776079c2daa5da02bcb12ed0c10"
+  integrity sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==
   dependencies:
-    "@jest/types" "^24.5.0"
+    "@jest/types" "^24.7.0"
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
@@ -5933,7 +6024,7 @@ retry@^0.10.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -5941,14 +6032,14 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.2:
     glob "^7.1.3"
 
 rollup-plugin-commonjs@^9.2.1:
-  version "9.2.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.2.2.tgz#4959f3ff0d9706c132e5247b47ab385f11d9aae6"
-  integrity sha512-FXBgY+IvZIV2AZVT/0CPMsP+b1dKkxE+F6SHI9wddqKDV9KCGDA2cV5e/VsJLwXKFgrtliqMr7Rq3QBfPiJ8Xg==
+  version "9.3.4"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.3.4.tgz#2b3dddbbbded83d45c36ff101cdd29e924fd23bc"
+  integrity sha512-DTZOvRoiVIHHLFBCL4pFxOaJt8pagxsVldEXBOn6wl3/V21wVaj17HFfyzTsQUuou3sZL3lEJZVWKPFblJfI6w==
   dependencies:
     estree-walker "^0.6.0"
     magic-string "^0.25.2"
     resolve "^1.10.0"
-    rollup-pluginutils "^2.5.0"
+    rollup-pluginutils "^2.6.0"
 
 rollup-plugin-filesize@^6.0.1:
   version "6.0.1"
@@ -5964,10 +6055,11 @@ rollup-plugin-filesize@^6.0.1:
     terser "^3.10.0"
 
 rollup-plugin-node-resolve@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.0.1.tgz#f95765d174e5daeef9ea6268566141f53aa9d422"
-  integrity sha512-fSS7YDuCe0gYqKsr5OvxMloeZYUSgN43Ypi1WeRZzQcWtHgFayV5tUSPYpxuaioIIWaBXl6NrVk0T2/sKwueLg==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.2.0.tgz#f1f38392a97360195be04d3c3d791ddd9715d755"
+  integrity sha512-JhD9hcOFv4oPQ5zViwP3Z79WSXCvcoSDmtZ1tn2pOKry28+XpoRRzWZHp5qz1aPKtTHRLRoMMnrMxnwDhbtuUw==
   dependencies:
+    "@types/resolve" "0.0.8"
     builtin-modules "^3.0.0"
     is-module "^1.0.0"
     resolve "^1.10.0"
@@ -5990,7 +6082,7 @@ rollup-plugin-terser@^4.0.4:
     serialize-javascript "^1.6.1"
     terser "^3.14.1"
 
-rollup-pluginutils@^2.4.1, rollup-pluginutils@^2.5.0:
+rollup-pluginutils@^2.4.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.5.0.tgz#23be0f05ac3972ea7b08fc7870cb91fde5b23a09"
   integrity sha512-9Muh1H+XB5f5ONmKMayUoTYR1EZwHbwJJ9oZLrKT5yuTf/RLIQ5mYIGsrERquVucJmjmaAW0Y7+6Qo1Ep+5w3Q==
@@ -5998,13 +6090,21 @@ rollup-pluginutils@^2.4.1, rollup-pluginutils@^2.5.0:
     estree-walker "^0.6.0"
     micromatch "^3.1.10"
 
+rollup-pluginutils@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.6.0.tgz#203706edd43dfafeaebc355d7351119402fc83ad"
+  integrity sha512-aGQwspEF8oPKvg37u3p7h0cYNwmJR1sCBMZGZ5b9qy8HGtETknqjzcxrDRrcAnJNXN18lBH4Q9vZYth/p4n8jQ==
+  dependencies:
+    estree-walker "^0.6.0"
+    micromatch "^3.1.10"
+
 rollup@^1.6.0:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.7.4.tgz#dd9d1d4935d3db38f16e1caaef635d8d1b0831c4"
-  integrity sha512-nc86fETLHdozhRWlW/uNVIQ7ODuA1vU2/L8znAxP9TNMx1NA6GTth3llqoxxCle2kkyui+OfGzbKaQxD60NJjA==
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.9.0.tgz#65f7db8d312a07d4e9702316025f91df56ce9f9c"
+  integrity sha512-cNZx9MLpKFMSaObdVFeu8nXw8gfw6yjuxWjt5mRCJcBZrAJ0NHAYwemKjayvYvhLaNNkf3+kS2DKRKS5J6NRVg==
   dependencies:
     "@types/estree" "0.0.39"
-    "@types/node" "^11.11.6"
+    "@types/node" "^11.13.0"
     acorn "^6.1.1"
 
 rsvp@^4.8.4:
@@ -6325,9 +6425,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz#81c0ce8f21474756148bbb5f3bfc0f36bf15d76e"
-  integrity sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz#75ecd1a88de8c184ef015eafb51b5b48bfd11bb1"
+  integrity sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -6598,7 +6698,7 @@ tar@^2.0.0:
     fstream "^1.0.2"
     inherits "2"
 
-tar@^4.4.8:
+tar@^4, tar@^4.4.8:
   version "4.4.8"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
   integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
@@ -6773,9 +6873,9 @@ trim-right@^1.0.1:
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
 ts-jest@^24.0.0:
-  version "24.0.1"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.0.1.tgz#77258061cc354c3fa8616b8ac03baa0f8580f854"
-  integrity sha512-mgNZmYPuGBNgYpUzchI7vdSr6zATQI0TrSyzREnXHuPCvlW8T1DQ/fdscgx4ivS5vAMUGUaoxGdWIVHC5I8imw==
+  version "24.0.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.0.2.tgz#8dde6cece97c31c03e80e474c749753ffd27194d"
+  integrity sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==
   dependencies:
     bs-logger "0.x"
     buffer-from "1.x"
@@ -6809,9 +6909,9 @@ tslint-config-prettier@^1.18.0:
   integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
 
 tslint@^5.14.0:
-  version "5.14.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.14.0.tgz#be62637135ac244fc9b37ed6ea5252c9eba1616e"
-  integrity sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.15.0.tgz#6ffb180986d63afa1e531feb2a134dbf961e27d3"
+  integrity sha512-6bIEujKR21/3nyeoX2uBnE8s+tMXCQXhqMmaIPJpHmXJoBJPTLcI7/VHRtUwMhnLVdwLqqY3zmd8Dxqa5CVdJA==
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"
@@ -6819,7 +6919,7 @@ tslint@^5.14.0:
     commander "^2.12.1"
     diff "^3.2.0"
     glob "^7.1.1"
-    js-yaml "^3.7.0"
+    js-yaml "^3.13.0"
     minimatch "^3.0.4"
     mkdirp "^0.5.1"
     resolve "^1.3.2"
@@ -6906,9 +7006,9 @@ typescript@3.2.x:
   integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
 typescript@^3.3.3333:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.1.tgz#b6691be11a881ffa9a05765a205cb7383f3b63c6"
-  integrity sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.2.tgz#9ed4e6475d906f589200193be056f5913caed481"
+  integrity sha512-Og2Vn6Mk7JAuWA1hQdDQN/Ekm/SchX80VzLhjKN9ETYrIepBFAd8PkOdOTK2nKt0FCkmMZKBJvQ1dV1gIxPu/A==
 
 uglify-js@^3.1.4:
   version "3.5.3"
@@ -7043,7 +7143,7 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
-walker@~1.0.5:
+walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=


### PR DESCRIPTION
Fixes #1247 

Due to a new check for type nesting in TS3.4 (capped at 50 iterations) that only applies to .d.ts files (AFAIK), generated type definitions were giving this error with relatively small models.
This PR reduces the type nesting (from around 51 from the provided test case to around 12) by refactoring a bit the type system.

The only con is that the smarter "create" function, which was able to magically infer if create can or cannot take a snapshot has to be gone for this change to work. (Though anyway that feature seems to give some users some problems, see #1208 )

The good thing is that since the type nesting is greatly reduced IDE auto-completion should be even faster now.

I also checked type definition generation, now they are slightly smaller.