### PR TITLE
Fix browser event click that calls mobx action

### DIFF
--- a/packages/mst-middlewares/src/redux.ts
+++ b/packages/mst-middlewares/src/redux.ts
@@ -80,7 +80,13 @@ function getActionContextNameAndTypePath(actionContext: ActionContext, logArgsNe
     let targetTypePath = actionContext.targetTypePath
 
     if (logArgsNearName) {
-        let args = actionContext.callArgs.map(a => JSON.stringify(a)).join(", ")
+        let args = actionContext.callArgs.map(a => {
+            try {
+                return JSON.stringify(a);
+            } catch (e) {
+                // Seems it may be a browser event?
+            }
+        }).join(", ")
 
         if (args.length > 64) {
             args = args.slice(0, 64) + "..."


### PR DESCRIPTION
```
Uncaught TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'FiberNode'
    |     property 'stateNode' -> object with constructor 'HTMLSpanElement'
    --- property '__reactInternalInstance$qcz9vcggugc' closes the circle
    at JSON.stringify (<anonymous>)
    at eval (mst-middlewares.module.js:182)
    at Array.map (<anonymous>)
    at getActionContextNameAndTypePath (mst-middlewares.module.js:182)
    at logStep (mst-middlewares.module.js:355)
    at actionMiddleware (mst-middlewares.module.js:387)
    at runNextMiddleware (mobx-state-tree.module.js:2669)
    at runMiddleWares (mobx-state-tree.module.js:2682)
    at runWithActionContext (mobx-state-tree.module.js:2501)
    at res (mobx-state-tree.module.js:2528)
```

Happens when you do this
```
<Button
	size={"large"}
	onClick={toggleAddEditConversation}
	className={"start-conversation-btn"}
>
	Start Conversation
</Button>
```
Instead of
```
<Button
	size={"large"}
	onClick={() => {
		toggleAddEditConversation();
	}}
	className={"start-conversation-btn"}
>
	Start Conversation
</Button>
```
Which is silly