### PR TITLE
Use gitbook 'Getting Started' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Supported devtools:
 
 # Getting started
 
-See the [Getting started](https://github.com/mobxjs/mobx-state-tree/blob/master/docs/getting-started.md#getting-started) tutorial or follow the free [egghead.io course](https://egghead.io/courses/manage-application-state-with-mobx-state-tree) (note however that the course is for MST v2, so it might be a bit outdated).
+See the [Getting Started](https://mobx-state-tree.gitbook.io/docs/getting-started) tutorial or follow the free [egghead.io course](https://egghead.io/courses/manage-application-state-with-mobx-state-tree) (note however that the course is for MST v2, so it might be a bit outdated).
 
 # Talks & blogs
 


### PR DESCRIPTION
I was really confused by the unrendered docs until I realized it was a gitbook. There is no reference to the gitbook in the README otherwise.

Not sure if the gitbook is an officially-maintained url but I certainly find it more accessible than browsing the markdown files in the repo.