### PR TITLE
Snapshot processor is assignable from fix

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/snapshotProcessor.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/snapshotProcessor.test.ts
@@ -410,9 +410,6 @@ describe("snapshotProcessor", () => {
             detach(n)
             expect(s.a.length).toBe(0)
             expect(getSnapshot(n)).toEqual({ x: 1 })
-            if (process.env.NODE_ENV !== "production") {
-                expect(() => s.b.push(n)).toThrow("Error while converting")
-            }
         })
 
         test("moving from b to a", () => {
@@ -424,9 +421,6 @@ describe("snapshotProcessor", () => {
             detach(n)
             expect(s.b.length).toBe(0)
             expect(getSnapshot(n)).toEqual({ x: 1 })
-            if (process.env.NODE_ENV !== "production") {
-                expect(() => s.a.push(n)).toThrow("Error while converting")
-            }
         })
     })
 
@@ -454,9 +448,6 @@ describe("snapshotProcessor", () => {
             detach(n)
             expect(s.a.length).toBe(0)
             expect(getSnapshot(n)).toEqual({ x: "1" })
-            if (process.env.NODE_ENV !== "production") {
-                expect(() => s.b.push(n)).toThrow("Error while converting")
-            }
         })
 
         test("moving from b to a", () => {
@@ -468,9 +459,6 @@ describe("snapshotProcessor", () => {
             detach(n)
             expect(s.b.length).toBe(0)
             expect(getSnapshot(n)).toEqual({ x: 1 })
-            if (process.env.NODE_ENV !== "production") {
-                expect(() => s.a.push(n)).toThrow("Error while converting")
-            }
         })
     })
 

--- a/packages/mobx-state-tree/__tests__/core/snapshotProcessor.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/snapshotProcessor.test.ts
@@ -410,6 +410,10 @@ describe("snapshotProcessor", () => {
             detach(n)
             expect(s.a.length).toBe(0)
             expect(getSnapshot(n)).toEqual({ x: 1 })
+
+            s.b.push(n)
+            expect(s.b.length).toBe(1)
+            expect(getSnapshot(s.b)).toEqual([{ x: 1 }])
         })
 
         test("moving from b to a", () => {
@@ -421,6 +425,10 @@ describe("snapshotProcessor", () => {
             detach(n)
             expect(s.b.length).toBe(0)
             expect(getSnapshot(n)).toEqual({ x: 1 })
+
+            s.a.push(n)
+            expect(s.a.length).toBe(1)
+            expect(getSnapshot(s.a)).toEqual([{ x: 1 }])
         })
     })
 
@@ -448,6 +456,10 @@ describe("snapshotProcessor", () => {
             detach(n)
             expect(s.a.length).toBe(0)
             expect(getSnapshot(n)).toEqual({ x: "1" })
+
+            s.b.push(n)
+            expect(s.b.length).toBe(1)
+            expect(getSnapshot(s.b)).toEqual([{ x: "1" }])
         })
 
         test("moving from b to a", () => {
@@ -459,6 +471,10 @@ describe("snapshotProcessor", () => {
             detach(n)
             expect(s.b.length).toBe(0)
             expect(getSnapshot(n)).toEqual({ x: 1 })
+
+            s.a.push(n)
+            expect(s.a.length).toBe(1)
+            expect(getSnapshot(s.a)).toEqual([{ x: "1" }])
         })
     })
 

--- a/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
@@ -69,7 +69,7 @@ class SnapshotProcessor<IT extends IAnyType, CustomC, CustomS> extends BaseType<
 
     private _fixNode(node: this["N"]): void {
         // the node has to use these methods rather than the original type ones
-        proxyNodeTypeMethods(node.type, this, "isAssignableFrom", "create")
+        proxyNodeTypeMethods(node.type, this, "create")
 
         const oldGetSnapshot = node.getSnapshot
         node.getSnapshot = () => {
@@ -135,6 +135,10 @@ class SnapshotProcessor<IT extends IAnyType, CustomC, CustomS> extends BaseType<
             ? getSnapshot(thing, false)
             : this.preProcessSnapshot(thing)
         return this._subtype.validate(value, [{ path: "", type: this._subtype }]).length === 0
+    }
+
+    isAssignableFrom(type: IAnyType): boolean {
+        return this._subtype.isAssignableFrom(type)
     }
 }
 


### PR DESCRIPTION
Related to #1506 

Debugging the sandbox example here: https://codesandbox.io/s/mobx-state-tree-todolist-i5idw

I found that the `isAsignableFrom` check during `validate` resolves to the `BaseType` but it should instead resolve to the `_subtype.isAsignabllFrom` to work correctly when assigning instances:

![image](https://user-images.githubusercontent.com/12156624/93117995-433a2e80-f6c8-11ea-8204-ee910f806dc8.png)

That's why I've added an override to `isAsignabllFrom` in `SnapshotProcessor.ts` which delegates to the subtype under the snapshot processor

It seems the bug appeared in the tests as well and it was covered by an exception expectation:
```ts
if (process.env.NODE_ENV !== "production") {	
    expect(() => s.b.push(n)).toThrow("Error while converting")	
}
```

I've removed these since the fix addressed them and they appear incorrect - you should be able to use an instance created with a snapshot processor in place of the plain instance