### PR TITLE
Add toGenerator utility function

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/api.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/api.test.ts
@@ -78,7 +78,8 @@ const METHODS_AND_INTERNAL_TYPES = stringToArray(`
     getNodeId,
     getRunningActionContext,
     isActionContextChildOf,
-    isActionContextThisOrChildOf
+    isActionContextThisOrChildOf,
+    toGenerator
 `)
 
 const DEPRECATED_METHODS_AND_INTERNAL_TYPES = stringToArray(`

--- a/packages/mobx-state-tree/__tests__/core/api.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/api.test.ts
@@ -79,7 +79,8 @@ const METHODS_AND_INTERNAL_TYPES = stringToArray(`
     getRunningActionContext,
     isActionContextChildOf,
     isActionContextThisOrChildOf,
-    toGeneratorFunction
+    toGeneratorFunction,
+    toGenerator
 `)
 
 const DEPRECATED_METHODS_AND_INTERNAL_TYPES = stringToArray(`

--- a/packages/mobx-state-tree/__tests__/core/api.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/api.test.ts
@@ -79,7 +79,7 @@ const METHODS_AND_INTERNAL_TYPES = stringToArray(`
     getRunningActionContext,
     isActionContextChildOf,
     isActionContextThisOrChildOf,
-    toGenerator
+    toGeneratorFunction
 `)
 
 const DEPRECATED_METHODS_AND_INTERNAL_TYPES = stringToArray(`

--- a/packages/mobx-state-tree/__tests__/core/async.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/async.test.ts
@@ -363,8 +363,11 @@ test("flow typings", async () => {
  * https://stackoverflow.com/a/55541672/4289902
  */
 type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
-function ensureNotAny<T>(value: IfAny<T, never, T>) {}
-function ensureType<T>(value: T) {}
+
+/**
+ * Ensure that the type of the passed value is of the expected type, and is NOT the TypeScript `any` type
+ */
+function ensureNotAnyType<TExpected, TActual>(value: IfAny<TActual, never, TExpected>) {}
 
 test("yield* typings for toGeneratorFunction", async () => {
     const voidPromise = () => Promise.resolve()
@@ -379,16 +382,13 @@ test("yield* typings for toGeneratorFunction", async () => {
     const M = types.model({ x: 5 }).actions((self) => {
         function* testAction() {
             const voidResult = yield* voidGen()
-            ensureNotAny(voidResult)
-            ensureType<void>(voidResult)
+            ensureNotAnyType<void, typeof voidResult>(voidResult)
 
             const numberResult = yield* numberGen()
-            ensureNotAny(numberResult)
-            ensureType<number>(numberResult)
+            ensureNotAnyType<number, typeof numberResult>(numberResult)
 
             const stringResult = yield* stringWithArgsGen("input", true)
-            ensureNotAny(stringResult)
-            ensureType<string>(stringResult)
+            ensureNotAnyType<string, typeof stringResult>(stringResult)
 
             return stringResult
         }
@@ -401,8 +401,7 @@ test("yield* typings for toGeneratorFunction", async () => {
     const m = M.create()
 
     const result = await m.testAction()
-    ensureNotAny(result)
-    ensureType<string>(result)
+    ensureNotAnyType<string, typeof result>(result)
     expect(result).toBe("test-result")
 })
 
@@ -415,16 +414,13 @@ test("yield* typings for toGenerator", async () => {
     const M = types.model({ x: 5 }).actions((self) => {
         function* testAction() {
             const voidResult = yield* toGenerator(voidPromise())
-            ensureNotAny(voidResult)
-            ensureType<void>(voidResult)
+            ensureNotAnyType<void, typeof voidResult>(voidResult)
 
             const numberResult = yield* toGenerator(numberPromise())
-            ensureNotAny(numberResult)
-            ensureType<number>(numberResult)
+            ensureNotAnyType<number, typeof numberResult>(numberResult)
 
             const stringResult = yield* toGenerator(stringWithArgsPromise("input", true))
-            ensureNotAny(stringResult)
-            ensureType<string>(stringResult)
+            ensureNotAnyType<string, typeof stringResult>(stringResult)
 
             return stringResult
         }
@@ -437,7 +433,6 @@ test("yield* typings for toGenerator", async () => {
     const m = M.create()
 
     const result = await m.testAction()
-    ensureNotAny(result)
-    ensureType<string>(result)
+    ensureNotAnyType<string, typeof result>(result)
     expect(result).toBe("test-result")
 })

--- a/packages/mobx-state-tree/__tests__/core/async.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/async.test.ts
@@ -8,7 +8,8 @@ import {
     IMiddlewareHandler,
     IMiddlewareEvent,
     IMiddlewareEventType,
-    toGeneratorFunction
+    toGeneratorFunction,
+    toGenerator
     // TODO: export IRawActionCall
 } from "../../src"
 import { reaction, configure } from "mobx"
@@ -386,6 +387,42 @@ test("yield* typings for toGeneratorFunction", async () => {
             ensureType<number>(numberResult)
 
             const stringResult = yield* stringWithArgsGen("input", true)
+            ensureNotAny(stringResult)
+            ensureType<string>(stringResult)
+
+            return stringResult
+        }
+
+        return {
+            testAction: flow(testAction)
+        }
+    })
+
+    const m = M.create()
+
+    const result = await m.testAction()
+    ensureNotAny(result)
+    ensureType<string>(result)
+    expect(result).toBe("test-result")
+})
+
+test("yield* typings for toGenerator", async () => {
+    const voidPromise = () => Promise.resolve()
+    const numberPromise = () => Promise.resolve(7)
+    const stringWithArgsPromise = (input1: string, input2: boolean) =>
+        Promise.resolve("test-result")
+
+    const M = types.model({ x: 5 }).actions((self) => {
+        function* testAction() {
+            const voidResult = yield* toGenerator(voidPromise())
+            ensureNotAny(voidResult)
+            ensureType<void>(voidResult)
+
+            const numberResult = yield* toGenerator(numberPromise())
+            ensureNotAny(numberResult)
+            ensureType<number>(numberResult)
+
+            const stringResult = yield* toGenerator(stringWithArgsPromise("input", true))
             ensureNotAny(stringResult)
             ensureType<string>(stringResult)
 

--- a/packages/mobx-state-tree/__tests__/core/async.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/async.test.ts
@@ -366,7 +366,7 @@ type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
 function ensureNotAny<T>(value: IfAny<T, never, T>) {}
 function ensureType<T>(value: T) {}
 
-test("yield* typings", async () => {
+test("yield* typings for toGenerator", async () => {
     const voidPromise = () => Promise.resolve()
     const numberPromise = () => Promise.resolve(7)
     const stringWithArgsPromise = (input1: string, input2: boolean) =>

--- a/packages/mobx-state-tree/__tests__/core/async.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/async.test.ts
@@ -8,8 +8,7 @@ import {
     IMiddlewareHandler,
     IMiddlewareEvent,
     IMiddlewareEventType,
-    castFlowReturn,
-    toGenerator
+    toGeneratorFunction
     // TODO: export IRawActionCall
 } from "../../src"
 import { reaction, configure } from "mobx"
@@ -366,15 +365,15 @@ type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
 function ensureNotAny<T>(value: IfAny<T, never, T>) {}
 function ensureType<T>(value: T) {}
 
-test("yield* typings for toGenerator", async () => {
+test("yield* typings for toGeneratorFunction", async () => {
     const voidPromise = () => Promise.resolve()
     const numberPromise = () => Promise.resolve(7)
     const stringWithArgsPromise = (input1: string, input2: boolean) =>
         Promise.resolve("test-result")
 
-    const voidGen = toGenerator(voidPromise)
-    const numberGen = toGenerator(numberPromise)
-    const stringWithArgsGen = toGenerator(stringWithArgsPromise)
+    const voidGen = toGeneratorFunction(voidPromise)
+    const numberGen = toGeneratorFunction(numberPromise)
+    const stringWithArgsGen = toGeneratorFunction(stringWithArgsPromise)
 
     const M = types.model({ x: 5 }).actions((self) => {
         function* testAction() {

--- a/packages/mobx-state-tree/src/core/flow.ts
+++ b/packages/mobx-state-tree/src/core/flow.ts
@@ -63,6 +63,31 @@ export function toGeneratorFunction<R, Args extends any[]>(p: (...args: Args) =>
 }
 
 /**
+ * @experimental
+ * experimental api - might change on minor/patch releases
+ *
+ * Convert a promise to a generator yielding that promise
+ * This is intended to allow for usage of `yield*` in async actions to
+ * retain the promise return type.
+ *
+ * Example:
+ * ```ts
+ * function getDataAsync(input: string): Promise<number> { ... }
+ *
+ * const someModel.actions(self => ({
+ *   someAction: flow(function*() {
+ *     // value is typed as number
+ *     const value = yield* toGenerator(getDataAsync("input value"));
+ *     ...
+ *   })
+ * }))
+ * ```
+ */
+export function* toGenerator<R>(p: Promise<R>) {
+    return (yield p) as R
+}
+
+/**
  * @internal
  * @hidden
  */

--- a/packages/mobx-state-tree/src/core/flow.ts
+++ b/packages/mobx-state-tree/src/core/flow.ts
@@ -45,7 +45,7 @@ export function castFlowReturn<T>(val: T): T {
  * Example:
  * ```ts
  * function getDataAsync(input: string): Promise<number> { ... }
- * const getDataGen = toGenerator(getDataAsync);
+ * const getDataGen = toGeneratorFunction(getDataAsync);
  *
  * const someModel.actions(self => ({
  *   someAction: flow(function*() {
@@ -56,7 +56,7 @@ export function castFlowReturn<T>(val: T): T {
  * }))
  * ```
  */
-export function toGenerator<R, Args extends any[]>(p: (...args: Args) => Promise<R>) {
+export function toGeneratorFunction<R, Args extends any[]>(p: (...args: Args) => Promise<R>) {
     return function* (...args: Args) {
         return (yield p(...args)) as R
     }

--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -149,5 +149,6 @@ export {
     isActionContextChildOf,
     isActionContextThisOrChildOf,
     types,
-    toGeneratorFunction
+    toGeneratorFunction,
+    toGenerator
 } from "./internal"

--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -148,5 +148,6 @@ export {
     getRunningActionContext,
     isActionContextChildOf,
     isActionContextThisOrChildOf,
-    types
+    types,
+    toGenerator
 } from "./internal"

--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -149,5 +149,5 @@ export {
     isActionContextChildOf,
     isActionContextThisOrChildOf,
     types,
-    toGenerator
+    toGeneratorFunction
 } from "./internal"

--- a/packages/mobx-state-tree/src/utils.ts
+++ b/packages/mobx-state-tree/src/utils.ts
@@ -483,3 +483,30 @@ export function setImmediateWithFallback(fn: (...args: any[]) => void) {
         setTimeout(fn, 1)
     }
 }
+
+/**
+ * Convert a promise-returning function to a generator-returning one.
+ * This is intended to allow for usage of `yield*` in async actions to
+ * retain the promise return type.
+ *
+ * Example:
+ * ```ts
+ * function getDataAsync(input: string): Promise<number> { ... }
+ * const getDataGen = toGenerator(getDataAsync);
+ *
+ * const someModel.actions(self => ({
+ *   someAction: flow(function*() {
+ *     // value is typed as number
+ *     const value = yield* getDataGen("input value");
+ *     ...
+ *   })
+ * }))
+ * ```
+ */
+export function toGenerator<R, Args extends any[]>(
+    p: (...args: Args) => Promise<R>
+): (...args: Args) => Generator<Promise<R>, R, R> {
+    return function* (...args: Args) {
+        return (yield p(...args)) as R
+    }
+}

--- a/packages/mobx-state-tree/src/utils.ts
+++ b/packages/mobx-state-tree/src/utils.ts
@@ -483,30 +483,3 @@ export function setImmediateWithFallback(fn: (...args: any[]) => void) {
         setTimeout(fn, 1)
     }
 }
-
-/**
- * Convert a promise-returning function to a generator-returning one.
- * This is intended to allow for usage of `yield*` in async actions to
- * retain the promise return type.
- *
- * Example:
- * ```ts
- * function getDataAsync(input: string): Promise<number> { ... }
- * const getDataGen = toGenerator(getDataAsync);
- *
- * const someModel.actions(self => ({
- *   someAction: flow(function*() {
- *     // value is typed as number
- *     const value = yield* getDataGen("input value");
- *     ...
- *   })
- * }))
- * ```
- */
-export function toGenerator<R, Args extends any[]>(
-    p: (...args: Args) => Promise<R>
-): (...args: Args) => Generator<Promise<R>, R, R> {
-    return function* (...args: Args) {
-        return (yield p(...args)) as R
-    }
-}


### PR DESCRIPTION
The `toGenerator` function is intended for wrapping a promise-returning function to create a generator-returning function. This can then be used to obtain a strongly-typed return value in async actions using `yield*` (rather than `yield`).

This approach has been discussed in [this Spectrum thread](https://spectrum.chat/mobx-state-tree/general/typescript-typing-for-async-actions-yield~2bcd1b6c-2449-4c56-987f-4483fc57e32b).