### PR TITLE
Updated typescript to 3.5.3, to verify #1307

### DIFF
--- a/README.md
+++ b/README.md
@@ -1384,9 +1384,24 @@ Yes, with MST it is pretty straight forward to setup hot reloading for your stor
 ### TypeScript and MST
 
 TypeScript support is best-effort as not all patterns can be expressed in TypeScript. Except for assigning snapshots to properties we get pretty close! As MST uses the latest fancy TypeScript features it is required to use TypeScript 3.0 or later with `noImplicitThis` and `strictNullChecks` enabled.
-Actually, the more strict options that are enabled, the better the type system will behave.
+Actually, the more strict options that are enabled, the better the type system will behave. 
 
-We recommend using TypeScript together with MST, but since the type system of MST is more dynamic than the TypeScript system, there are cases that cannot be expressed neatly and occasionally you will need to fallback to `any` or manually adding type annotations.
+#### Recommend compiler flags
+
+The recommended compiler flags (against which all our tests are written) are:
+
+```json
+{
+    "strict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true
+}
+```
+
 
 Flow is not supported.
 

--- a/README.md
+++ b/README.md
@@ -1392,16 +1392,22 @@ The recommended compiler flags (against which all our tests are written) are:
 
 ```json
 {
-    "strict": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,
-    "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noImplicitThis": true
 }
 ```
 
+Or shorter by leveraging `strict`:
+
+```json
+{
+  "strict": true,
+  "noImplicitReturns": true
+}
+```
 
 Flow is not supported.
 

--- a/README.md
+++ b/README.md
@@ -1439,7 +1439,8 @@ type ITodoSnapshotOut = SnapshotOut<typeof Todo> // => { title: string }
 ```
 
 Due to the way typeof operator works, when working with big and deep models trees, it might make your IDE/ts server takes a lot of CPU time and freeze vscode (or others).
-A partial solution for this is to turn the types into interfaces.
+A solution for this is to turn the types into interfaces. 
+This way of defining types enables TypeScript to better cope with circular type definitions as well.
 
 ```ts
 interface ITodo extends Instance<typeof Todo> {}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "size-limit": "^1.3.2",
         "tslint": "^5.14.0",
         "tslint-config-prettier": "^1.18.0",
-        "typescript": "^3.3.3333"
+        "typescript": "^3.5.3"
     },
     "husky": {
         "hooks": {

--- a/packages/mobx-state-tree/__tests__/core/type-system.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/type-system.test.ts
@@ -12,7 +12,9 @@ import {
     IType,
     isStateTreeNode,
     isFrozenType,
-    TypeOfValue
+    TypeOfValue,
+    IAnyType,
+    ModelPrimitive
 } from "../../src"
 
 const createTestFactories = () => {
@@ -1023,4 +1025,23 @@ test("#1307 optional can be omitted in .create", () => {
 
     const Model2 = types.model({ name: "" })
     const model2 = Model2.create({})
+})
+
+test("#1307 custom types failing", () => {
+    const createCustomType = <ICustomType extends ModelPrimitive | IAnyType>({
+        CustomType
+    }: {
+        CustomType: ICustomType
+    }) => {
+        return types
+            .model("Example", {
+                someProp: types.boolean
+                // someType: CustomType
+            })
+            .views(self => ({
+                get isSomePropTrue(): boolean {
+                    return self.someProp
+                }
+            }))
+    }
 })

--- a/packages/mobx-state-tree/__tests__/core/type-system.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/type-system.test.ts
@@ -1016,3 +1016,11 @@ test("can extract type from complex objects", () => {
     type OriginalType = TypeOfValue<typeof t>
     const T2: OriginalType = T
 })
+
+test("#1307 optional can be omitted in .create", () => {
+    const Model1 = types.model({ name: types.optional(types.string, "") })
+    const model1 = Model1.create({})
+
+    const Model2 = types.model({ name: "" })
+    const model2 = Model2.create({})
+})

--- a/packages/mobx-state-tree/package.json
+++ b/packages/mobx-state-tree/package.json
@@ -65,7 +65,7 @@
         "tslint": "^5.14.0",
         "typedoc": "^0.14.2",
         "typedoc-plugin-markdown": "^1.1.27",
-        "typescript": "^3.3.3333"
+        "typescript": "^3.5.3"
     },
     "peerDependencies": {
         "mobx": ">=4.8.0 <5.0.0 || >=5.8.0 <6.0.0"

--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -12,6 +12,7 @@ export {
     IArrayType,
     IType,
     IAnyType,
+    ModelPrimitive,
     ISimpleType,
     IComplexType,
     IAnyComplexType,

--- a/packages/mst-middlewares/package.json
+++ b/packages/mst-middlewares/package.json
@@ -41,7 +41,7 @@
         "rollup-plugin-terser": "^5.0.0",
         "ts-jest": "^24.0.0",
         "tslib": "^1.9.3",
-        "typescript": "^3.3.3333"
+        "typescript": "^3.5.3"
     },
     "peerDependencies": {
         "mobx-state-tree": "^3.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9488,10 +9488,10 @@ typescript@3.2.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
   integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
-typescript@^3.3.3333:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
-  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
+typescript@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
Also added docs on recommended compiler flags. 

Also removed the "we recommend TS", I feel people run too often into it's limitation. Personally would still recommend it, but the price is higher than it should be :cry: (most notably on forward references to actions and such, and circular type definitions)