### PR TITLE
[Typescript] Improving flow typings #1378

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/async.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/async.test.ts
@@ -329,7 +329,7 @@ test("flow typings", async () => {
         numberToNumber: flow(function*(val: number) {
             yield promise
             return val
-        }), // should be () => Promise<Promise<number>>
+        }), // should be () => Promise<number>
         voidToNumber: flow(function*() {
             yield promise
             return Promise.resolve(2)
@@ -345,4 +345,8 @@ test("flow typings", async () => {
     expect(b).toBe(4)
     const c: number = await m.voidToNumber()
     expect(c).toBe(2)
+    await m.voidToNumber().then(d => {
+        const _d: number = d
+        expect(_d).toBe(2)
+    })
 })

--- a/packages/mobx-state-tree/src/core/flow.ts
+++ b/packages/mobx-state-tree/src/core/flow.ts
@@ -1,11 +1,16 @@
 /**
+ * @hidden
+ */
+export type FlowReturn<R> = R extends Promise<infer T> ? T : R
+
+/**
  * See [asynchronous actions](https://github.com/mobxjs/mobx-state-tree/blob/master/docs/async-actions.md).
  *
  * @returns The flow as a promise.
  */
 export function flow<R, Args extends any[]>(
-    generator: (...args: Args) => Generator<any, R, any>
-): (...args: Args) => Promise<R> {
+    generator: (...args: Args) => Generator<Promise<any>, R, any>
+): (...args: Args) => Promise<FlowReturn<R>> {
     return createFlowSpawner(generator.name, generator) as any
 }
 


### PR DESCRIPTION
This is an attempt to fix #1378

This is a breaking change to flow typings that requires TS version 3.6+
I am still not sold on the final solution, but I see two major alternatives:

- the one described in [this comment](https://github.com/mobxjs/mobx-state-tree/issues/1378#issuecomment-532639990) and implemented in this PR
- typing flow as `Generator<Promise<any>, R, unknown>`, so that we get inferred return type, type-check on yielded promises and that we're required to type yield results, which is somewhat similar to what we had before

Both of this are not perfect and still breaking, because TS changed `Generator` interface.
It seems that there's a possibility to escape the breaking change by utilising `typesVersions`  as mentioned [here](https://github.com/mobxjs/mobx-state-tree/issues/1378#issuecomment-527531474), however I am not quite sure I understand how to do that

It is also worth mentioning that with arriving of [`actionAsync`](https://github.com/mobxjs/mobx-utils#actionasync) this problem might not  be that important, and we might just use the second alternative to fix TS errors and not rely on lots of TS magic