### PR TITLE
docs: castToReferenceSnapshot instant of castToReference

### DIFF
--- a/docs/API/index.md
+++ b/docs/API/index.md
@@ -902,7 +902,7 @@ const ModelB = types.model({
 
 const a = ModelA.create({ id: 'someId', n: 5 });
 // this will allow the compiler to use a model as if it were a reference snapshot
-const b = ModelB.create({ refA: castToReference(a)})
+const b = ModelB.create({ refA: castToReferenceSnapshot(a)})
 ```
 
 **Type parameters:**

--- a/packages/mobx-state-tree/src/core/mst-operations.ts
+++ b/packages/mobx-state-tree/src/core/mst-operations.ts
@@ -966,7 +966,7 @@ export function castToSnapshot<I>(
  *
  * const a = ModelA.create({ id: 'someId', n: 5 });
  * // this will allow the compiler to use a model as if it were a reference snapshot
- * const b = ModelB.create({ refA: castToReference(a)})
+ * const b = ModelB.create({ refA: castToReferenceSnapshot(a)})
  * ```
  *
  * @param instance Instance


### PR DESCRIPTION
castToReference function not exist in the package.
https://mobx-state-tree.js.org/API/#casttoreferencesnapshot