### PR TITLE
Use ObservableArray for types.array

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/action.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/action.test.ts
@@ -1,3 +1,4 @@
+import { configure } from "mobx"
 import {
     recordActions,
     types,
@@ -308,6 +309,10 @@ test("volatile state survives reonciliation", () => {
     expect(store.cnt.x).toBe(5) // incrementor was not lost
 })
 test("middleware events are correct", () => {
+    configure({
+        useProxies: "never"
+    })
+
     const A = types.model({}).actions((self) => ({
         a(x: number) {
             return this.b(x * 2)
@@ -353,6 +358,10 @@ test("middleware events are correct", () => {
 })
 
 test("actions are mockable", () => {
+    configure({
+        useProxies: "never"
+    })
+
     const M = types
         .model()
         .actions((self) => ({

--- a/packages/mobx-state-tree/__tests__/core/array.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/array.test.ts
@@ -14,7 +14,7 @@ import {
     detach,
     cast
 } from "../../src"
-import { observable, autorun } from "mobx"
+import { observable, autorun, configure } from "mobx"
 
 const createTestFactories = () => {
     const ItemFactory = types.optional(
@@ -340,6 +340,31 @@ test("it should support observable arrays", () => {
     expect(testArray[0] === 1).toBe(true)
     expect(testArray.length === 2).toBe(true)
     expect(Array.isArray(testArray.slice())).toBe(true)
+})
+
+test("it should support observable arrays, array should be real when useProxies eq 'always'", () => {
+    configure({
+        useProxies: "always"
+    })
+
+    const TestArray = types.array(types.number)
+    const testArray = TestArray.create(observable([1, 2]))
+    expect(testArray[0] === 1).toBe(true)
+    expect(testArray.length === 2).toBe(true)
+    expect(Array.isArray(testArray)).toBe(true)
+})
+
+test("it should support observable arrays, array should be not real when useProxies eq 'never'", () => {
+    configure({
+        useProxies: "never"
+    })
+
+    const TestArray = types.array(types.number)
+    const testArray = TestArray.create(observable([1, 2]))
+    expect(testArray[0] === 1).toBe(true)
+    expect(testArray.length === 2).toBe(true)
+    expect(Array.isArray(testArray.slice())).toBe(true)
+    expect(Array.isArray(testArray)).toBe(false)
 })
 
 test("it should correctly handle re-adding of the same objects", () => {

--- a/packages/mobx-state-tree/__tests__/core/array.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/array.test.ts
@@ -36,6 +36,10 @@ test("it should succeed if not optional and no default provided", () => {
     expect(getSnapshot(Factory.create())).toEqual([])
 })
 test("it should restore the state from the snapshot", () => {
+    configure({
+        useProxies: "never"
+    })
+
     const { Factory } = createTestFactories()
     const instance = Factory.create([{ to: "universe" }])
     expect(getSnapshot(instance)).toEqual([{ to: "universe" }])
@@ -160,6 +164,10 @@ test("paths shoud remain correct when splicing", () => {
     expect(store.todos.map(getPath)).toEqual(["/todos/0", "/todos/1"])
 })
 test("items should be reconciled correctly when splicing - 1", () => {
+    configure({
+        useProxies: "never"
+    })
+
     const Task = types.model("Task", {
         x: types.string
     })

--- a/packages/mobx-state-tree/__tests__/core/env.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/env.test.ts
@@ -1,3 +1,4 @@
+import { configure } from "mobx"
 import {
     types,
     getEnv,
@@ -132,6 +133,10 @@ test("clone preserves environnment", () => {
 })
 
 test("#1231", () => {
+    configure({
+        useProxies: "never"
+    })
+
     const envObj = createEnvironment()
     const logs: string[] = []
 

--- a/packages/mobx-state-tree/__tests__/core/map.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/map.test.ts
@@ -1,3 +1,4 @@
+import { configure } from "mobx"
 import {
     onSnapshot,
     onPatch,
@@ -150,6 +151,10 @@ test("it should check the type correctly", () => {
     expect(Factory.is({ hello: { to: true } })).toEqual(false)
 })
 test("it should support identifiers", () => {
+    configure({
+        useProxies: "never"
+    })
+
     const Store = types.model({
         todos: types.optional(
             types.map(
@@ -243,6 +248,10 @@ test("#192 - map should not mess up keys when putting twice", () => {
     expect(getSnapshot(todoStore.todos)).toEqual({ "1": { todo_id: 1, title: "Test Edited" } })
 })
 test("#694 - map.put should return new node", () => {
+    configure({
+        useProxies: "never"
+    })
+
     const Todo = types.model("Todo", {
         todo_id: types.identifier,
         title: types.string

--- a/packages/mobx-state-tree/__tests__/core/node.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/node.test.ts
@@ -21,7 +21,7 @@ import {
     getNodeId
 } from "../../src"
 
-import { autorun } from "mobx"
+import { autorun, configure } from "mobx"
 
 // getParent
 test("it should resolve to the parent instance", () => {
@@ -60,6 +60,10 @@ test("it should check for parent instance (unbound)", () => {
 })
 // getParentOfType
 test("it should resolve to the given parent instance", () => {
+    configure({
+        useProxies: "never"
+    })
+
     const Cell = types.model({})
     const Row = types.model({
         cells: types.optional(types.array(Cell), [])
@@ -197,6 +201,10 @@ test("it should resolve parents", () => {
 })
 // clone
 test("it should clone a node", () => {
+    configure({
+        useProxies: "never"
+    })
+
     const Row = types.model({
         article_id: 0
     })
@@ -212,6 +220,10 @@ test("it should clone a node", () => {
     expect(getSnapshot(doc)).toEqual(getSnapshot(cloned))
 })
 test("it should be possible to clone a dead object", () => {
+    configure({
+        useProxies: "never"
+    })
+
     const Task = types.model("Task", {
         x: types.string
     })

--- a/packages/mobx-state-tree/__tests__/core/reference.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/reference.test.ts
@@ -1,4 +1,4 @@
-import { reaction, autorun, isObservable } from "mobx"
+import { reaction, autorun, isObservable, configure } from "mobx"
 import {
     types,
     getSnapshot,
@@ -908,6 +908,10 @@ test("#1052 - Reference returns destroyed model after subtree replacing", () => 
 })
 
 test("#1080 - does not crash trying to resolve a reference to a destroyed+recreated model", () => {
+    configure({
+        useProxies: "never"
+    })
+
     const Branch = types.model("Branch", {
         id: types.identifierNumber,
         name: types.string

--- a/packages/mobx-state-tree/__tests__/core/union.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/union.test.ts
@@ -1,3 +1,4 @@
+import { configure } from "mobx"
 import {
     types,
     hasParent,
@@ -235,11 +236,19 @@ describe("1045 - secondary union types with applySnapshot and ids", () => {
                     for (const type of [2, 1]) {
                         describe(`snapshot is of type Submodel${type}`, () => {
                             it(`apply snapshot works when the node is not touched`, () => {
+                                configure({
+                                    useProxies: "never"
+                                })
+
                                 const t = initTest(useCreate, submodel1First, type)
                                 t.applySn()
                             })
 
                             it(`apply snapshot works when the node is touched`, () => {
+                                configure({
+                                    useProxies: "never"
+                                })
+
                                 const t = initTest(useCreate, submodel1First, type)
                                 // tslint:disable-next-line:no-unused-expression
                                 t.store[0]

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -9,8 +9,7 @@ import {
     IObservableArray,
     observable,
     observe,
-    makeObservable,
-    _getGlobalState
+    makeObservable
 } from "mobx"
 import {
     addHiddenFinalProp,
@@ -125,12 +124,7 @@ export class ArrayType<IT extends IAnyType> extends ComplexType<
     }
 
     createNewInstance(childNodes: IChildNodesMap): this["T"] {
-        const useProxies = _getGlobalState().useProxies
-
-        return observable.array(convertChildNodesToArray(childNodes), {
-            ...mobxShallow,
-            proxy: useProxies
-        }) as this["T"]
+        return observable.array(convertChildNodesToArray(childNodes), mobxShallow) as this["T"]
     }
 
     finalizeNewInstance(node: this["N"], instance: this["T"]): void {

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -9,7 +9,8 @@ import {
     IObservableArray,
     observable,
     observe,
-    makeObservable
+    makeObservable,
+    _getGlobalState
 } from "mobx"
 import {
     addHiddenFinalProp,
@@ -124,7 +125,12 @@ export class ArrayType<IT extends IAnyType> extends ComplexType<
     }
 
     createNewInstance(childNodes: IChildNodesMap): this["T"] {
-        return observable.array(convertChildNodesToArray(childNodes), mobxShallow) as this["T"]
+        const useProxies = _getGlobalState().useProxies
+
+        return observable.array(convertChildNodesToArray(childNodes), {
+            ...mobxShallow,
+            proxy: useProxies
+        }) as this["T"]
     }
 
     finalizeNewInstance(node: this["N"], instance: this["T"]): void {

--- a/packages/mobx-state-tree/src/utils.ts
+++ b/packages/mobx-state-tree/src/utils.ts
@@ -1,4 +1,4 @@
-import { isObservableArray, $mobx, getAtom } from "mobx"
+import { isObservableArray, _getGlobalState, getAtom } from "mobx"
 import { Primitives } from "./core/type/type"
 
 /**
@@ -23,8 +23,9 @@ export const EMPTY_OBJECT: {} = Object.freeze({})
  * @internal
  * @hidden
  */
-export const mobxShallow =
-    typeof $mobx === "string" ? { deep: false } : { deep: false, proxy: false }
+export const mobxShallow = _getGlobalState().useProxies
+    ? { deep: false }
+    : { deep: false, proxy: false }
 Object.freeze(mobxShallow)
 
 /**

--- a/packages/mst-middlewares/__tests__/undo-manager.test.ts
+++ b/packages/mst-middlewares/__tests__/undo-manager.test.ts
@@ -1,5 +1,6 @@
 import { UndoManager } from "../src"
 import { types, clone, getSnapshot, flow, Instance } from "mobx-state-tree"
+import { configure } from "mobx"
 
 let undoManager: any = {}
 const setUndoManagerSameTree = (targetStore: any) => {
@@ -454,6 +455,10 @@ describe("same tree - clean", () => {
 })
 
 test("#1195 - withoutUndo() used inside an action should NOT affect all patches within that action", () => {
+    configure({
+        useProxies: "never"
+    })
+
     let _undoManager: any
 
     const store = types


### PR DESCRIPTION
Fixes: https://github.com/mobxjs/mobx-state-tree/issues/1598 
Fixes: https://github.com/mobxjs/mobx-state-tree/issues/1608

https://github.com/mobxjs/mobx/blob/main/packages/mobx/src/api/observable.ts#L160

### Debug information

before:
```
options {deep: false, proxy: false}
mobx.esm.js:589 globalState.useProxies true
mobx.esm.js:590 o.proxy false
mobx.esm.js:5024 createLegacyArray
```

after:
```
options {deep: false}
mobx.esm.js:589 globalState.useProxies true
mobx.esm.js:590 o.proxy undefined
mobx.esm.js:3646 createObservableArray
```