### PR TITLE
(docs): update link to Redux example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Simply subscribing to the patch stream of a tree is another way to sync diffs wi
 
 Since MST uses MobX behind the scenes, it integrates seamlessly with [mobx](https://mobx.js.org) and [mobx-react](https://github.com/mobxjs/mobx-react). See also this [egghead.io lesson: Render mobx-state-tree Models in React](https://egghead.io/lessons/react-render-mobx-state-tree-models-in-react).
 Even cooler, because it supports snapshots, middleware and replayable actions out of the box, it is possible to replace a Redux store and reducer with a MobX state tree.
-This makes it possible to connect the Redux devtools to MST. See the [Redux / MST TodoMVC example](https://github.com/mobxjs/mobx-state-tree/blob/4c2b19ec4a6a8d74064e4b8a87c0f8b46e97e621/examples/redux-todomvc/src/index.js#L6).
+This makes it possible to connect the Redux devtools to MST. See the [Redux / MST TodoMVC example](https://github.com/mobxjs/mobx-state-tree/blob/1906a394906d2e8f2cc1c778e1e3228307c1b112/packages/mst-example-redux-todomvc/src/index.js#L6).
 
 ---
 


### PR DESCRIPTION
- old link is to old commit that does not use `mst-middlewares` package

So there's a bit of a conundrum in the docs/README. Some of the links are to specific commits -- which mean they're permalinks and generally won't 404 (regex: `/blob/(?!master)`) -- and others are just to `master` (`/blob/master`) -- which means they might 404 or point to the wrong line in the future.

I think pointing to an old commit is better than 404'ing or referencing the wrong line (it's hard to even tell what the link was meant to be for in that case), so I've updated this specific example to the current commit.

Ideally, there should probably be an automated check when code changes that verifies whether or not any links in the docs need to be updated (or an automatic update by CI). I'm not sure if there already exists a library to do this out-of-the-box.