### PR TITLE
fix IMSTMAP is not an ObservableMap

### DIFF
--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -64,7 +64,7 @@ export interface IMapType<IT extends IAnyType>
 }
 
 /** @hidden */
-export interface IMSTMap<IT extends IAnyType> {
+export interface IMSTMap<IT extends IAnyType> extends MSTMap<IT> {
     // bases on ObservableMap, but fine tuned to the auto snapshot conversion of MST
 
     clear(): void
@@ -151,7 +151,7 @@ export enum MapIdentifierMode {
     NO
 }
 
-class MSTMap<IT extends IAnyType> extends ObservableMap<string, any> {
+class MSTMap<IT extends IAnyType> extends ObservableMap<string, IT["Type"]> {
     constructor(initialData?: [string, any][] | IKeyValueMap<any> | Map<string, any> | undefined) {
         super(initialData, observable.ref.enhancer)
     }


### PR DESCRIPTION
fix https://github.com/mobxjs/mobx/issues/2422#issuecomment-674816446.

I use `conditional-type-checks` for test ts type. the code is as below.

```tsx
import { types } from "mobx-state-tree"
import { values } from "mobx"
import { Has, AssertTrue } from "conditional-type-checks"

const Todo = types.model("Todo", {
    id: types.identifierNumber,
    text: types.optional(types.string, "")
})

const TodoListStore = types.model("TodoList", {
    todos: types.optional(types.map(Todo), {})
})

const store = TodoListStore.create({
    todos: {
        "1001": {
            id: 1001,
            text: "Mow Lawn"
        },
        "1002": {
            id: 1002,
            text: "Pickup shopping"
        }
    }
})

const todoListValues = values(store.todos)
todoListValues.forEach((it) => {
    type doTest = AssertTrue<Has<typeof it, { id: number; text: string }>>
})

```