### PR TITLE
Change castToReference to castToReferenceSnapshot

### DIFF
--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -966,7 +966,7 @@ export function castToSnapshot<I>(
  *
  * const a = ModelA.create({ id: 'someId', n: 5 });
  * // this will allow the compiler to use a model as if it were a reference snapshot
- * const b = ModelB.create({ refA: castToReference(a)})
+ * const b = ModelB.create({ refA: castToReferenceSnapshot(a)})
  * ```
  *
  * @param instance Instance


### PR DESCRIPTION
Change `castToReference` to `castToReferenceSnapshot` for docs.