### PR TITLE
Fix extraneous actions from ComplexType.getValue (and elsewhere)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 3.15.1
+
+- Fixed that calling "createObservableInstanceIfNeeded" would execute an action, even if the function immediately returned. (significant since the extraneous actions would pollute the mobx dev-tools on mere accesses, eg. by ComplexType.prototype.getValue) Fixes [#1421](https://github.com/mobxjs/mobx-state-tree/issues/1421)
+
 # 3.15.0
 
 - Fix for flow typings. This means that now using flows requires at least TypeScript v3.6 and that `castFlowReturn` becomes deprecated.

--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -172,11 +172,14 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
         }
     }
 
-    @action
     createObservableInstanceIfNeeded(): void {
-        if (this._observableInstanceState !== ObservableInstanceLifecycle.UNINITIALIZED) {
-            return
+        if (this._observableInstanceState === ObservableInstanceLifecycle.UNINITIALIZED) {
+            this.createObservableInstance()
         }
+    }
+
+    @action
+    createObservableInstance(): void {
         if (devMode()) {
             if (this.state !== NodeLifeCycle.INITIALIZING) {
                 // istanbul ignore next


### PR DESCRIPTION
* Fixed that calling "createObservableInstanceIfNeeded" would execute an action, even if the function immediately returned. (significant since the extraneous actions would pollute the mobx dev-tools on mere accesses, eg. by ComplexType.prototype.getValue)

Resolves #1421.