### PR TITLE
Add fail message when applyPatch replace root of store

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/action.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/action.test.ts
@@ -84,6 +84,18 @@ test("applying snapshots should be recordable and replayable", () => {
     recorder.replay(t2)
     expect(t2.done).toBe(true)
 })
+test("applying patches should not replacing when node is root", () => {
+    const t1 = Task.create()
+    expect(() => {
+        applyPatch(t1, [
+            {
+                op: "replace",
+                path: "",
+                value: true
+            }
+        ])
+    }).toThrow("node is root, path is empty")
+})
 // Complex actions
 const Customer = types.model("Customer", {
     id: types.identifierNumber,

--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -502,6 +502,9 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
             "@APPLY_PATCHES",
             (patches: IJsonPatch[]) => {
                 patches.forEach(patch => {
+                    if (!patch.path) {
+                        throw fail(`node is root, path is empty`)
+                    }
                     const parts = splitJsonPath(patch.path)
                     const node = resolveNodeByPathParts(self, parts.slice(0, -1)) as AnyObjectNode
                     node.applyPatchLocally(parts[parts.length - 1], patch)


### PR DESCRIPTION
It seems to fix [#1411](https://github.com/mobxjs/mobx-state-tree/issues/1411)