### PR TITLE
Make umd debug build work without 'process' global

### DIFF
--- a/packages/mobx-state-tree/src/utils.ts
+++ b/packages/mobx-state-tree/src/utils.ts
@@ -407,7 +407,7 @@ export function isTypeCheckingEnabled() {
  * @hidden
  */
 export function devMode() {
-    return process.env.NODE_ENV !== "production"
+    return (typeof process === "undefined" || (process && process.env && process.env.NODE_ENV !== "production"));
 }
 
 /**

--- a/packages/mobx-state-tree/src/utils.ts
+++ b/packages/mobx-state-tree/src/utils.ts
@@ -407,7 +407,7 @@ export function isTypeCheckingEnabled() {
  * @hidden
  */
 export function devMode() {
-    return (typeof process === "undefined" || (process && process.env && process.env.NODE_ENV !== "production"));
+    return process.env.NODE_ENV !== "production"
 }
 
 /**

--- a/rollup.base-config.js
+++ b/rollup.base-config.js
@@ -4,7 +4,11 @@ import resolve from "rollup-plugin-node-resolve"
 import { terser } from "rollup-plugin-terser"
 import replace from "rollup-plugin-replace"
 
-const devPlugins = () => [resolve(), filesize()]
+const devPlugins = () => [
+    resolve(),
+    replace({ "process.env.NODE_ENV": JSON.stringify("development") }),
+    filesize()
+]
 
 const prodPlugins = () => [
     resolve(),

--- a/rollup.base-config.js
+++ b/rollup.base-config.js
@@ -4,7 +4,10 @@ import resolve from "rollup-plugin-node-resolve"
 import { terser } from "rollup-plugin-terser"
 import replace from "rollup-plugin-replace"
 
-const devPlugins = () => [
+const devPlugins = () => [resolve(), filesize()]
+
+// For umd builds, set process.env.NODE_ENV to "development" since 'process' is not available in the browser
+const devPluginsUmd = () => [
     resolve(),
     replace({ "process.env.NODE_ENV": JSON.stringify("development") }),
     filesize()
@@ -26,5 +29,6 @@ export const baseConfig = ({ input, globals, umdName, external, outFile, format,
         name: format === "umd" ? umdName : undefined
     },
     external,
-    plugins: mode === "production" ? prodPlugins() : devPlugins()
+    plugins:
+        mode === "production" ? prodPlugins() : format === "umd" ? devPluginsUmd() : devPlugins()
 })


### PR DESCRIPTION
I noticed this when adding the umd debug (not-minified) version to an app that doesn't have the process global variable. Because of it, mobx-state-tree doesn't instantiate.