### PR TITLE
Add onValidated support to safeReference

### DIFF
--- a/packages/mobx-state-tree/src/types/utility-types/reference.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/reference.ts
@@ -102,9 +102,7 @@ class StoredReference<IT extends IAnyType> {
 
             if (!target) {
                 throw new InvalidReferenceError(
-                    `[mobx-state-tree] Failed to resolve reference '${this.identifier}' to type '${
-                        this.targetType.name
-                    }' (from node: ${node.path})`
+                    `[mobx-state-tree] Failed to resolve reference '${this.identifier}' to type '${this.targetType.name}' (from node: ${node.path})`
                 )
             }
 
@@ -567,11 +565,15 @@ export function safeReference<IT extends IAnyComplexType>(
     subType: IT,
     options?: (ReferenceOptionsGetSet<IT> | {}) & {
         acceptsUndefined?: boolean
+        onInvalidated?: OnReferenceInvalidated<ReferenceT<IT>>
     }
 ): IReferenceType<IT> | IMaybe<IReferenceType<IT>> {
     const refType = reference(subType, {
         ...options,
         onInvalidated(ev) {
+            if (options && options.onInvalidated) {
+                options.onInvalidated(ev)
+            }
             ev.removeRef()
         }
     })


### PR DESCRIPTION
So you can do, just like you would do with a normal reference:

```ts
types.safeReference(Entity, {
    onInvalidated(ev: any) {
        console.log('fancy', ev);
    }
})
```