### PR TITLE
devMode() check works if process is undefined

### DIFF
--- a/packages/mobx-state-tree/src/utils.ts
+++ b/packages/mobx-state-tree/src/utils.ts
@@ -407,7 +407,7 @@ export function isTypeCheckingEnabled() {
  * @hidden
  */
 export function devMode() {
-    return process.env.NODE_ENV !== "production"
+    return (typeof process === "undefined" || (process && process.env && process.NODE_ENV !== "production"));
 }
 
 /**


### PR DESCRIPTION
I noticed this problem when trying to add the UMD build to an app which doesn't have process defined.