### PR TITLE
[On hold] Add option to resolve non unique identifiers

### DIFF
--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -517,17 +517,22 @@ export function resolvePath(target: IAnyStateTreeNode, path: string): any {
 
 /**
  * Resolves a model instance given a root target, the type and the identifier you are searching for.
+ * By default it throws error if there is more then one instance found (i.e. instance is not unique).
+ * This can be overriden by last optional parameter set to false, in which case it will return the
+ * first instance found.
  * Returns undefined if no value can be found.
  *
  * @param type
  * @param target
  * @param identifier
+ * @param unique
  * @returns
  */
 export function resolveIdentifier<IT extends IAnyModelType>(
     type: IT,
     target: IAnyStateTreeNode,
-    identifier: ReferenceIdentifier
+    identifier: ReferenceIdentifier,
+    unique = true
 ): IT["Type"] | undefined {
     // check all arguments
     assertIsType(type, 1)
@@ -536,7 +541,8 @@ export function resolveIdentifier<IT extends IAnyModelType>(
 
     const node = getStateTreeNode(target).root.identifierCache!.resolve(
         type,
-        normalizeIdentifier(identifier)
+        normalizeIdentifier(identifier),
+        unique
     )
     return node ? node.value : undefined
 }

--- a/packages/mobx-state-tree/src/core/node/identifier-cache.ts
+++ b/packages/mobx-state-tree/src/core/node/identifier-cache.ts
@@ -95,7 +95,8 @@ export class IdentifierCache {
 
     resolve<IT extends IAnyComplexType>(
         type: IT,
-        identifier: string
+        identifier: string,
+        unique = true
     ): ObjectNode<IT["CreationType"], IT["SnapshotType"], IT["TypeWithoutSTN"]> | null {
         const set = this.cache.get(identifier)
         if (!set) return null
@@ -106,13 +107,17 @@ export class IdentifierCache {
             case 1:
                 return matches[0]
             default:
-                throw fail(
-                    `Cannot resolve a reference to type '${
-                        type.name
-                    }' with id: '${identifier}' unambigously, there are multiple candidates: ${matches
-                        .map(n => n.path)
-                        .join(", ")}`
-                )
+                if (unique) {
+                    throw fail(
+                        `Cannot resolve a reference to type '${
+                            type.name
+                        }' with id: '${identifier}' unambigously, there are multiple candidates: ${matches
+                            .map(n => n.path)
+                            .join(", ")}`
+                    )
+                } else {
+                    return matches[0]
+                }
         }
     }
 }


### PR DESCRIPTION
This is PR partially related to #1156 

The main goal is to provide `resolveIdentifier` version that doesn't throw if there are multiple instances of the same id in the tree, but rather returns first one (i.e. first one in the cache - might not be the first one in the tree structure).