### PR TITLE
(docs): fix unmatched italic in identifiers docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ console.log(storeInstance.selectedTodo.title)
 -   The `map.put()` method can be used to simplify adding objects that have identifiers to [maps](docs/API/README.md#typesmap)
 -   The primary goal of identifiers is not validation, but reconciliation and reference resolving. For this reason identifiers cannot be defined or updated after creation. If you want to check if some value just looks as an identifier, without providing the above semantics; use something like: `types.refinement(types.string, v => v.match(/someregex/))`
 
-_Tip: If you know the format of the identifiers in your application, leverage `types.refinement` to actively check this, for example the following definition enforces that identifiers of `Car` always start with the string `"Car_"`:
+_Tip: If you know the format of the identifiers in your application, leverage `types.refinement` to actively check this, for example the following definition enforces that identifiers of `Car` always start with the string `"Car_"`:_
 
 ```javascript
 const Car = types.model("Car", {


### PR DESCRIPTION
- didn't get italicized before this and instead had a visible
  underscore at the beginning