### PR TITLE
Add clear error when volatile state is not a function

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/volatile.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/volatile.test.ts
@@ -81,9 +81,9 @@ test("VS should not be modifiable without action", () => {
 
 test("VS should expect a function as an argument", () => {
     expect(() => {
-        // @ts-ignore
         const t = types
             .model({})
+            // @ts-ignore
             .volatile({ state: 1 })
             .create()
     }).toThrowError(

--- a/packages/mobx-state-tree/__tests__/core/volatile.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/volatile.test.ts
@@ -79,6 +79,18 @@ test("VS should not be modifiable without action", () => {
     }).toThrowError(/the object is protected and can only be modified by using an action/)
 })
 
+test("VS should expect a function as an argument", () => {
+    expect(() => {
+        // @ts-ignore
+        const t = types
+            .model({})
+            .volatile({ state: 1 })
+            .create()
+    }).toThrowError(
+        `You passed an object to volatile state as an argument, when function is expected`
+    )
+})
+
 test("VS should not be modifiable when unprotected", () => {
     const i = Todo.create()
     unprotect(i)

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -777,7 +777,7 @@ export function compose<PA extends ModelProperties, OA, FCA, FSA, PB extends Mod
 // prettier-ignore
 export function compose<PA extends ModelProperties, OA, FCA, FSA, PB extends ModelProperties, OB, FCB, FSB, PC extends ModelProperties, OC, FCC, FSC, PD extends ModelProperties, OD, FCD, FSD, PE extends ModelProperties, OE, FCE, FSE>(A:
     IModelType<PA, OA, FCA, FSA>, B: IModelType<PB, OB, FCB, FSB>, C: IModelType<PC, OC, FCC, FSC>, D: IModelType<PD, OD, FCD, FSD>, E: IModelType<PE, OE, FCE, FSE>): IModelType<PA & PB & PC & PD & PE, OA & OB & OC & OD & OE, _CustomJoin<FCA,
-        _CustomJoin<FCB, _CustomJoin<FCC, _CustomJoin<FCD, FCE>>>>, _CustomJoin<FSA, _CustomJoin<FSB, _CustomJoin<FSC, _CustomJoin<FSD, FSE>>>>>
+    _CustomJoin<FCB, _CustomJoin<FCC, _CustomJoin<FCD, FCE>>>>, _CustomJoin<FSA, _CustomJoin<FSB, _CustomJoin<FSC, _CustomJoin<FSD, FSE>>>>>
 // prettier-ignore
 export function compose<PA extends ModelProperties, OA, FCA, FSA, PB extends ModelProperties, OB, FCB, FSB, PC extends ModelProperties, OC, FCC, FSC, PD extends ModelProperties, OD, FCD, FSD, PE extends ModelProperties, OE, FCE, FSE, PF
     extends ModelProperties, OF, FCF, FSF>(name: string, A: IModelType<PA, OA, FCA, FSA>, B: IModelType<PB, OB, FCB, FSB>, C: IModelType<PC, OC, FCC, FSC>, D: IModelType<PD, OD, FCD, FSD>, E: IModelType<PE, OE, FCE, FSE>, F: IModelType<PF, OF, FCF, FSF>): IModelType<PA & PB & PC & PD & PE & PF, OA & OB & OC & OD & OE & OF, _CustomJoin<FCA, _CustomJoin<FCB, _CustomJoin<FCC, _CustomJoin<FCD, _CustomJoin<FCE, FCF>>>>>, _CustomJoin<FSA, _CustomJoin<FSB, _CustomJoin<FSC, _CustomJoin<FSD, _CustomJoin<FSE, FSF>>>>>>

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -437,6 +437,11 @@ export class ModelType<
     }
 
     volatile<TP extends object>(fn: (self: Instance<this>) => TP) {
+        if (typeof fn !== "function") {
+            throw fail(
+                `You passed an ${typeof fn} to volatile state as an argument, when function is expected`
+            )
+        }
         const stateInitializer = (self: Instance<this>) => {
             this.instantiateVolatileState(self, fn(self))
             return self
@@ -772,7 +777,7 @@ export function compose<PA extends ModelProperties, OA, FCA, FSA, PB extends Mod
 // prettier-ignore
 export function compose<PA extends ModelProperties, OA, FCA, FSA, PB extends ModelProperties, OB, FCB, FSB, PC extends ModelProperties, OC, FCC, FSC, PD extends ModelProperties, OD, FCD, FSD, PE extends ModelProperties, OE, FCE, FSE>(A:
     IModelType<PA, OA, FCA, FSA>, B: IModelType<PB, OB, FCB, FSB>, C: IModelType<PC, OC, FCC, FSC>, D: IModelType<PD, OD, FCD, FSD>, E: IModelType<PE, OE, FCE, FSE>): IModelType<PA & PB & PC & PD & PE, OA & OB & OC & OD & OE, _CustomJoin<FCA,
-    _CustomJoin<FCB, _CustomJoin<FCC, _CustomJoin<FCD, FCE>>>>, _CustomJoin<FSA, _CustomJoin<FSB, _CustomJoin<FSC, _CustomJoin<FSD, FSE>>>>>
+        _CustomJoin<FCB, _CustomJoin<FCC, _CustomJoin<FCD, FCE>>>>, _CustomJoin<FSA, _CustomJoin<FSB, _CustomJoin<FSC, _CustomJoin<FSD, FSE>>>>>
 // prettier-ignore
 export function compose<PA extends ModelProperties, OA, FCA, FSA, PB extends ModelProperties, OB, FCB, FSB, PC extends ModelProperties, OC, FCC, FSC, PD extends ModelProperties, OD, FCD, FSD, PE extends ModelProperties, OE, FCE, FSE, PF
     extends ModelProperties, OF, FCF, FSF>(name: string, A: IModelType<PA, OA, FCA, FSA>, B: IModelType<PB, OB, FCB, FSB>, C: IModelType<PC, OC, FCC, FSC>, D: IModelType<PD, OD, FCD, FSD>, E: IModelType<PE, OE, FCE, FSE>, F: IModelType<PF, OF, FCF, FSF>): IModelType<PA & PB & PC & PD & PE & PF, OA & OB & OC & OD & OE & OF, _CustomJoin<FCA, _CustomJoin<FCB, _CustomJoin<FCC, _CustomJoin<FCD, _CustomJoin<FCE, FCF>>>>>, _CustomJoin<FSA, _CustomJoin<FSB, _CustomJoin<FSC, _CustomJoin<FSD, _CustomJoin<FSE, FSF>>>>>>


### PR DESCRIPTION
It seems to fix [#1482](https://github.com/mobxjs/mobx-state-tree/issues/1482)