### PR TITLE
Add missing type definitions for onInvalidated in safeReference

### DIFF
--- a/packages/mobx-state-tree/src/types/utility-types/reference.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/reference.ts
@@ -536,12 +536,16 @@ export function isReferenceType<IT extends IReferenceType<any>>(type: IT): type 
 
 export function safeReference<IT extends IAnyComplexType>(
     subType: IT,
-    options: (ReferenceOptionsGetSet<IT> | {}) & { acceptsUndefined: false }
+    options: (ReferenceOptionsGetSet<IT> | {}) & {
+        acceptsUndefined: false
+        onInvalidated?: OnReferenceInvalidated<ReferenceT<IT>>
+    }
 ): IReferenceType<IT>
 export function safeReference<IT extends IAnyComplexType>(
     subType: IT,
     options?: (ReferenceOptionsGetSet<IT> | {}) & {
         acceptsUndefined?: boolean
+        onInvalidated?: OnReferenceInvalidated<ReferenceT<IT>>
     }
 ): IMaybe<IReferenceType<IT>>
 /**
@@ -553,6 +557,7 @@ export function safeReference<IT extends IAnyComplexType>(
  * for model properties.
  * When used inside collections (arrays/maps), it is recommended to set this option to false so it can't take undefined as value,
  * which is usually the desired in those cases.
+ * Additionally, the optional options parameter object accepts a parameter named `onInvalidated`, which will be called when the reference target node that the reference is pointing to is about to be detached/destroyed
  *
  * Strictly speaking it is a `types.maybe(types.reference(X))` (when `acceptsUndefined` is set to true, the default) and
  * `types.reference(X)` (when `acceptsUndefined` is set to false), both of them with a customized `onInvalidated` option.


### PR DESCRIPTION
I missed some types definitions in https://github.com/mobxjs/mobx-state-tree/pull/1540

Example of error:

```
      TS2769: No overload matches this call.
  Overload 1 of 2, '(subType: ITypeUnion<ModelCreationType<ExtractCFromProps<{ id: IOptionalIType<ISimpleType<string>, [undefined]>; type: ISimpleType<BlockType>; params: IModelType<{ vertices: IArrayType<IModelType<{ ...; } & { ...; }, { ...; } & ... 2 more ... & { ...; }, _NotCustomized, _NotCustomized>>; isStatic: IType<...>; }, {}, _NotCustomized, _NotCustomized>; }>> | ModelCreationType<...> | ModelCreationType<...> | ModelCreationType<...> | ModelCreationType<...>, ModelSnapshotType<...> | ... 3 more ... | ModelSnapshotType<...>, ModelInstanceType<...> | ... 3 more ... | ModelInstanceType<...>>, options: { ...; } | (ReferenceOptionsGetSet<...> & { ...; })): IReferenceType<...>', gave the following error.
    Argument of type '{ onInvalidated({ parent }: OnReferenceInvalidatedEvent<IEntity>): void; }' is not assignable to parameter of type '{ acceptsUndefined: false; } | (ReferenceOptionsGetSet<ITypeUnion<ModelCreationType<ExtractCFromProps<{ id: IOptionalIType<ISimpleType<string>, [undefined]>; type: ISimpleType<BlockType>; params: IModelType<...>; }>> | ModelCreationType<...> | ModelCreationType<...> | ModelCreationType<...> | ModelCreationType<...>,...'.
      Object literal may only specify known properties, and 'onInvalidated' does not exist in type '{ acceptsUndefined: false; } | (ReferenceOptionsGetSet<ITypeUnion<ModelCreationType<ExtractCFromProps<{ id: IOptionalIType<ISimpleType<string>, [undefined]>; type: ISimpleType<BlockType>; params: IModelType<...>; }>> | ModelCreationType<...> | ModelCreationType<...> | ModelCreationType<...> | ModelCreationType<...>,...'.
  Overload 2 of 2, '(subType: ITypeUnion<ModelCreationType<ExtractCFromProps<{ id: IOptionalIType<ISimpleType<string>, [undefined]>; type: ISimpleType<BlockType>; params: IModelType<{ vertices: IArrayType<IModelType<{ ...; } & { ...; }, { ...; } & ... 2 more ... & { ...; }, _NotCustomized, _NotCustomized>>; isStatic: IType<...>; }, {}, _NotCustomized, _NotCustomized>; }>> | ModelCreationType<...> | ModelCreationType<...> | ModelCreationType<...> | ModelCreationType<...>, ModelSnapshotType<...> | ... 3 more ... | ModelSnapshotType<...>, ModelInstanceType<...> | ... 3 more ... | ModelInstanceType<...>>, options?: { ...; } | ... 1 more ... | undefined): IMaybe<...>', gave the following error.
    Argument of type '{ onInvalidated({ parent }: OnReferenceInvalidatedEvent<IEntity>): void; }' is not assignable to parameter of type '{ acceptsUndefined?: boolean | undefined; } | (ReferenceOptionsGetSet<ITypeUnion<ModelCreationType<ExtractCFromProps<{ id: IOptionalIType<ISimpleType<string>, [undefined]>; type: ISimpleType<BlockType>; params: IModelType<...>; }>> | ModelCreationType<...> | ModelCreationType<...> | ModelCreationType<...> | ModelCre...'.
      Object literal may only specify known properties, and 'onInvalidated' does not exist in type '{ acceptsUndefined?: boolean | undefined; } | (ReferenceOptionsGetSet<ITypeUnion<ModelCreationType<ExtractCFromProps<{ id: IOptionalIType<ISimpleType<string>, [undefined]>; type: ISimpleType<BlockType>; params: IModelType<...>; }>> | ModelCreationType<...> | ModelCreationType<...> | ModelCreationType<...> | ModelCre...'.
```