### PR TITLE
Update docs and website for 5.0

### DIFF
--- a/docs/API/index.md
+++ b/docs/API/index.md
@@ -1,10 +1,10 @@
 ---
 id: "index"
-title: "mobx-state-tree - v4.0.2"
+title: "mobx-state-tree - v5.0.0"
 sidebar_label: "Globals"
 ---
 
-[mobx-state-tree - v4.0.2](index.md)
+[mobx-state-tree - v5.0.0](index.md)
 
 ## Index
 
@@ -173,7 +173,7 @@ sidebar_label: "Globals"
 
 Ƭ **IDisposer**: *function*
 
-*Defined in [packages/mobx-state-tree/src/utils.ts:34](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/utils.ts#L34)*
+*Defined in [packages/mobx-state-tree/src/utils.ts:36](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/utils.ts#L36)*
 
 A generic disposer.
 
@@ -187,7 +187,7 @@ ___
 
 Ƭ **IHooksGetter**: *function*
 
-*Defined in [packages/mobx-state-tree/src/core/node/Hook.ts:19](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/node/Hook.ts#L19)*
+*Defined in [packages/mobx-state-tree/src/core/node/Hook.ts:19](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/node/Hook.ts#L19)*
 
 #### Type declaration:
 
@@ -205,7 +205,7 @@ ___
 
 Ƭ **IMiddlewareEventType**: *"action" | "flow_spawn" | "flow_resume" | "flow_resume_error" | "flow_return" | "flow_throw"*
 
-*Defined in [packages/mobx-state-tree/src/core/action.ts:16](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/action.ts#L16)*
+*Defined in [packages/mobx-state-tree/src/core/action.ts:16](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/action.ts#L16)*
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 Ƭ **IMiddlewareHandler**: *function*
 
-*Defined in [packages/mobx-state-tree/src/core/action.ts:49](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/action.ts#L49)*
+*Defined in [packages/mobx-state-tree/src/core/action.ts:49](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/action.ts#L49)*
 
 #### Type declaration:
 
@@ -250,7 +250,7 @@ ___
 
 Ƭ **ITypeDispatcher**: *function*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:27](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L27)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:27](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L27)*
 
 #### Type declaration:
 
@@ -268,7 +268,7 @@ ___
 
 Ƭ **IValidationContext**: *[IValidationContextEntry](interfaces/ivalidationcontextentry.md)[]*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:23](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type-checker.ts#L23)*
+*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:23](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type-checker.ts#L23)*
 
 Array of validation context entries
 
@@ -278,7 +278,7 @@ ___
 
 Ƭ **IValidationResult**: *[IValidationError](interfaces/ivalidationerror.md)[]*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:36](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type-checker.ts#L36)*
+*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:36](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type-checker.ts#L36)*
 
 Type validation result, which is an array of type validation errors
 
@@ -288,7 +288,7 @@ ___
 
 Ƭ **Instance**: *T extends object ? T["Type"] : T*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:227](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L227)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:227](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L227)*
 
 The instance representation of a given type.
 
@@ -298,7 +298,7 @@ ___
 
 Ƭ **LivelinessMode**: *"warn" | "error" | "ignore"*
 
-*Defined in [packages/mobx-state-tree/src/core/node/livelinessChecking.ts:7](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/node/livelinessChecking.ts#L7)*
+*Defined in [packages/mobx-state-tree/src/core/node/livelinessChecking.ts:7](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/node/livelinessChecking.ts#L7)*
 
 Defines what MST should do when running into reads / writes to objects that have died.
 - `"warn"`: Print a warning (default).
@@ -311,7 +311,7 @@ ___
 
 Ƭ **OnReferenceInvalidated**: *function*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:43](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/reference.ts#L43)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:43](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/reference.ts#L43)*
 
 #### Type declaration:
 
@@ -329,7 +329,7 @@ ___
 
 Ƭ **OnReferenceInvalidatedEvent**: *object*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:34](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/reference.ts#L34)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:34](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/reference.ts#L34)*
 
 #### Type declaration:
 
@@ -339,7 +339,7 @@ ___
 
 Ƭ **ReferenceIdentifier**: *string | number*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/identifier.ts:142](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/identifier.ts#L142)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/identifier.ts:142](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/identifier.ts#L142)*
 
 Valid types for identifiers.
 
@@ -349,7 +349,7 @@ ___
 
 Ƭ **ReferenceOptions**: *[ReferenceOptionsGetSet](interfaces/referenceoptionsgetset.md)‹IT› | [ReferenceOptionsOnInvalidated](interfaces/referenceoptionsoninvalidated.md)‹IT› | [ReferenceOptionsGetSet](interfaces/referenceoptionsgetset.md)‹IT› & [ReferenceOptionsOnInvalidated](interfaces/referenceoptionsoninvalidated.md)‹IT›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:473](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/reference.ts#L473)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:473](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/reference.ts#L473)*
 
 ___
 
@@ -357,7 +357,7 @@ ___
 
 Ƭ **SnapshotIn**: *T extends object ? T["CreationType"] : T extends IStateTreeNode<infer IT> ? IT["CreationType"] : T*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:232](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L232)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:232](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L232)*
 
 The input (creation) snapshot representation of a given type.
 
@@ -367,7 +367,7 @@ ___
 
 Ƭ **SnapshotOrInstance**: *[SnapshotIn](index.md#snapshotin)‹T› | [Instance](index.md#instance)‹T›*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:273](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L273)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:273](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L273)*
 
 A type which is equivalent to the union of SnapshotIn and Instance types of a given typeof TYPE or typeof VARIABLE.
 For primitives it defaults to the primitive itself.
@@ -400,7 +400,7 @@ ___
 
 Ƭ **SnapshotOut**: *T extends object ? T["SnapshotType"] : T extends IStateTreeNode<infer IT> ? IT["SnapshotType"] : T*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:241](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L241)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:241](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L241)*
 
 The output snapshot representation of a given type.
 
@@ -410,7 +410,7 @@ The output snapshot representation of a given type.
 
 • **DatePrimitive**: *[IType](interfaces/itype.md)‹number | Date, number, Date›* =  _DatePrimitive
 
-*Defined in [packages/mobx-state-tree/src/types/primitives.ts:178](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/primitives.ts#L178)*
+*Defined in [packages/mobx-state-tree/src/types/primitives.ts:178](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/primitives.ts#L178)*
 
 `types.Date` - Creates a type that can only contain a javascript Date value.
 
@@ -433,7 +433,7 @@ ___
     (v) => typeof v === "boolean"
 )
 
-*Defined in [packages/mobx-state-tree/src/types/primitives.ts:132](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/primitives.ts#L132)*
+*Defined in [packages/mobx-state-tree/src/types/primitives.ts:132](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/primitives.ts#L132)*
 
 `types.boolean` - Creates a type that can only contain a boolean value.
 This type is used for boolean values by default
@@ -452,7 +452,7 @@ ___
 
 • **identifier**: *[ISimpleType](interfaces/isimpletype.md)‹string›* =  new IdentifierType()
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/identifier.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/identifier.ts#L110)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/identifier.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/identifier.ts#L110)*
 
 `types.identifier` - Identifiers are used to make references, lifecycle events and reconciling works.
 Inside a state tree, for each type can exist only one instance for each given identifier.
@@ -476,7 +476,7 @@ ___
 
 • **identifierNumber**: *[ISimpleType](interfaces/isimpletype.md)‹number›* =  new IdentifierNumberType()
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/identifier.ts:125](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/identifier.ts#L125)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/identifier.ts:125](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/identifier.ts#L125)*
 
 `types.identifierNumber` - Similar to `types.identifier`. This one will serialize from / to a number when applying snapshots
 
@@ -500,7 +500,7 @@ ___
     (v) => isInteger(v)
 )
 
-*Defined in [packages/mobx-state-tree/src/types/primitives.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/primitives.ts#L113)*
+*Defined in [packages/mobx-state-tree/src/types/primitives.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/primitives.ts#L113)*
 
 `types.integer` - Creates a type that can only contain an integer value.
 This type is used for integer values by default
@@ -523,7 +523,7 @@ ___
     (v) => v === null
 )
 
-*Defined in [packages/mobx-state-tree/src/types/primitives.ts:141](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/primitives.ts#L141)*
+*Defined in [packages/mobx-state-tree/src/types/primitives.ts:141](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/primitives.ts#L141)*
 
 `types.null` - The type of the value `null`
 
@@ -537,7 +537,7 @@ ___
     (v) => typeof v === "number"
 )
 
-*Defined in [packages/mobx-state-tree/src/types/primitives.ts:94](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/primitives.ts#L94)*
+*Defined in [packages/mobx-state-tree/src/types/primitives.ts:94](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/primitives.ts#L94)*
 
 `types.number` - Creates a type that can only contain a numeric value.
 This type is used for numeric values by default
@@ -560,7 +560,7 @@ ___
     (v) => typeof v === "string"
 )
 
-*Defined in [packages/mobx-state-tree/src/types/primitives.ts:75](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/primitives.ts#L75)*
+*Defined in [packages/mobx-state-tree/src/types/primitives.ts:75](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/primitives.ts#L75)*
 
 `types.string` - Creates a type that can only contain a string value.
 This type is used for string values by default
@@ -583,7 +583,7 @@ ___
     (v) => v === undefined
 )
 
-*Defined in [packages/mobx-state-tree/src/types/primitives.ts:150](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/primitives.ts#L150)*
+*Defined in [packages/mobx-state-tree/src/types/primitives.ts:150](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/primitives.ts#L150)*
 
 `types.undefined` - The type of the value `undefined`
 
@@ -593,7 +593,7 @@ ___
 
 ▸ **addDisposer**(`target`: IAnyStateTreeNode, `disposer`: [IDisposer](index.md#idisposer)): *[IDisposer](index.md#idisposer)*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:753](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L753)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:753](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L753)*
 
 Use this utility to register a function that should be called whenever the
 targeted state tree node is destroyed. This is a useful alternative to managing
@@ -635,7 +635,7 @@ ___
 
 ▸ **addMiddleware**(`target`: IAnyStateTreeNode, `handler`: [IMiddlewareHandler](index.md#imiddlewarehandler), `includeHooks`: boolean): *[IDisposer](index.md#idisposer)*
 
-*Defined in [packages/mobx-state-tree/src/core/action.ts:157](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/action.ts#L157)*
+*Defined in [packages/mobx-state-tree/src/core/action.ts:157](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/action.ts#L157)*
 
 Middleware can be used to intercept any action is invoked on the subtree where it is attached.
 If a tree is protected (by default), this means that any mutation of the tree will pass through your middleware.
@@ -660,7 +660,7 @@ ___
 
 ▸ **applyAction**(`target`: IAnyStateTreeNode, `actions`: [ISerializedActionCall](interfaces/iserializedactioncall.md) | [ISerializedActionCall](interfaces/iserializedactioncall.md)[]): *void*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/on-action.ts#L89)*
+*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/on-action.ts#L89)*
 
 Applies an action or a series of actions in a single MobX transaction.
 Does not return any value
@@ -681,7 +681,7 @@ ___
 
 ▸ **applyPatch**(`target`: IAnyStateTreeNode, `patch`: [IJsonPatch](interfaces/ijsonpatch.md) | ReadonlyArray‹[IJsonPatch](interfaces/ijsonpatch.md)›): *void*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:126](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L126)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:126](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L126)*
 
 Applies a JSON-patch to the given model instance or bails out if the patch couldn't be applied
 See [patches](https://github.com/mobxjs/mobx-state-tree#patches) for more details.
@@ -703,7 +703,7 @@ ___
 
 ▸ **applySnapshot**<**C**>(`target`: IStateTreeNode‹[IType](interfaces/itype.md)‹C, any, any››, `snapshot`: C): *void*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:323](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L323)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:323](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L323)*
 
 Applies a snapshot to a given model instances. Patch and snapshot listeners will be invoked as usual.
 
@@ -726,7 +726,7 @@ ___
 
 ▸ **array**<**IT**>(`subtype`: IT): *IArrayType‹IT›*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/array.ts:338](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/array.ts#L338)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/array.ts:338](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/array.ts#L338)*
 
 `types.array` - Creates an index based collection type who's children are all of a uniform declared type.
 
@@ -766,7 +766,7 @@ ___
 
 ▸ **cast**<**O**>(`snapshotOrInstance`: O): *O*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:872](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L872)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:872](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L872)*
 
 Casts a node snapshot or instance type to an instance type so it can be assigned to a type instance.
 Note that this is just a cast for the type system, this is, it won't actually convert a snapshot to an instance,
@@ -809,7 +809,7 @@ The same object casted as an instance
 
 ▸ **cast**<**O**>(`snapshotOrInstance`: TypeOfValue<O>["CreationType"] | TypeOfValue<O>["SnapshotType"] | TypeOfValue<O>["Type"]): *O*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:875](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L875)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:875](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L875)*
 
 Casts a node snapshot or instance type to an instance type so it can be assigned to a type instance.
 Note that this is just a cast for the type system, this is, it won't actually convert a snapshot to an instance,
@@ -856,7 +856,7 @@ ___
 
 ▸ **castFlowReturn**<**T**>(`val`: T): *T*
 
-*Defined in [packages/mobx-state-tree/src/core/flow.ts:33](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/flow.ts#L33)*
+*Defined in [packages/mobx-state-tree/src/core/flow.ts:33](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/flow.ts#L33)*
 
 **`deprecated`** Not needed since TS3.6.
 Used for TypeScript to make flows that return a promise return the actual promise result.
@@ -879,7 +879,7 @@ ___
 
 ▸ **castToReferenceSnapshot**<**I**>(`instance`: I): *Extract<I, IAnyStateTreeNode> extends never ? I : ReferenceIdentifier*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:975](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L975)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:975](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L975)*
 
 Casts a node instance type to a reference snapshot type so it can be assigned to a refernence snapshot (e.g. to be used inside a create call).
 Note that this is just a cast for the type system, this is, it won't actually convert an instance to a refererence snapshot,
@@ -925,7 +925,7 @@ ___
 
 ▸ **castToSnapshot**<**I**>(`snapshotOrInstance`: I): *Extract<I, IAnyStateTreeNode> extends never ? I : TypeOfValue<I>["CreationType"]*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:941](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L941)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:941](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L941)*
 
 Casts a node instance type to an snapshot type so it can be assigned to a type snapshot (e.g. to be used inside a create call).
 Note that this is just a cast for the type system, this is, it won't actually convert an instance to a snapshot,
@@ -970,7 +970,7 @@ ___
 
 ▸ **clone**<**T**>(`source`: T, `keepEnvironment`: boolean | any): *T*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:668](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L668)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:668](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L668)*
 
 Returns a deep copy of the given state tree node as new tree.
 Short hand for `snapshot(x) = getType(x).create(getSnapshot(x))`
@@ -996,7 +996,7 @@ ___
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›): *[IModelType](interfaces/imodeltype.md)‹PA & PB, OA & OB, _CustomJoin‹FCA, FCB›, _CustomJoin‹FSA, FSB››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:768](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L768)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:768](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L768)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1034,7 +1034,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›): *[IModelType](interfaces/imodeltype.md)‹PA & PB, OA & OB, _CustomJoin‹FCA, FCB›, _CustomJoin‹FSA, FSB››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:770](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L770)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:770](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L770)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1071,7 +1071,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC, OA & OB & OC, _CustomJoin‹FCA, _CustomJoin‹FCB, FCC››, _CustomJoin‹FSA, _CustomJoin‹FSB, FSC›››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:772](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L772)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:772](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L772)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1118,7 +1118,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC, OA & OB & OC, _CustomJoin‹FCA, _CustomJoin‹FCB, FCC››, _CustomJoin‹FSA, _CustomJoin‹FSB, FSC›››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:774](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L774)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:774](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L774)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1164,7 +1164,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD, OA & OB & OC & OD, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, FCD›››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, FSD››››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:776](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L776)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:776](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L776)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1220,7 +1220,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD, OA & OB & OC & OD, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, FCD›››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, FSD››››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:778](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L778)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:778](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L778)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1275,7 +1275,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE, OA & OB & OC & OD & OE, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, FCE››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, FSE›››››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:780](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L780)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:780](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L780)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1340,7 +1340,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE, OA & OB & OC & OD & OE, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, FCE››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, FSE›››››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:782](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L782)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:782](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L782)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1404,7 +1404,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF, OA & OB & OC & OD & OE & OF, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, FCF›››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, FSF››››››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:786](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L786)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:786](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L786)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1478,7 +1478,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF, OA & OB & OC & OD & OE & OF, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, FCF›››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, FSF››››››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:789](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L789)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:789](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L789)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1551,7 +1551,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF & PG, OA & OB & OC & OD & OE & OF & OG, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, _CustomJoin‹FCF, FCG››››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, _CustomJoin‹FSF, FSG›››››››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:792](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L792)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:792](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L792)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1634,7 +1634,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF & PG, OA & OB & OC & OD & OE & OF & OG, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, _CustomJoin‹FCF, FCG››››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, _CustomJoin‹FSF, FSG›››››››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:795](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L795)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:795](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L795)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1716,7 +1716,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF & PG & PH, OA & OB & OC & OD & OE & OF & OG & OH, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, _CustomJoin‹FCF, _CustomJoin‹FCG, FCH›››››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, _CustomJoin‹FSF, _CustomJoin‹FSG, FSH››››››››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:798](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L798)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:798](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L798)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1808,7 +1808,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF & PG & PH, OA & OB & OC & OD & OE & OF & OG & OH, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, _CustomJoin‹FCF, _CustomJoin‹FCG, FCH›››››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, _CustomJoin‹FSF, _CustomJoin‹FSG, FSH››››››››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:801](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L801)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:801](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L801)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1899,7 +1899,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**, **PI**, **OI**, **FCI**, **FSI**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›, `I`: [IModelType](interfaces/imodeltype.md)‹PI, OI, FCI, FSI›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF & PG & PH & PI, OA & OB & OC & OD & OE & OF & OG & OH & OI, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, _CustomJoin‹FCF, _CustomJoin‹FCG, _CustomJoin‹FCH, FCI››››››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, _CustomJoin‹FSF, _CustomJoin‹FSG, _CustomJoin‹FSH, FSI›››››››››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:804](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L804)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:804](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L804)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -2000,7 +2000,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**, **PI**, **OI**, **FCI**, **FSI**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›, `I`: [IModelType](interfaces/imodeltype.md)‹PI, OI, FCI, FSI›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF & PG & PH & PI, OA & OB & OC & OD & OE & OF & OG & OH & OI, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, _CustomJoin‹FCF, _CustomJoin‹FCG, _CustomJoin‹FCH, FCI››››››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, _CustomJoin‹FSF, _CustomJoin‹FSG, _CustomJoin‹FSH, FSI›››››››››*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:807](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L807)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:807](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L807)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -2104,7 +2104,7 @@ ___
 
 ▸ **createActionTrackingMiddleware**<**T**>(`hooks`: [IActionTrackingMiddlewareHooks](interfaces/iactiontrackingmiddlewarehooks.md)‹T›): *[IMiddlewareHandler](index.md#imiddlewarehandler)*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts:28](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts#L28)*
+*Defined in [packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts:28](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts#L28)*
 
 Note: Consider migrating to `createActionTrackingMiddleware2`, it is easier to use.
 
@@ -2134,7 +2134,7 @@ ___
 
 ▸ **createActionTrackingMiddleware2**<**TEnv**>(`middlewareHooks`: [IActionTrackingMiddleware2Hooks](interfaces/iactiontrackingmiddleware2hooks.md)‹TEnv›): *[IMiddlewareHandler](index.md#imiddlewarehandler)*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts:74](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts#L74)*
+*Defined in [packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts:74](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts#L74)*
 
 Convenience utility to create action based middleware that supports async processes more easily.
 The flow is like this:
@@ -2173,7 +2173,7 @@ ___
 
 ▸ **custom**<**S**, **T**>(`options`: [CustomTypeOptions](interfaces/customtypeoptions.md)‹S, T›): *[IType](interfaces/itype.md)‹S | T, S, T›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/custom.ts:74](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/custom.ts#L74)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/custom.ts:74](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/custom.ts#L74)*
 
 `types.custom` - Creates a custom type. Custom types can be used for arbitrary immutable values, that have a serializable representation. For example, to create your own Date representation, Decimal type etc.
 
@@ -2237,7 +2237,7 @@ ___
 
 ▸ **decorate**<**T**>(`handler`: [IMiddlewareHandler](index.md#imiddlewarehandler), `fn`: T, `includeHooks`: boolean): *T*
 
-*Defined in [packages/mobx-state-tree/src/core/action.ts:196](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/action.ts#L196)*
+*Defined in [packages/mobx-state-tree/src/core/action.ts:196](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/action.ts#L196)*
 
 Binds middleware to a specific action.
 
@@ -2278,7 +2278,7 @@ ___
 
 ▸ **destroy**(`target`: IAnyStateTreeNode): *void*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:700](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L700)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:700](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L700)*
 
 Removes a model element from the state tree, and mark it as end-of-life; the element should not be used anymore
 
@@ -2296,7 +2296,7 @@ ___
 
 ▸ **detach**<**T**>(`target`: T): *T*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:689](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L689)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:689](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L689)*
 
 Removes a model element from the state tree, and let it live on as a new state tree
 
@@ -2318,7 +2318,7 @@ ___
 
 ▸ **enumeration**<**T**>(`options`: T[]): *[ISimpleType](interfaces/isimpletype.md)‹UnionStringArray‹T[]››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/enumeration.ts:11](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/enumeration.ts#L11)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/enumeration.ts:11](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/enumeration.ts#L11)*
 
 `types.enumeration` - Can be used to create an string based enumeration.
 (note: this methods is just sugar for a union of string literals)
@@ -2344,7 +2344,7 @@ Name | Type | Description |
 
 ▸ **enumeration**<**T**>(`name`: string, `options`: T[]): *[ISimpleType](interfaces/isimpletype.md)‹UnionStringArray‹T[]››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/enumeration.ts:12](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/enumeration.ts#L12)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/enumeration.ts:12](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/enumeration.ts#L12)*
 
 `types.enumeration` - Can be used to create an string based enumeration.
 (note: this methods is just sugar for a union of string literals)
@@ -2375,7 +2375,7 @@ ___
 
 ▸ **escapeJsonPath**(`path`: string): *string*
 
-*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:77](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/json-patch.ts#L77)*
+*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:77](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/json-patch.ts#L77)*
 
 Escape slashes and backslashes.
 
@@ -2395,7 +2395,7 @@ ___
 
 ▸ **flow**<**R**, **Args**>(`generator`: function): *function*
 
-*Defined in [packages/mobx-state-tree/src/core/flow.ts:20](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/flow.ts#L20)*
+*Defined in [packages/mobx-state-tree/src/core/flow.ts:20](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/flow.ts#L20)*
 
 See [asynchronous actions](concepts/async-actions.md).
 
@@ -2435,7 +2435,7 @@ ___
 
 ▸ **frozen**<**C**>(`subType`: [IType](interfaces/itype.md)‹C, any, any›): *[IType](interfaces/itype.md)‹C, C, C›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/frozen.ts:58](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/frozen.ts#L58)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/frozen.ts:58](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/frozen.ts#L58)*
 
 `types.frozen` - Frozen can be used to store any value that is serializable in itself (that is valid JSON).
 Frozen values need to be immutable or treated as if immutable. They need be serializable as well.
@@ -2487,7 +2487,7 @@ Name | Type |
 
 ▸ **frozen**<**T**>(`defaultValue`: T): *[IType](interfaces/itype.md)‹T | undefined | null, T, T›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/frozen.ts:59](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/frozen.ts#L59)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/frozen.ts:59](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/frozen.ts#L59)*
 
 `types.frozen` - Frozen can be used to store any value that is serializable in itself (that is valid JSON).
 Frozen values need to be immutable or treated as if immutable. They need be serializable as well.
@@ -2539,7 +2539,7 @@ Name | Type |
 
 ▸ **frozen**<**T**>(): *[IType](interfaces/itype.md)‹T, T, T›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/frozen.ts:60](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/frozen.ts#L60)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/frozen.ts:60](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/frozen.ts#L60)*
 
 `types.frozen` - Frozen can be used to store any value that is serializable in itself (that is valid JSON).
 Frozen values need to be immutable or treated as if immutable. They need be serializable as well.
@@ -2589,7 +2589,7 @@ ___
 
 ▸ **getChildType**(`object`: IAnyStateTreeNode, `propertyName?`: undefined | string): *[IAnyType](interfaces/ianytype.md)*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:70](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L70)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:70](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L70)*
 
 Returns the _declared_ type of the given sub property of an object, array or map.
 In the case of arrays and maps the property name is optional and will be ignored.
@@ -2617,7 +2617,7 @@ ___
 
 ▸ **getEnv**<**T**>(`target`: IAnyStateTreeNode): *T*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:775](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L775)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:775](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L775)*
 
 Returns the environment of the current state tree. For more info on environments,
 see [Dependency injection](https://github.com/mobxjs/mobx-state-tree#dependency-injection)
@@ -2645,7 +2645,7 @@ ___
 
 ▸ **getIdentifier**(`target`: IAnyStateTreeNode): *string | null*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:551](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L551)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:551](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L551)*
 
 Returns the identifier of the target node.
 This is the *string normalized* identifier, which might not match the type of the identifier attribute
@@ -2664,7 +2664,7 @@ ___
 
 ▸ **getLivelinessChecking**(): *[LivelinessMode](index.md#livelinessmode)*
 
-*Defined in [packages/mobx-state-tree/src/core/node/livelinessChecking.ts:27](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/node/livelinessChecking.ts#L27)*
+*Defined in [packages/mobx-state-tree/src/core/node/livelinessChecking.ts:27](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/node/livelinessChecking.ts#L27)*
 
 Returns the current liveliness checking mode.
 
@@ -2678,7 +2678,7 @@ ___
 
 ▸ **getMembers**(`target`: IAnyStateTreeNode): *[IModelReflectionData](interfaces/imodelreflectiondata.md)*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:846](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L846)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:846](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L846)*
 
 Returns a reflection of the model node, including name, properties, views, volatile and actions.
 
@@ -2696,7 +2696,7 @@ ___
 
 ▸ **getNodeId**(`target`: IAnyStateTreeNode): *number*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:990](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L990)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:990](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L990)*
 
 Returns the unique node id (not to be confused with the instance identifier) for a
 given instance.
@@ -2718,7 +2718,7 @@ ___
 
 ▸ **getParent**<**IT**>(`target`: IAnyStateTreeNode, `depth`: number): *TypeOrStateTreeNodeToStateTreeNode‹IT›*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:384](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L384)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:384](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L384)*
 
 Returns the immediate parent of this object, or throws.
 
@@ -2747,7 +2747,7 @@ ___
 
 ▸ **getParentOfType**<**IT**>(`target`: IAnyStateTreeNode, `type`: IT): *IT["Type"]*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:428](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L428)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:428](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L428)*
 
 Returns the target's parent of a given type, or throws.
 
@@ -2770,7 +2770,7 @@ ___
 
 ▸ **getPath**(`target`: IAnyStateTreeNode): *string*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:468](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L468)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:468](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L468)*
 
 Returns the path of the given object in the model tree
 
@@ -2788,7 +2788,7 @@ ___
 
 ▸ **getPathParts**(`target`: IAnyStateTreeNode): *string[]*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:481](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L481)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:481](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L481)*
 
 Returns the path of the given object as unescaped string array.
 
@@ -2806,7 +2806,7 @@ ___
 
 ▸ **getPropertyMembers**(`typeOrNode`: [IAnyModelType](interfaces/ianymodeltype.md) | IAnyStateTreeNode): *[IModelReflectionPropertiesData](interfaces/imodelreflectionpropertiesdata.md)*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:815](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L815)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:815](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L815)*
 
 Returns a reflection of the model type properties and name for either a model type or model node.
 
@@ -2824,7 +2824,7 @@ ___
 
 ▸ **getRelativePath**(`base`: IAnyStateTreeNode, `target`: IAnyStateTreeNode): *string*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:650](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L650)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:650](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L650)*
 
 Given two state tree nodes that are part of the same tree,
 returns the shortest jsonpath needed to navigate from the one to the other
@@ -2844,7 +2844,7 @@ ___
 
 ▸ **getRoot**<**IT**>(`target`: IAnyStateTreeNode): *TypeOrStateTreeNodeToStateTreeNode‹IT›*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:453](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L453)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:453](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L453)*
 
 Given an object in a model tree, returns the root object of that tree.
 
@@ -2869,7 +2869,7 @@ ___
 
 ▸ **getRunningActionContext**(): *[IActionContext](interfaces/iactioncontext.md) | undefined*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:26](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L26)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:26](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L26)*
 
 Returns the currently executing MST action context, or undefined if none.
 
@@ -2881,7 +2881,7 @@ ___
 
 ▸ **getSnapshot**<**S**>(`target`: IStateTreeNode‹[IType](interfaces/itype.md)‹any, S, any››, `applyPostProcess`: boolean): *S*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:338](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L338)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:338](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L338)*
 
 Calculates a snapshot from the given model instance. The snapshot will always reflect the latest state but use
 structural sharing where possible. Doesn't require MobX transactions to be completed.
@@ -2905,7 +2905,7 @@ ___
 
 ▸ **getType**(`object`: IAnyStateTreeNode): *[IAnyComplexType](interfaces/ianycomplextype.md)*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:48](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L48)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:48](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L48)*
 
 Returns the _actual_ type of the given tree node. (Or throws)
 
@@ -2923,7 +2923,7 @@ ___
 
 ▸ **hasParent**(`target`: IAnyStateTreeNode, `depth`: number): *boolean*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:358](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L358)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:358](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L358)*
 
 Given a model instance, returns `true` if the object has a parent, that is, is part of another object, map or array.
 
@@ -2942,7 +2942,7 @@ ___
 
 ▸ **hasParentOfType**(`target`: IAnyStateTreeNode, `type`: [IAnyComplexType](interfaces/ianycomplextype.md)): *boolean*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:408](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L408)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:408](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L408)*
 
 Given a model instance, returns `true` if the object has a parent of given type, that is, is part of another object, map or array
 
@@ -2961,7 +2961,7 @@ ___
 
 ▸ **isActionContextChildOf**(`actionContext`: [IActionContext](interfaces/iactioncontext.md), `parent`: number | [IActionContext](interfaces/iactioncontext.md) | [IMiddlewareEvent](interfaces/imiddlewareevent.md)): *boolean*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:56](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L56)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:56](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L56)*
 
 Returns if the given action context is a parent of this action context.
 
@@ -2980,7 +2980,7 @@ ___
 
 ▸ **isActionContextThisOrChildOf**(`actionContext`: [IActionContext](interfaces/iactioncontext.md), `parentOrThis`: number | [IActionContext](interfaces/iactioncontext.md) | [IMiddlewareEvent](interfaces/imiddlewareevent.md)): *boolean*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:66](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L66)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:66](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L66)*
 
 Returns if the given action context is this or a parent of this action context.
 
@@ -2999,7 +2999,7 @@ ___
 
 ▸ **isAlive**(`target`: IAnyStateTreeNode): *boolean*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:718](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L718)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:718](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L718)*
 
 Returns true if the given state tree node is not killed yet.
 This means that the node is still a part of a tree, and that `destroy`
@@ -3020,7 +3020,7 @@ ___
 
 ▸ **isArrayType**<**Items**>(`type`: [IAnyType](interfaces/ianytype.md)): *type is IArrayType<Items>*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/array.ts:498](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/array.ts#L498)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/array.ts:498](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/array.ts#L498)*
 
 Returns if a given value represents an array type.
 
@@ -3044,7 +3044,7 @@ ___
 
 ▸ **isFrozenType**<**IT**, **T**>(`type`: IT): *type is IT*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/frozen.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/frozen.ts#L113)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/frozen.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/frozen.ts#L113)*
 
 Returns if a given value represents a frozen type.
 
@@ -3068,7 +3068,7 @@ ___
 
 ▸ **isIdentifierType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/identifier.ts:133](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/identifier.ts#L133)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/identifier.ts:133](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/identifier.ts#L133)*
 
 Returns if a given value represents an identifier type.
 
@@ -3090,7 +3090,7 @@ ___
 
 ▸ **isLateType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/late.ts:141](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/late.ts#L141)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/late.ts:141](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/late.ts#L141)*
 
 Returns if a given value represents a late type.
 
@@ -3112,7 +3112,7 @@ ___
 
 ▸ **isLiteralType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/literal.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/literal.ts#L86)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/literal.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/literal.ts#L86)*
 
 Returns if a given value represents a literal type.
 
@@ -3134,7 +3134,7 @@ ___
 
 ▸ **isMapType**<**Items**>(`type`: [IAnyType](interfaces/ianytype.md)): *type is IMapType<Items>*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/map.ts:529](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/map.ts#L529)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/map.ts:529](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/map.ts#L529)*
 
 Returns if a given value represents a map type.
 
@@ -3158,7 +3158,7 @@ ___
 
 ▸ **isModelType**<**IT**>(`type`: [IAnyType](interfaces/ianytype.md)): *type is IT*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:853](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L853)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:853](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L853)*
 
 Returns if a given value represents a model type.
 
@@ -3180,7 +3180,7 @@ ___
 
 ▸ **isOptionalType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/optional.ts:234](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/optional.ts#L234)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/optional.ts:234](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/optional.ts#L234)*
 
 Returns if a value represents an optional type.
 
@@ -3204,7 +3204,7 @@ ___
 
 ▸ **isPrimitiveType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [packages/mobx-state-tree/src/types/primitives.ts:204](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/primitives.ts#L204)*
+*Defined in [packages/mobx-state-tree/src/types/primitives.ts:204](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/primitives.ts#L204)*
 
 Returns if a given value represents a primitive type.
 
@@ -3226,7 +3226,7 @@ ___
 
 ▸ **isProtected**(`target`: IAnyStateTreeNode): *boolean*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:312](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L312)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:312](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L312)*
 
 Returns true if the object is in protected mode, @see protect
 
@@ -3244,7 +3244,7 @@ ___
 
 ▸ **isReferenceType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:533](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/reference.ts#L533)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:533](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/reference.ts#L533)*
 
 Returns if a given value represents a reference type.
 
@@ -3266,7 +3266,7 @@ ___
 
 ▸ **isRefinementType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/refinement.ts:126](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/refinement.ts#L126)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/refinement.ts:126](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/refinement.ts#L126)*
 
 Returns if a given value is a refinement type.
 
@@ -3288,7 +3288,7 @@ ___
 
 ▸ **isRoot**(`target`: IAnyStateTreeNode): *boolean*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:494](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L494)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:494](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L494)*
 
 Returns true if the given object is the root of a model tree.
 
@@ -3306,7 +3306,7 @@ ___
 
 ▸ **isStateTreeNode**<**IT**>(`value`: any): *value is STNValue<Instance<IT>, IT>*
 
-*Defined in [packages/mobx-state-tree/src/core/node/node-utils.ts:68](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/node/node-utils.ts#L68)*
+*Defined in [packages/mobx-state-tree/src/core/node/node-utils.ts:68](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/node/node-utils.ts#L68)*
 
 Returns true if the given value is a node in a state tree.
 More precisely, that is, if the value is an instance of a
@@ -3332,7 +3332,7 @@ ___
 
 ▸ **isType**(`value`: any): *value is IAnyType*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:530](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L530)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:530](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L530)*
 
 Returns if a given value represents a type.
 
@@ -3352,7 +3352,7 @@ ___
 
 ▸ **isUnionType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:282](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L282)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:282](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L282)*
 
 Returns if a given value represents a union type.
 
@@ -3374,7 +3374,7 @@ ___
 
 ▸ **isValidReference**<**N**>(`getter`: function, `checkIfAlive`: boolean): *boolean*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:598](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L598)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:598](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L598)*
 
 Tests if a reference is valid (pointing to an existing node and optionally if alive) and returns if the check passes or not.
 
@@ -3402,7 +3402,7 @@ ___
 
 ▸ **joinJsonPath**(`path`: string[]): *string*
 
-*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:98](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/json-patch.ts#L98)*
+*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:98](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/json-patch.ts#L98)*
 
 Generates a json-path compliant json path from path parts.
 
@@ -3420,7 +3420,7 @@ ___
 
 ▸ **late**<**T**>(`type`: function): *T*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/late.ts:103](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/late.ts#L103)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/late.ts:103](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/late.ts#L103)*
 
 `types.late` - Defines a type that gets implemented later. This is useful when you have to deal with circular dependencies.
 Please notice that when defining circular dependencies TypeScript isn't smart enough to inference them.
@@ -3449,7 +3449,7 @@ A function that returns the type that will be defined.
 
 ▸ **late**<**T**>(`name`: string, `type`: function): *T*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/late.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/late.ts#L104)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/late.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/late.ts#L104)*
 
 `types.late` - Defines a type that gets implemented later. This is useful when you have to deal with circular dependencies.
 Please notice that when defining circular dependencies TypeScript isn't smart enough to inference them.
@@ -3486,7 +3486,7 @@ ___
 
 ▸ **literal**<**S**>(`value`: S): *[ISimpleType](interfaces/isimpletype.md)‹S›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/literal.ts:73](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/literal.ts#L73)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/literal.ts:73](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/literal.ts#L73)*
 
 `types.literal` - The literal type will return a type that will match only the exact given type.
 The given value must be a primitive, in order to be serialized to a snapshot correctly.
@@ -3518,7 +3518,7 @@ ___
 
 ▸ **map**<**IT**>(`subtype`: IT): *IMapType‹IT›*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/map.ts:519](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/map.ts#L519)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/map.ts:519](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/map.ts#L519)*
 
 `types.map` - Creates a key based collection type who's children are all of a uniform declared type.
 If the type stored in a map has an identifier, it is mandatory to store the child under that identifier in the map.
@@ -3561,7 +3561,7 @@ ___
 
 ▸ **maybe**<**IT**>(`type`: IT): *IMaybe‹IT›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/maybe.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/maybe.ts#L31)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/maybe.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/maybe.ts#L31)*
 
 `types.maybe` - Maybe will make a type nullable, and also optional.
 The value `undefined` will be used to represent nullability.
@@ -3584,7 +3584,7 @@ ___
 
 ▸ **maybeNull**<**IT**>(`type`: IT): *IMaybeNull‹IT›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/maybe.ts:44](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/maybe.ts#L44)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/maybe.ts:44](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/maybe.ts#L44)*
 
 `types.maybeNull` - Maybe will make a type nullable, and also optional.
 The value `null` will be used to represent no value.
@@ -3607,7 +3607,7 @@ ___
 
 ▸ **model**<**P**>(`name`: string, `properties?`: [P](undefined)): *[IModelType](interfaces/imodeltype.md)‹ModelPropertiesDeclarationToProperties‹P›, __type›*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:743](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L743)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:743](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L743)*
 
 `types.model` - Creates a new model type by providing a name, properties, volatile state and actions.
 
@@ -3628,7 +3628,7 @@ Name | Type |
 
 ▸ **model**<**P**>(`properties?`: [P](undefined)): *[IModelType](interfaces/imodeltype.md)‹ModelPropertiesDeclarationToProperties‹P›, __type›*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:747](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L747)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:747](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L747)*
 
 `types.model` - Creates a new model type by providing a name, properties, volatile state and actions.
 
@@ -3652,7 +3652,7 @@ ___
 
 ▸ **onAction**(`target`: IAnyStateTreeNode, `listener`: function, `attachAfter`: boolean): *[IDisposer](index.md#idisposer)*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:226](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/on-action.ts#L226)*
+*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:226](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/on-action.ts#L226)*
 
 Registers a function that will be invoked for each action that is called on the provided model instance, or to any of its children.
 See [actions](https://github.com/mobxjs/mobx-state-tree#actions) for more details. onAction events are emitted only for the outermost called action in the stack.
@@ -3712,7 +3712,7 @@ ___
 
 ▸ **onPatch**(`target`: IAnyStateTreeNode, `callback`: function): *[IDisposer](index.md#idisposer)*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:85](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L85)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:85](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L85)*
 
 Registers a function that will be invoked for each mutation that is applied to the provided model instance, or to any of its children.
 See [patches](https://github.com/mobxjs/mobx-state-tree#patches) for more details. onPatch events are emitted immediately and will not await the end of a transaction.
@@ -3747,7 +3747,7 @@ ___
 
 ▸ **onSnapshot**<**S**>(`target`: IStateTreeNode‹[IType](interfaces/itype.md)‹any, S, any››, `callback`: function): *[IDisposer](index.md#idisposer)*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:105](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L105)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:105](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L105)*
 
 Registers a function that is invoked whenever a new snapshot for the given model instance is available.
 The listener will only be fire at the end of the current MobX (trans)action.
@@ -3779,7 +3779,7 @@ ___
 
 ▸ **optional**<**IT**>(`type`: IT, `defaultValueOrFunction`: OptionalDefaultValueOrFunction‹IT›): *IOptionalIType‹IT, [undefined]›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/optional.ts:160](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/optional.ts#L160)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/optional.ts:160](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/optional.ts#L160)*
 
 `types.optional` - Can be used to create a property with a default value.
 
@@ -3831,7 +3831,7 @@ Name | Type |
 
 ▸ **optional**<**IT**, **OptionalVals**>(`type`: IT, `defaultValueOrFunction`: OptionalDefaultValueOrFunction‹IT›, `optionalValues`: OptionalVals): *IOptionalIType‹IT, OptionalVals›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/optional.ts:164](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/optional.ts#L164)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/optional.ts:164](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/optional.ts#L164)*
 
 `types.optional` - Can be used to create a property with a default value.
 
@@ -3890,7 +3890,7 @@ ___
 
 ▸ **protect**(`target`: IAnyStateTreeNode): *void*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:267](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L267)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:267](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L267)*
 
 The inverse of `unprotect`.
 
@@ -3908,7 +3908,7 @@ ___
 
 ▸ **recordActions**(`subject`: IAnyStateTreeNode, `filter?`: undefined | function): *[IActionRecorder](interfaces/iactionrecorder.md)*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:148](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/on-action.ts#L148)*
+*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:148](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/on-action.ts#L148)*
 
 Small abstraction around `onAction` and `applyAction`, attaches an action listener to a tree and records all the actions emitted.
 Returns an recorder object with the following signature:
@@ -3946,7 +3946,7 @@ ___
 
 ▸ **recordPatches**(`subject`: IAnyStateTreeNode, `filter?`: undefined | function): *[IPatchRecorder](interfaces/ipatchrecorder.md)*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:179](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L179)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:179](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L179)*
 
 Small abstraction around `onPatch` and `applyPatch`, attaches a patch listener to a tree and records all the patches.
 Returns an recorder object with the following signature:
@@ -3989,7 +3989,7 @@ ___
 
 ▸ **reference**<**IT**>(`subType`: IT, `options?`: [ReferenceOptions](index.md#referenceoptions)‹IT›): *IReferenceType‹IT›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:486](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/reference.ts#L486)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:486](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/reference.ts#L486)*
 
 `types.reference` - Creates a reference to another type, which should have defined an identifier.
 See also the [reference and identifiers](https://github.com/mobxjs/mobx-state-tree#references-and-identifiers) section.
@@ -4013,7 +4013,7 @@ ___
 
 ▸ **refinement**<**IT**>(`name`: string, `type`: IT, `predicate`: function, `message?`: string | function): *IT*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/refinement.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/refinement.ts#L84)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/refinement.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/refinement.ts#L84)*
 
 `types.refinement` - Creates a type that is more specific than the base type, e.g. `types.refinement(types.string, value => value.length > 5)` to create a type of strings that can only be longer then 5.
 
@@ -4043,7 +4043,7 @@ Name | Type |
 
 ▸ **refinement**<**IT**>(`type`: IT, `predicate`: function, `message?`: string | function): *IT*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/refinement.ts:90](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/refinement.ts#L90)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/refinement.ts:90](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/refinement.ts#L90)*
 
 `types.refinement` - Creates a type that is more specific than the base type, e.g. `types.refinement(types.string, value => value.length > 5)` to create a type of strings that can only be longer then 5.
 
@@ -4075,7 +4075,7 @@ ___
 
 ▸ **resolveIdentifier**<**IT**>(`type`: IT, `target`: IAnyStateTreeNode, `identifier`: [ReferenceIdentifier](index.md#referenceidentifier)): *IT["Type"] | undefined*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:527](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L527)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:527](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L527)*
 
 Resolves a model instance given a root target, the type and the identifier you are searching for.
 Returns undefined if no value can be found.
@@ -4100,7 +4100,7 @@ ___
 
 ▸ **resolvePath**(`target`: IAnyStateTreeNode, `path`: string): *any*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:509](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L509)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:509](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L509)*
 
 Resolves a path relatively to a given object.
 Returns undefined if no value can be found.
@@ -4120,7 +4120,7 @@ ___
 
 ▸ **safeReference**<**IT**>(`subType`: IT, `options`: __type | [ReferenceOptionsGetSet](interfaces/referenceoptionsgetset.md)‹IT› & object): *IReferenceType‹IT›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:537](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/reference.ts#L537)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:537](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/reference.ts#L537)*
 
 `types.safeReference` - A safe reference is like a standard reference, except that it accepts the undefined value by default
 and automatically sets itself to undefined (when the parent is a model) / removes itself from arrays and maps
@@ -4130,6 +4130,7 @@ The optional options parameter object accepts a parameter named `acceptsUndefine
 for model properties.
 When used inside collections (arrays/maps), it is recommended to set this option to false so it can't take undefined as value,
 which is usually the desired in those cases.
+Additionally, the optional options parameter object accepts a parameter named `onInvalidated`, which will be called when the reference target node that the reference is pointing to is about to be detached/destroyed
 
 Strictly speaking it is a `types.maybe(types.reference(X))` (when `acceptsUndefined` is set to true, the default) and
 `types.reference(X)` (when `acceptsUndefined` is set to false), both of them with a customized `onInvalidated` option.
@@ -4149,7 +4150,7 @@ Name | Type |
 
 ▸ **safeReference**<**IT**>(`subType`: IT, `options?`: __type | [ReferenceOptionsGetSet](interfaces/referenceoptionsgetset.md)‹IT› & object): *IMaybe‹IReferenceType‹IT››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:541](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/reference.ts#L541)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:544](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/reference.ts#L544)*
 
 `types.safeReference` - A safe reference is like a standard reference, except that it accepts the undefined value by default
 and automatically sets itself to undefined (when the parent is a model) / removes itself from arrays and maps
@@ -4159,6 +4160,7 @@ The optional options parameter object accepts a parameter named `acceptsUndefine
 for model properties.
 When used inside collections (arrays/maps), it is recommended to set this option to false so it can't take undefined as value,
 which is usually the desired in those cases.
+Additionally, the optional options parameter object accepts a parameter named `onInvalidated`, which will be called when the reference target node that the reference is pointing to is about to be detached/destroyed
 
 Strictly speaking it is a `types.maybe(types.reference(X))` (when `acceptsUndefined` is set to true, the default) and
 `types.reference(X)` (when `acceptsUndefined` is set to false), both of them with a customized `onInvalidated` option.
@@ -4182,7 +4184,7 @@ ___
 
 ▸ **setLivelinessChecking**(`mode`: [LivelinessMode](index.md#livelinessmode)): *void*
 
-*Defined in [packages/mobx-state-tree/src/core/node/livelinessChecking.ts:18](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/node/livelinessChecking.ts#L18)*
+*Defined in [packages/mobx-state-tree/src/core/node/livelinessChecking.ts:18](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/node/livelinessChecking.ts#L18)*
 
 Defines what MST should do when running into reads / writes to objects that have died.
 By default it will print a warning.
@@ -4202,7 +4204,7 @@ ___
 
 ▸ **snapshotProcessor**<**IT**, **CustomC**, **CustomS**>(`type`: IT, `processors`: [ISnapshotProcessors](interfaces/isnapshotprocessors.md)‹IT["CreationType"], CustomC, IT["SnapshotType"], CustomS›, `name?`: undefined | string): *[ISnapshotProcessor](interfaces/isnapshotprocessor.md)‹IT, CustomC, CustomS›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts:209](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts#L209)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts:213](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts#L213)*
 
 `types.snapshotProcessor` - Runs a pre/post snapshot processor before/after serializing a given type.
 
@@ -4253,7 +4255,7 @@ ___
 
 ▸ **splitJsonPath**(`path`: string): *string[]*
 
-*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/json-patch.ts#L118)*
+*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/json-patch.ts#L118)*
 
 Splits and decodes a json path into several parts.
 
@@ -4271,7 +4273,7 @@ ___
 
 ▸ **toGenerator**<**R**>(`p`: Promise‹R›): *Generator‹Promise‹R›, R, R›*
 
-*Defined in [packages/mobx-state-tree/src/core/flow.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/flow.ts#L86)*
+*Defined in [packages/mobx-state-tree/src/core/flow.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/flow.ts#L86)*
 
 **`experimental`** 
 experimental api - might change on minor/patch releases
@@ -4311,7 +4313,7 @@ ___
 
 ▸ **toGeneratorFunction**<**R**, **Args**>(`p`: function): *(Anonymous function)*
 
-*Defined in [packages/mobx-state-tree/src/core/flow.ts:59](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/flow.ts#L59)*
+*Defined in [packages/mobx-state-tree/src/core/flow.ts:59](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/flow.ts#L59)*
 
 **`experimental`** 
 experimental api - might change on minor/patch releases
@@ -4360,7 +4362,7 @@ ___
 
 ▸ **tryReference**<**N**>(`getter`: function, `checkIfAlive`: boolean): *N | undefined*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:566](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L566)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:566](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L566)*
 
 Tests if a reference is valid (pointing to an existing node and optionally if alive) and returns such reference if it the check passes,
 else it returns undefined.
@@ -4389,7 +4391,7 @@ ___
 
 ▸ **tryResolve**(`target`: IAnyStateTreeNode, `path`: string): *any*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:626](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L626)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:626](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L626)*
 
 Try to resolve a given path relative to a given node.
 
@@ -4408,7 +4410,7 @@ ___
 
 ▸ **typecheck**<**IT**>(`type`: IT, `value`: ExtractCSTWithSTN‹IT›): *void*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:166](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type-checker.ts#L166)*
+*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:166](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type-checker.ts#L166)*
 
 Run's the typechecker for the given type on the given value, which can be a snapshot or an instance.
 Throws if the given value is not according the provided type specification.
@@ -4433,7 +4435,7 @@ ___
 
 ▸ **unescapeJsonPath**(`path`: string): *string*
 
-*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:88](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/json-patch.ts#L88)*
+*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:88](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/json-patch.ts#L88)*
 
 Unescape slashes and backslashes.
 
@@ -4451,7 +4453,7 @@ ___
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:159](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L159)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:159](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L159)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4484,7 +4486,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:161](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L161)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:161](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L161)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4518,7 +4520,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:164](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L164)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:164](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L164)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4560,7 +4562,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:166](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L166)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:166](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L166)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4603,7 +4605,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:168](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L168)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:168](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L168)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4654,7 +4656,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:171](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L171)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:171](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L171)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4706,7 +4708,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:174](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L174)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:174](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L174)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4766,7 +4768,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:177](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L177)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:177](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L177)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4827,7 +4829,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:180](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L180)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:180](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L180)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4896,7 +4898,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:183](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L183)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:183](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L183)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4966,7 +4968,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF› | ModelCreationType2‹PG, FCG›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF› | ModelSnapshotType2‹PG, FSG›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF› | ModelInstanceType‹PG, OG››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:186](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L186)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:186](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L186)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5044,7 +5046,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF› | ModelCreationType2‹PG, FCG›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF› | ModelSnapshotType2‹PG, FSG›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF› | ModelInstanceType‹PG, OG››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:189](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L189)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:189](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L189)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5123,7 +5125,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF› | ModelCreationType2‹PG, FCG› | ModelCreationType2‹PH, FCH›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF› | ModelSnapshotType2‹PG, FSG› | ModelSnapshotType2‹PH, FSH›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF› | ModelInstanceType‹PG, OG› | ModelInstanceType‹PH, OH››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:193](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L193)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:193](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L193)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5210,7 +5212,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF› | ModelCreationType2‹PG, FCG› | ModelCreationType2‹PH, FCH›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF› | ModelSnapshotType2‹PG, FSG› | ModelSnapshotType2‹PH, FSH›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF› | ModelInstanceType‹PG, OG› | ModelInstanceType‹PH, OH››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:196](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L196)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:196](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L196)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5298,7 +5300,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**, **PI**, **OI**, **FCI**, **FSI**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›, `I`: [IModelType](interfaces/imodeltype.md)‹PI, OI, FCI, FSI›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF› | ModelCreationType2‹PG, FCG› | ModelCreationType2‹PH, FCH› | ModelCreationType2‹PI, FCI›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF› | ModelSnapshotType2‹PG, FSG› | ModelSnapshotType2‹PH, FSH› | ModelSnapshotType2‹PI, FSI›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF› | ModelInstanceType‹PG, OG› | ModelInstanceType‹PH, OH› | ModelInstanceType‹PI, OI››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:200](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L200)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:200](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L200)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5394,7 +5396,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**, **PI**, **OI**, **FCI**, **FSI**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›, `I`: [IModelType](interfaces/imodeltype.md)‹PI, OI, FCI, FSI›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF› | ModelCreationType2‹PG, FCG› | ModelCreationType2‹PH, FCH› | ModelCreationType2‹PI, FCI›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF› | ModelSnapshotType2‹PG, FSG› | ModelSnapshotType2‹PH, FSH› | ModelSnapshotType2‹PI, FSI›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF› | ModelInstanceType‹PG, OG› | ModelInstanceType‹PH, OH› | ModelInstanceType‹PI, OI››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:203](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L203)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:203](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L203)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5491,7 +5493,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›): *ITypeUnion‹CA | CB, SA | SB, TA | TB›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:207](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L207)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:207](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L207)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5520,7 +5522,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›): *ITypeUnion‹CA | CB, SA | SB, TA | TB›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:209](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L209)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:209](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L209)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5550,7 +5552,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›): *ITypeUnion‹CA | CB | CC, SA | SB | SC, TA | TB | TC›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:211](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L211)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:211](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L211)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5586,7 +5588,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›): *ITypeUnion‹CA | CB | CC, SA | SB | SC, TA | TB | TC›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:213](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L213)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:213](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L213)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5623,7 +5625,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›): *ITypeUnion‹CA | CB | CC | CD, SA | SB | SC | SD, TA | TB | TC | TD›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:215](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L215)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:215](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L215)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5666,7 +5668,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›): *ITypeUnion‹CA | CB | CC | CD, SA | SB | SC | SD, TA | TB | TC | TD›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:218](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L218)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:218](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L218)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5710,7 +5712,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›): *ITypeUnion‹CA | CB | CC | CD | CE, SA | SB | SC | SD | SE, TA | TB | TC | TD | TE›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:220](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L220)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:220](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L220)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5760,7 +5762,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›): *ITypeUnion‹CA | CB | CC | CD | CE, SA | SB | SC | SD | SE, TA | TB | TC | TD | TE›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:222](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L222)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:222](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L222)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5811,7 +5813,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›): *ITypeUnion‹CA | CB | CC | CD | CE | CF, SA | SB | SC | SD | SE | SF, TA | TB | TC | TD | TE | TF›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:224](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L224)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:224](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L224)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5868,7 +5870,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›): *ITypeUnion‹CA | CB | CC | CD | CE | CF, SA | SB | SC | SD | SE | SF, TA | TB | TC | TD | TE | TF›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:226](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L226)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:226](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L226)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5926,7 +5928,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**, **CG**, **SG**, **TG**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›, `G`: [IType](interfaces/itype.md)‹CG, SG, TG›): *ITypeUnion‹CA | CB | CC | CD | CE | CF | CG, SA | SB | SC | SD | SE | SF | SG, TA | TB | TC | TD | TE | TF | TG›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:228](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L228)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:228](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L228)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5990,7 +5992,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**, **CG**, **SG**, **TG**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›, `G`: [IType](interfaces/itype.md)‹CG, SG, TG›): *ITypeUnion‹CA | CB | CC | CD | CE | CF | CG, SA | SB | SC | SD | SE | SF | SG, TA | TB | TC | TD | TE | TF | TG›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:231](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L231)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:231](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L231)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6055,7 +6057,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**, **CG**, **SG**, **TG**, **CH**, **SH**, **TH**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›, `G`: [IType](interfaces/itype.md)‹CG, SG, TG›, `H`: [IType](interfaces/itype.md)‹CH, SH, TH›): *ITypeUnion‹CA | CB | CC | CD | CE | CF | CG | CH, SA | SB | SC | SD | SE | SF | SG | SH, TA | TB | TC | TD | TE | TF | TG | TH›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:233](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L233)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:233](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L233)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6126,7 +6128,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**, **CG**, **SG**, **TG**, **CH**, **SH**, **TH**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›, `G`: [IType](interfaces/itype.md)‹CG, SG, TG›, `H`: [IType](interfaces/itype.md)‹CH, SH, TH›): *ITypeUnion‹CA | CB | CC | CD | CE | CF | CG | CH, SA | SB | SC | SD | SE | SF | SG | SH, TA | TB | TC | TD | TE | TF | TG | TH›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:236](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L236)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:236](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L236)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6198,7 +6200,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**, **CG**, **SG**, **TG**, **CH**, **SH**, **TH**, **CI**, **SI**, **TI**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›, `G`: [IType](interfaces/itype.md)‹CG, SG, TG›, `H`: [IType](interfaces/itype.md)‹CH, SH, TH›, `I`: [IType](interfaces/itype.md)‹CI, SI, TI›): *ITypeUnion‹CA | CB | CC | CD | CE | CF | CG | CH | CI, SA | SB | SC | SD | SE | SF | SG | SH | SI, TA | TB | TC | TD | TE | TF | TG | TH | TI›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:239](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L239)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:239](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L239)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6276,7 +6278,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**, **CG**, **SG**, **TG**, **CH**, **SH**, **TH**, **CI**, **SI**, **TI**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›, `G`: [IType](interfaces/itype.md)‹CG, SG, TG›, `H`: [IType](interfaces/itype.md)‹CH, SH, TH›, `I`: [IType](interfaces/itype.md)‹CI, SI, TI›): *ITypeUnion‹CA | CB | CC | CD | CE | CF | CG | CH | CI, SA | SB | SC | SD | SE | SF | SG | SH | SI, TA | TB | TC | TD | TE | TF | TG | TH | TI›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:242](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L242)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:242](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L242)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6355,7 +6357,7 @@ Name | Type |
 
 ▸ **union**(...`types`: [IAnyType](interfaces/ianytype.md)[]): *[IAnyType](interfaces/ianytype.md)*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:245](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L245)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:245](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L245)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6369,7 +6371,7 @@ Name | Type |
 
 ▸ **union**(`dispatchOrType`: [UnionOptions](interfaces/unionoptions.md) | [IAnyType](interfaces/ianytype.md), ...`otherTypes`: [IAnyType](interfaces/ianytype.md)[]): *[IAnyType](interfaces/ianytype.md)*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:246](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L246)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:246](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L246)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6388,7 +6390,7 @@ ___
 
 ▸ **unprotect**(`target`: IAnyStateTreeNode): *void*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:300](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L300)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:300](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L300)*
 
 By default it is not allowed to directly modify a model. Models can only be modified through actions.
 However, in some cases you don't care about the advantages (like replayability, traceability, etc) this yields.
@@ -6427,7 +6429,7 @@ ___
 
 ▸ **walk**(`target`: IAnyStateTreeNode, `processor`: function): *void*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:788](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L788)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:788](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L788)*
 
 Performs a depth first walk through a tree.
 
@@ -6453,160 +6455,160 @@ Name | Type |
 
 ### ▪ **types**: *object*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L31)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L31)*
 
 ###  Date
 
 • **Date**: *[IType](interfaces/itype.md)‹number | Date, number, Date›* =  DatePrimitive
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:48](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L48)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:48](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L48)*
 
 ###  array
 
 • **array**: *[array](index.md#array)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:50](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L50)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:50](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L50)*
 
 ###  boolean
 
 • **boolean**: *[ISimpleType](interfaces/isimpletype.md)‹boolean›*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:45](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L45)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:45](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L45)*
 
 ###  compose
 
 • **compose**: *[compose](index.md#compose)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:34](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L34)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:34](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L34)*
 
 ###  custom
 
 • **custom**: *[custom](index.md#custom)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:35](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L35)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:35](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L35)*
 
 ###  enumeration
 
 • **enumeration**: *[enumeration](index.md#enumeration)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L32)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L32)*
 
 ###  frozen
 
 • **frozen**: *[frozen](index.md#frozen)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:51](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L51)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:51](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L51)*
 
 ###  identifier
 
 • **identifier**: *[ISimpleType](interfaces/isimpletype.md)‹string›*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:52](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L52)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:52](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L52)*
 
 ###  identifierNumber
 
 • **identifierNumber**: *[ISimpleType](interfaces/isimpletype.md)‹number›*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:53](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L53)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:53](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L53)*
 
 ###  integer
 
 • **integer**: *[ISimpleType](interfaces/isimpletype.md)‹number›*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:47](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L47)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:47](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L47)*
 
 ###  late
 
 • **late**: *[late](index.md#late)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:54](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L54)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:54](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L54)*
 
 ###  literal
 
 • **literal**: *[literal](index.md#literal)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:40](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L40)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:40](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L40)*
 
 ###  map
 
 • **map**: *[map](index.md#map)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:49](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L49)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:49](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L49)*
 
 ###  maybe
 
 • **maybe**: *[maybe](index.md#maybe)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:41](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L41)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:41](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L41)*
 
 ###  maybeNull
 
 • **maybeNull**: *[maybeNull](index.md#maybenull)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:42](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L42)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:42](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L42)*
 
 ###  model
 
 • **model**: *[model](index.md#model)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:33](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L33)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:33](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L33)*
 
 ###  null
 
 • **null**: *[ISimpleType](interfaces/isimpletype.md)‹null›* =  nullType
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:56](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L56)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:56](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L56)*
 
 ###  number
 
 • **number**: *[ISimpleType](interfaces/isimpletype.md)‹number›*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:46](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L46)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:46](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L46)*
 
 ###  optional
 
 • **optional**: *[optional](index.md#optional)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:39](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L39)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:39](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L39)*
 
 ###  reference
 
 • **reference**: *[reference](index.md#reference)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:36](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L36)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:36](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L36)*
 
 ###  refinement
 
 • **refinement**: *[refinement](index.md#refinement)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:43](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L43)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:43](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L43)*
 
 ###  safeReference
 
 • **safeReference**: *[safeReference](index.md#safereference)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:37](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L37)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:37](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L37)*
 
 ###  snapshotProcessor
 
 • **snapshotProcessor**: *[snapshotProcessor](index.md#snapshotprocessor)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:57](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L57)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:57](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L57)*
 
 ###  string
 
 • **string**: *[ISimpleType](interfaces/isimpletype.md)‹string›*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:44](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L44)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:44](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L44)*
 
 ###  undefined
 
 • **undefined**: *[ISimpleType](interfaces/isimpletype.md)‹undefined›* =  undefinedType
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:55](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L55)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:55](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L55)*
 
 ###  union
 
 • **union**: *[union](index.md#union)*
 
-*Defined in [packages/mobx-state-tree/src/types/index.ts:38](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/index.ts#L38)*
+*Defined in [packages/mobx-state-tree/src/types/index.ts:38](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/index.ts#L38)*

--- a/docs/API/interfaces/customtypeoptions.md
+++ b/docs/API/interfaces/customtypeoptions.md
@@ -4,7 +4,7 @@ title: "CustomTypeOptions"
 sidebar_label: "CustomTypeOptions"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [CustomTypeOptions](customtypeoptions.md)
+[mobx-state-tree - v5.0.0](../index.md) › [CustomTypeOptions](customtypeoptions.md)
 
 ## Type parameters
 
@@ -35,7 +35,7 @@ sidebar_label: "CustomTypeOptions"
 
 • **name**: *string*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/custom.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/custom.ts#L15)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/custom.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/custom.ts#L15)*
 
 Friendly name
 
@@ -45,7 +45,7 @@ Friendly name
 
 ▸ **fromSnapshot**(`snapshot`: S, `env?`: any): *T*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/custom.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/custom.ts#L17)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/custom.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/custom.ts#L17)*
 
 given a serialized value and environment, how to turn it into the target type
 
@@ -64,7 +64,7 @@ ___
 
 ▸ **getValidationMessage**(`snapshot`: S): *string*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/custom.ts:23](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/custom.ts#L23)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/custom.ts:23](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/custom.ts#L23)*
 
 a non empty string is assumed to be a validation error
 
@@ -82,7 +82,7 @@ ___
 
 ▸ **isTargetType**(`value`: T | S): *boolean*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/custom.ts:21](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/custom.ts#L21)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/custom.ts:21](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/custom.ts#L21)*
 
 if true, this is a converted value, if false, it's a snapshot
 
@@ -100,7 +100,7 @@ ___
 
 ▸ **toSnapshot**(`value`: T): *S*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/custom.ts:19](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/custom.ts#L19)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/custom.ts:19](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/custom.ts#L19)*
 
 return the serialization of the current value
 

--- a/docs/API/interfaces/iactioncontext.md
+++ b/docs/API/interfaces/iactioncontext.md
@@ -4,7 +4,7 @@ title: "IActionContext"
 sidebar_label: "IActionContext"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IActionContext](iactioncontext.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IActionContext](iactioncontext.md)
 
 ## Hierarchy
 
@@ -29,7 +29,7 @@ sidebar_label: "IActionContext"
 
 • **args**: *any[]*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:20](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L20)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:20](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L20)*
 
 Event arguments in an array (action arguments for actions)
 
@@ -39,7 +39,7 @@ ___
 
 • **context**: *IAnyStateTreeNode*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L15)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L15)*
 
 Event context (node where the action was invoked)
 
@@ -49,7 +49,7 @@ ___
 
 • **id**: *number*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L9)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L9)*
 
 Event unique id
 
@@ -59,7 +59,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L6)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L6)*
 
 Event name (action name for actions)
 
@@ -69,7 +69,7 @@ ___
 
 • **parentActionEvent**: *[IMiddlewareEvent](imiddlewareevent.md) | undefined*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:12](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L12)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:12](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L12)*
 
 Parent action event object
 
@@ -79,6 +79,6 @@ ___
 
 • **tree**: *IAnyStateTreeNode*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L17)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L17)*
 
 Event tree (root node of the node where the action was invoked)

--- a/docs/API/interfaces/iactionrecorder.md
+++ b/docs/API/interfaces/iactionrecorder.md
@@ -4,7 +4,7 @@ title: "IActionRecorder"
 sidebar_label: "IActionRecorder"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IActionRecorder](iactionrecorder.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IActionRecorder](iactionrecorder.md)
 
 ## Hierarchy
 
@@ -29,7 +29,7 @@ sidebar_label: "IActionRecorder"
 
 • **actions**: *ReadonlyArray‹[ISerializedActionCall](iserializedactioncall.md)›*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:37](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/on-action.ts#L37)*
+*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:37](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/on-action.ts#L37)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **recording**: *boolean*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:38](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/on-action.ts#L38)*
+*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:38](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/on-action.ts#L38)*
 
 ## Methods
 
@@ -45,7 +45,7 @@ ___
 
 ▸ **replay**(`target`: IAnyStateTreeNode): *void*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:41](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/on-action.ts#L41)*
+*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:41](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/on-action.ts#L41)*
 
 **Parameters:**
 
@@ -61,7 +61,7 @@ ___
 
 ▸ **resume**(): *void*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:40](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/on-action.ts#L40)*
+*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:40](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/on-action.ts#L40)*
 
 **Returns:** *void*
 
@@ -71,6 +71,6 @@ ___
 
 ▸ **stop**(): *void*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:39](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/on-action.ts#L39)*
+*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:39](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/on-action.ts#L39)*
 
 **Returns:** *void*

--- a/docs/API/interfaces/iactiontrackingmiddleware2call.md
+++ b/docs/API/interfaces/iactiontrackingmiddleware2call.md
@@ -4,7 +4,7 @@ title: "IActionTrackingMiddleware2Call"
 sidebar_label: "IActionTrackingMiddleware2Call"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IActionTrackingMiddleware2Call](iactiontrackingmiddleware2call.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IActionTrackingMiddleware2Call](iactiontrackingmiddleware2call.md)
 
 ## Type parameters
 
@@ -29,7 +29,7 @@ sidebar_label: "IActionTrackingMiddleware2Call"
 
 • **env**: *TEnv | undefined*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts#L6)*
+*Defined in [packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts#L6)*
 
 ___
 
@@ -37,4 +37,4 @@ ___
 
 • **parentCall**? : *[IActionTrackingMiddleware2Call](iactiontrackingmiddleware2call.md)‹TEnv›*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts:7](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts#L7)*
+*Defined in [packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts:7](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts#L7)*

--- a/docs/API/interfaces/iactiontrackingmiddleware2hooks.md
+++ b/docs/API/interfaces/iactiontrackingmiddleware2hooks.md
@@ -4,7 +4,7 @@ title: "IActionTrackingMiddleware2Hooks"
 sidebar_label: "IActionTrackingMiddleware2Hooks"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IActionTrackingMiddleware2Hooks](iactiontrackingmiddleware2hooks.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IActionTrackingMiddleware2Hooks](iactiontrackingmiddleware2hooks.md)
 
 ## Type parameters
 
@@ -28,7 +28,7 @@ sidebar_label: "IActionTrackingMiddleware2Hooks"
 
 • **filter**? : *undefined | function*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts:11](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts#L11)*
+*Defined in [packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts:11](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts#L11)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 • **onFinish**: *function*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts:13](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts#L13)*
+*Defined in [packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts:13](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts#L13)*
 
 #### Type declaration:
 
@@ -55,7 +55,7 @@ ___
 
 • **onStart**: *function*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts:12](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts#L12)*
+*Defined in [packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts:12](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/createActionTrackingMiddleware2.ts#L12)*
 
 #### Type declaration:
 

--- a/docs/API/interfaces/iactiontrackingmiddlewarehooks.md
+++ b/docs/API/interfaces/iactiontrackingmiddlewarehooks.md
@@ -4,7 +4,7 @@ title: "IActionTrackingMiddlewareHooks"
 sidebar_label: "IActionTrackingMiddlewareHooks"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IActionTrackingMiddlewareHooks](iactiontrackingmiddlewarehooks.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IActionTrackingMiddlewareHooks](iactiontrackingmiddlewarehooks.md)
 
 ## Type parameters
 
@@ -31,7 +31,7 @@ sidebar_label: "IActionTrackingMiddlewareHooks"
 
 • **filter**? : *undefined | function*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts#L6)*
+*Defined in [packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts#L6)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • **onFail**: *function*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts:11](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts#L11)*
+*Defined in [packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts:11](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts#L11)*
 
 #### Type declaration:
 
@@ -59,7 +59,7 @@ ___
 
 • **onResume**: *function*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts:8](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts#L8)*
+*Defined in [packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts:8](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts#L8)*
 
 #### Type declaration:
 
@@ -78,7 +78,7 @@ ___
 
 • **onStart**: *function*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts:7](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts#L7)*
+*Defined in [packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts:7](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts#L7)*
 
 #### Type declaration:
 
@@ -96,7 +96,7 @@ ___
 
 • **onSuccess**: *function*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts:10](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts#L10)*
+*Defined in [packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts:10](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts#L10)*
 
 #### Type declaration:
 
@@ -116,7 +116,7 @@ ___
 
 • **onSuspend**: *function*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts#L9)*
+*Defined in [packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/create-action-tracking-middleware.ts#L9)*
 
 #### Type declaration:
 

--- a/docs/API/interfaces/ianycomplextype.md
+++ b/docs/API/interfaces/ianycomplextype.md
@@ -4,7 +4,7 @@ title: "IAnyComplexType"
 sidebar_label: "IAnyComplexType"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IAnyComplexType](ianycomplextype.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IAnyComplexType](ianycomplextype.md)
 
 Any kind of complex type.
 
@@ -36,7 +36,7 @@ Any kind of complex type.
 
 *Inherited from [IType](itype.md).[identifierAttribute](itype.md#optional-identifierattribute)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L86)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L86)*
 
 Name of the identifier attribute or null if none.
 
@@ -48,7 +48,7 @@ ___
 
 *Inherited from [IType](itype.md).[name](itype.md#name)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:81](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L81)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:81](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L81)*
 
 Friendly type name.
 
@@ -60,7 +60,7 @@ Friendly type name.
 
 *Inherited from [IType](itype.md).[create](itype.md#create)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:93](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L93)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:93](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L93)*
 
 Creates an instance for the type given an snapshot input.
 
@@ -83,7 +83,7 @@ ___
 
 *Inherited from [IType](itype.md).[describe](itype.md#describe)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:115](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L115)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:115](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L115)*
 
 Gets the textual representation of the type as a string.
 
@@ -97,7 +97,7 @@ ___
 
 *Inherited from [IType](itype.md).[is](itype.md#is)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:101](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L101)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:101](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L101)*
 
 Checks if a given snapshot / instance is of the given type.
 
@@ -119,7 +119,7 @@ ___
 
 *Inherited from [IType](itype.md).[validate](itype.md#validate)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L110)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L110)*
 
 Run's the type's typechecker on the given value with the given validation context.
 

--- a/docs/API/interfaces/ianymodeltype.md
+++ b/docs/API/interfaces/ianymodeltype.md
@@ -4,7 +4,7 @@ title: "IAnyModelType"
 sidebar_label: "IAnyModelType"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IAnyModelType](ianymodeltype.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IAnyModelType](ianymodeltype.md)
 
 Any model type.
 
@@ -45,7 +45,7 @@ Any model type.
 
 *Inherited from [IType](itype.md).[identifierAttribute](itype.md#optional-identifierattribute)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L86)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L86)*
 
 Name of the identifier attribute or null if none.
 
@@ -57,7 +57,7 @@ ___
 
 *Inherited from [IType](itype.md).[name](itype.md#name)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:81](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L81)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:81](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L81)*
 
 Friendly type name.
 
@@ -69,7 +69,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[properties](imodeltype.md#properties)*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:190](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L190)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:190](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L190)*
 
 ## Methods
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[actions](imodeltype.md#actions)*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:204](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L204)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:204](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L204)*
 
 **Type parameters:**
 
@@ -107,7 +107,7 @@ ___
 
 *Inherited from [IType](itype.md).[create](itype.md#create)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:93](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L93)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:93](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L93)*
 
 Creates an instance for the type given an snapshot input.
 
@@ -130,7 +130,7 @@ ___
 
 *Inherited from [IType](itype.md).[describe](itype.md#describe)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:115](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L115)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:115](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L115)*
 
 Gets the textual representation of the type as a string.
 
@@ -144,7 +144,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[extend](imodeltype.md#extend)*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:212](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L212)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:212](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L212)*
 
 **Type parameters:**
 
@@ -176,7 +176,7 @@ ___
 
 *Inherited from [IType](itype.md).[is](itype.md#is)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:101](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L101)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:101](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L101)*
 
 Checks if a given snapshot / instance is of the given type.
 
@@ -198,7 +198,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[named](imodeltype.md#named)*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:192](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L192)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:192](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L192)*
 
 **Parameters:**
 
@@ -216,7 +216,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[postProcessSnapshot](imodeltype.md#postprocesssnapshot)*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:222](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L222)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:222](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L222)*
 
 **`deprecated`** See `types.snapshotProcessor`
 
@@ -246,7 +246,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[preProcessSnapshot](imodeltype.md#preprocesssnapshot)*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:217](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L217)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:217](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L217)*
 
 **`deprecated`** See `types.snapshotProcessor`
 
@@ -276,7 +276,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[props](imodeltype.md#props)*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:196](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L196)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:196](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L196)*
 
 **Type parameters:**
 
@@ -298,7 +298,7 @@ ___
 
 *Inherited from [IType](itype.md).[validate](itype.md#validate)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L110)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L110)*
 
 Run's the type's typechecker on the given value with the given validation context.
 
@@ -321,7 +321,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[views](imodeltype.md#views)*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:200](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L200)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:200](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L200)*
 
 **Type parameters:**
 
@@ -349,7 +349,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[volatile](imodeltype.md#volatile)*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:208](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L208)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:208](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L208)*
 
 **Type parameters:**
 

--- a/docs/API/interfaces/ianytype.md
+++ b/docs/API/interfaces/ianytype.md
@@ -4,7 +4,7 @@ title: "IAnyType"
 sidebar_label: "IAnyType"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IAnyType](ianytype.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IAnyType](ianytype.md)
 
 Any kind of type.
 
@@ -36,7 +36,7 @@ Any kind of type.
 
 *Inherited from [IType](itype.md).[identifierAttribute](itype.md#optional-identifierattribute)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L86)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L86)*
 
 Name of the identifier attribute or null if none.
 
@@ -48,7 +48,7 @@ ___
 
 *Inherited from [IType](itype.md).[name](itype.md#name)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:81](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L81)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:81](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L81)*
 
 Friendly type name.
 
@@ -60,7 +60,7 @@ Friendly type name.
 
 *Inherited from [IType](itype.md).[create](itype.md#create)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:93](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L93)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:93](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L93)*
 
 Creates an instance for the type given an snapshot input.
 
@@ -83,7 +83,7 @@ ___
 
 *Inherited from [IType](itype.md).[describe](itype.md#describe)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:115](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L115)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:115](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L115)*
 
 Gets the textual representation of the type as a string.
 
@@ -97,7 +97,7 @@ ___
 
 *Inherited from [IType](itype.md).[is](itype.md#is)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:101](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L101)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:101](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L101)*
 
 Checks if a given snapshot / instance is of the given type.
 
@@ -119,7 +119,7 @@ ___
 
 *Inherited from [IType](itype.md).[validate](itype.md#validate)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L110)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L110)*
 
 Run's the type's typechecker on the given value with the given validation context.
 

--- a/docs/API/interfaces/ihooks.md
+++ b/docs/API/interfaces/ihooks.md
@@ -4,7 +4,7 @@ title: "IHooks"
 sidebar_label: "IHooks"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IHooks](ihooks.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IHooks](ihooks.md)
 
 ## Hierarchy
 
@@ -25,7 +25,7 @@ sidebar_label: "IHooks"
 
 • **[Hook.afterAttach]**? : *undefined | function*
 
-*Defined in [packages/mobx-state-tree/src/core/node/Hook.ts:14](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/node/Hook.ts#L14)*
+*Defined in [packages/mobx-state-tree/src/core/node/Hook.ts:14](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/node/Hook.ts#L14)*
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 • **[Hook.afterCreate]**? : *undefined | function*
 
-*Defined in [packages/mobx-state-tree/src/core/node/Hook.ts:13](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/node/Hook.ts#L13)*
+*Defined in [packages/mobx-state-tree/src/core/node/Hook.ts:13](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/node/Hook.ts#L13)*
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 • **[Hook.beforeDestroy]**? : *undefined | function*
 
-*Defined in [packages/mobx-state-tree/src/core/node/Hook.ts:16](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/node/Hook.ts#L16)*
+*Defined in [packages/mobx-state-tree/src/core/node/Hook.ts:16](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/node/Hook.ts#L16)*
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 • **[Hook.beforeDetach]**? : *undefined | function*
 
-*Defined in [packages/mobx-state-tree/src/core/node/Hook.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/node/Hook.ts#L15)*
+*Defined in [packages/mobx-state-tree/src/core/node/Hook.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/node/Hook.ts#L15)*

--- a/docs/API/interfaces/ijsonpatch.md
+++ b/docs/API/interfaces/ijsonpatch.md
@@ -4,7 +4,7 @@ title: "IJsonPatch"
 sidebar_label: "IJsonPatch"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IJsonPatch](ijsonpatch.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IJsonPatch](ijsonpatch.md)
 
 https://tools.ietf.org/html/rfc6902
 http://jsonpatch.com/
@@ -29,7 +29,7 @@ http://jsonpatch.com/
 
 • **op**: *"replace" | "add" | "remove"*
 
-*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:8](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/json-patch.ts#L8)*
+*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:8](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/json-patch.ts#L8)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **path**: *string*
 
-*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/json-patch.ts#L9)*
+*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/json-patch.ts#L9)*
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 • **value**? : *any*
 
-*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:10](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/json-patch.ts#L10)*
+*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:10](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/json-patch.ts#L10)*

--- a/docs/API/interfaces/imiddlewareevent.md
+++ b/docs/API/interfaces/imiddlewareevent.md
@@ -4,7 +4,7 @@ title: "IMiddlewareEvent"
 sidebar_label: "IMiddlewareEvent"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IMiddlewareEvent](imiddlewareevent.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IMiddlewareEvent](imiddlewareevent.md)
 
 ## Hierarchy
 
@@ -34,7 +34,7 @@ sidebar_label: "IMiddlewareEvent"
 
 • **allParentIds**: *number[]*
 
-*Defined in [packages/mobx-state-tree/src/core/action.ts:37](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/action.ts#L37)*
+*Defined in [packages/mobx-state-tree/src/core/action.ts:37](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/action.ts#L37)*
 
 Id of all events, from root until current (excluding current)
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [IActionContext](iactioncontext.md).[args](iactioncontext.md#args)*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:20](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L20)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:20](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L20)*
 
 Event arguments in an array (action arguments for actions)
 
@@ -58,7 +58,7 @@ ___
 
 *Inherited from [IActionContext](iactioncontext.md).[context](iactioncontext.md#context)*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L15)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L15)*
 
 Event context (node where the action was invoked)
 
@@ -70,7 +70,7 @@ ___
 
 *Inherited from [IActionContext](iactioncontext.md).[id](iactioncontext.md#id)*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L9)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L9)*
 
 Event unique id
 
@@ -82,7 +82,7 @@ ___
 
 *Inherited from [IActionContext](iactioncontext.md).[name](iactioncontext.md#name)*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L6)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L6)*
 
 Event name (action name for actions)
 
@@ -94,7 +94,7 @@ ___
 
 *Inherited from [IActionContext](iactioncontext.md).[parentActionEvent](iactioncontext.md#parentactionevent)*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:12](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L12)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:12](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L12)*
 
 Parent action event object
 
@@ -104,7 +104,7 @@ ___
 
 • **parentEvent**: *[IMiddlewareEvent](imiddlewareevent.md) | undefined*
 
-*Defined in [packages/mobx-state-tree/src/core/action.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/action.ts#L32)*
+*Defined in [packages/mobx-state-tree/src/core/action.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/action.ts#L32)*
 
 Parent event object
 
@@ -114,7 +114,7 @@ ___
 
 • **parentId**: *number*
 
-*Defined in [packages/mobx-state-tree/src/core/action.ts:30](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/action.ts#L30)*
+*Defined in [packages/mobx-state-tree/src/core/action.ts:30](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/action.ts#L30)*
 
 Parent event unique id
 
@@ -124,7 +124,7 @@ ___
 
 • **rootId**: *number*
 
-*Defined in [packages/mobx-state-tree/src/core/action.ts:35](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/action.ts#L35)*
+*Defined in [packages/mobx-state-tree/src/core/action.ts:35](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/action.ts#L35)*
 
 Root event unique id
 
@@ -136,7 +136,7 @@ ___
 
 *Inherited from [IActionContext](iactioncontext.md).[tree](iactioncontext.md#tree)*
 
-*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/actionContext.ts#L17)*
+*Defined in [packages/mobx-state-tree/src/core/actionContext.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/actionContext.ts#L17)*
 
 Event tree (root node of the node where the action was invoked)
 
@@ -146,6 +146,6 @@ ___
 
 • **type**: *[IMiddlewareEventType](../index.md#imiddlewareeventtype)*
 
-*Defined in [packages/mobx-state-tree/src/core/action.ts:27](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/action.ts#L27)*
+*Defined in [packages/mobx-state-tree/src/core/action.ts:27](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/action.ts#L27)*
 
 Event type

--- a/docs/API/interfaces/imodelreflectiondata.md
+++ b/docs/API/interfaces/imodelreflectiondata.md
@@ -4,7 +4,7 @@ title: "IModelReflectionData"
 sidebar_label: "IModelReflectionData"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IModelReflectionData](imodelreflectiondata.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IModelReflectionData](imodelreflectiondata.md)
 
 ## Hierarchy
 
@@ -28,7 +28,7 @@ sidebar_label: "IModelReflectionData"
 
 • **actions**: *string[]*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:835](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L835)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:835](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L835)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 *Inherited from [IModelReflectionPropertiesData](imodelreflectionpropertiesdata.md).[name](imodelreflectionpropertiesdata.md#name)*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:805](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L805)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:805](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L805)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 *Inherited from [IModelReflectionPropertiesData](imodelreflectionpropertiesdata.md).[properties](imodelreflectionpropertiesdata.md#properties)*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:806](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L806)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:806](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L806)*
 
 #### Type declaration:
 
@@ -60,7 +60,7 @@ ___
 
 • **views**: *string[]*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:836](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L836)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:836](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L836)*
 
 ___
 
@@ -68,4 +68,4 @@ ___
 
 • **volatile**: *string[]*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:837](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L837)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:837](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L837)*

--- a/docs/API/interfaces/imodelreflectionpropertiesdata.md
+++ b/docs/API/interfaces/imodelreflectionpropertiesdata.md
@@ -4,7 +4,7 @@ title: "IModelReflectionPropertiesData"
 sidebar_label: "IModelReflectionPropertiesData"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IModelReflectionPropertiesData](imodelreflectionpropertiesdata.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IModelReflectionPropertiesData](imodelreflectionpropertiesdata.md)
 
 ## Hierarchy
 
@@ -25,7 +25,7 @@ sidebar_label: "IModelReflectionPropertiesData"
 
 • **name**: *string*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:805](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L805)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:805](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L805)*
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 • **properties**: *object*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:806](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L806)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:806](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L806)*
 
 #### Type declaration:
 

--- a/docs/API/interfaces/imodeltype.md
+++ b/docs/API/interfaces/imodeltype.md
@@ -4,7 +4,7 @@ title: "IModelType"
 sidebar_label: "IModelType"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IModelType](imodeltype.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IModelType](imodeltype.md)
 
 ## Type parameters
 
@@ -55,7 +55,7 @@ sidebar_label: "IModelType"
 
 *Inherited from [IType](itype.md).[identifierAttribute](itype.md#optional-identifierattribute)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L86)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L86)*
 
 Name of the identifier attribute or null if none.
 
@@ -67,7 +67,7 @@ ___
 
 *Inherited from [IType](itype.md).[name](itype.md#name)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:81](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L81)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:81](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L81)*
 
 Friendly type name.
 
@@ -77,7 +77,7 @@ ___
 
 • **properties**: *PROPS*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:190](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L190)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:190](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L190)*
 
 ## Methods
 
@@ -85,7 +85,7 @@ ___
 
 ▸ **actions**<**A**>(`fn`: function): *[IModelType](imodeltype.md)‹PROPS, OTHERS & A, CustomC, CustomS›*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:204](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L204)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:204](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L204)*
 
 **Type parameters:**
 
@@ -113,7 +113,7 @@ ___
 
 *Inherited from [IType](itype.md).[create](itype.md#create)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:93](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L93)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:93](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L93)*
 
 Creates an instance for the type given an snapshot input.
 
@@ -136,7 +136,7 @@ ___
 
 *Inherited from [IType](itype.md).[describe](itype.md#describe)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:115](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L115)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:115](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L115)*
 
 Gets the textual representation of the type as a string.
 
@@ -148,7 +148,7 @@ ___
 
 ▸ **extend**<**A**, **V**, **VS**>(`fn`: function): *[IModelType](imodeltype.md)‹PROPS, OTHERS & A & V & VS, CustomC, CustomS›*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:212](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L212)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:212](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L212)*
 
 **Type parameters:**
 
@@ -180,7 +180,7 @@ ___
 
 *Inherited from [IType](itype.md).[is](itype.md#is)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:101](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L101)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:101](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L101)*
 
 Checks if a given snapshot / instance is of the given type.
 
@@ -200,7 +200,7 @@ ___
 
 ▸ **named**(`newName`: string): *[IModelType](imodeltype.md)‹PROPS, OTHERS, CustomC, CustomS›*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:192](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L192)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:192](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L192)*
 
 **Parameters:**
 
@@ -216,7 +216,7 @@ ___
 
 ▸ **postProcessSnapshot**<**NewS**>(`fn`: function): *[IModelType](imodeltype.md)‹PROPS, OTHERS, CustomC, NewS›*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:222](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L222)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:222](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L222)*
 
 **`deprecated`** See `types.snapshotProcessor`
 
@@ -244,7 +244,7 @@ ___
 
 ▸ **preProcessSnapshot**<**NewC**>(`fn`: function): *[IModelType](imodeltype.md)‹PROPS, OTHERS, NewC, CustomS›*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:217](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L217)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:217](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L217)*
 
 **`deprecated`** See `types.snapshotProcessor`
 
@@ -272,7 +272,7 @@ ___
 
 ▸ **props**<**PROPS2**>(`props`: PROPS2): *[IModelType](imodeltype.md)‹PROPS & ModelPropertiesDeclarationToProperties‹PROPS2›, OTHERS, CustomC, CustomS›*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:196](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L196)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:196](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L196)*
 
 **Type parameters:**
 
@@ -294,7 +294,7 @@ ___
 
 *Inherited from [IType](itype.md).[validate](itype.md#validate)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L110)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L110)*
 
 Run's the type's typechecker on the given value with the given validation context.
 
@@ -315,7 +315,7 @@ ___
 
 ▸ **views**<**V**>(`fn`: function): *[IModelType](imodeltype.md)‹PROPS, OTHERS & V, CustomC, CustomS›*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:200](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L200)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:200](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L200)*
 
 **Type parameters:**
 
@@ -341,7 +341,7 @@ ___
 
 ▸ **volatile**<**TP**>(`fn`: function): *[IModelType](imodeltype.md)‹PROPS, OTHERS & TP, CustomC, CustomS›*
 
-*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:208](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/complex-types/model.ts#L208)*
+*Defined in [packages/mobx-state-tree/src/types/complex-types/model.ts:208](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/complex-types/model.ts#L208)*
 
 **Type parameters:**
 

--- a/docs/API/interfaces/ipatchrecorder.md
+++ b/docs/API/interfaces/ipatchrecorder.md
@@ -4,7 +4,7 @@ title: "IPatchRecorder"
 sidebar_label: "IPatchRecorder"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IPatchRecorder](ipatchrecorder.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IPatchRecorder](ipatchrecorder.md)
 
 ## Hierarchy
 
@@ -32,7 +32,7 @@ sidebar_label: "IPatchRecorder"
 
 • **inversePatches**: *ReadonlyArray‹[IJsonPatch](ijsonpatch.md)›*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:139](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L139)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:139](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L139)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **patches**: *ReadonlyArray‹[IJsonPatch](ijsonpatch.md)›*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:138](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L138)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:138](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L138)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **recording**: *boolean*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:141](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L141)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:141](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L141)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • **reversedInversePatches**: *ReadonlyArray‹[IJsonPatch](ijsonpatch.md)›*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:140](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L140)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:140](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L140)*
 
 ## Methods
 
@@ -64,7 +64,7 @@ ___
 
 ▸ **replay**(`target?`: IAnyStateTreeNode): *void*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:144](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L144)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:144](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L144)*
 
 **Parameters:**
 
@@ -80,7 +80,7 @@ ___
 
 ▸ **resume**(): *void*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:143](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L143)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:143](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L143)*
 
 **Returns:** *void*
 
@@ -90,7 +90,7 @@ ___
 
 ▸ **stop**(): *void*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:142](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L142)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:142](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L142)*
 
 **Returns:** *void*
 
@@ -100,7 +100,7 @@ ___
 
 ▸ **undo**(`target?`: IAnyStateTreeNode): *void*
 
-*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:145](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/mst-operations.ts#L145)*
+*Defined in [packages/mobx-state-tree/src/core/mst-operations.ts:145](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/mst-operations.ts#L145)*
 
 **Parameters:**
 

--- a/docs/API/interfaces/ireversiblejsonpatch.md
+++ b/docs/API/interfaces/ireversiblejsonpatch.md
@@ -4,7 +4,7 @@ title: "IReversibleJsonPatch"
 sidebar_label: "IReversibleJsonPatch"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IReversibleJsonPatch](ireversiblejsonpatch.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IReversibleJsonPatch](ireversiblejsonpatch.md)
 
 ## Hierarchy
 
@@ -27,7 +27,7 @@ sidebar_label: "IReversibleJsonPatch"
 
 • **oldValue**: *any*
 
-*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:14](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/json-patch.ts#L14)*
+*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:14](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/json-patch.ts#L14)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 *Inherited from [IJsonPatch](ijsonpatch.md).[op](ijsonpatch.md#op)*
 
-*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:8](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/json-patch.ts#L8)*
+*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:8](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/json-patch.ts#L8)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 *Inherited from [IJsonPatch](ijsonpatch.md).[path](ijsonpatch.md#path)*
 
-*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/json-patch.ts#L9)*
+*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/json-patch.ts#L9)*
 
 ___
 
@@ -57,4 +57,4 @@ ___
 
 *Inherited from [IJsonPatch](ijsonpatch.md).[value](ijsonpatch.md#optional-value)*
 
-*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:10](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/json-patch.ts#L10)*
+*Defined in [packages/mobx-state-tree/src/core/json-patch.ts:10](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/json-patch.ts#L10)*

--- a/docs/API/interfaces/iserializedactioncall.md
+++ b/docs/API/interfaces/iserializedactioncall.md
@@ -4,7 +4,7 @@ title: "ISerializedActionCall"
 sidebar_label: "ISerializedActionCall"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [ISerializedActionCall](iserializedactioncall.md)
+[mobx-state-tree - v5.0.0](../index.md) › [ISerializedActionCall](iserializedactioncall.md)
 
 ## Hierarchy
 
@@ -24,7 +24,7 @@ sidebar_label: "ISerializedActionCall"
 
 • **args**? : *any[]*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:33](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/on-action.ts#L33)*
+*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:33](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/on-action.ts#L33)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/on-action.ts#L31)*
+*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/on-action.ts#L31)*
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 • **path**? : *undefined | string*
 
-*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/middlewares/on-action.ts#L32)*
+*Defined in [packages/mobx-state-tree/src/middlewares/on-action.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/middlewares/on-action.ts#L32)*

--- a/docs/API/interfaces/isimpletype.md
+++ b/docs/API/interfaces/isimpletype.md
@@ -4,7 +4,7 @@ title: "ISimpleType"
 sidebar_label: "ISimpleType"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [ISimpleType](isimpletype.md)
+[mobx-state-tree - v5.0.0](../index.md) › [ISimpleType](isimpletype.md)
 
 A simple type, this is, a type where the instance and the snapshot representation are the same.
 
@@ -40,7 +40,7 @@ A simple type, this is, a type where the instance and the snapshot representatio
 
 *Inherited from [IType](itype.md).[identifierAttribute](itype.md#optional-identifierattribute)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L86)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L86)*
 
 Name of the identifier attribute or null if none.
 
@@ -52,7 +52,7 @@ ___
 
 *Inherited from [IType](itype.md).[name](itype.md#name)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:81](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L81)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:81](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L81)*
 
 Friendly type name.
 
@@ -64,7 +64,7 @@ Friendly type name.
 
 *Inherited from [IType](itype.md).[create](itype.md#create)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:93](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L93)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:93](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L93)*
 
 Creates an instance for the type given an snapshot input.
 
@@ -87,7 +87,7 @@ ___
 
 *Inherited from [IType](itype.md).[describe](itype.md#describe)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:115](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L115)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:115](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L115)*
 
 Gets the textual representation of the type as a string.
 
@@ -101,7 +101,7 @@ ___
 
 *Inherited from [IType](itype.md).[is](itype.md#is)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:101](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L101)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:101](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L101)*
 
 Checks if a given snapshot / instance is of the given type.
 
@@ -123,7 +123,7 @@ ___
 
 *Inherited from [IType](itype.md).[validate](itype.md#validate)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L110)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L110)*
 
 Run's the type's typechecker on the given value with the given validation context.
 

--- a/docs/API/interfaces/isnapshotprocessor.md
+++ b/docs/API/interfaces/isnapshotprocessor.md
@@ -4,7 +4,7 @@ title: "ISnapshotProcessor"
 sidebar_label: "ISnapshotProcessor"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [ISnapshotProcessor](isnapshotprocessor.md)
+[mobx-state-tree - v5.0.0](../index.md) › [ISnapshotProcessor](isnapshotprocessor.md)
 
 A type that has its snapshots processed.
 
@@ -44,7 +44,7 @@ A type that has its snapshots processed.
 
 *Inherited from [IType](itype.md).[identifierAttribute](itype.md#optional-identifierattribute)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L86)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L86)*
 
 Name of the identifier attribute or null if none.
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [IType](itype.md).[name](itype.md#name)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:81](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L81)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:81](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L81)*
 
 Friendly type name.
 
@@ -68,7 +68,7 @@ Friendly type name.
 
 *Inherited from [IType](itype.md).[create](itype.md#create)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:93](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L93)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:93](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L93)*
 
 Creates an instance for the type given an snapshot input.
 
@@ -91,7 +91,7 @@ ___
 
 *Inherited from [IType](itype.md).[describe](itype.md#describe)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:115](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L115)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:115](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L115)*
 
 Gets the textual representation of the type as a string.
 
@@ -105,7 +105,7 @@ ___
 
 *Inherited from [IType](itype.md).[is](itype.md#is)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:101](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L101)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:101](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L101)*
 
 Checks if a given snapshot / instance is of the given type.
 
@@ -127,7 +127,7 @@ ___
 
 *Inherited from [IType](itype.md).[validate](itype.md#validate)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L110)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L110)*
 
 Run's the type's typechecker on the given value with the given validation context.
 

--- a/docs/API/interfaces/isnapshotprocessors.md
+++ b/docs/API/interfaces/isnapshotprocessors.md
@@ -4,7 +4,7 @@ title: "ISnapshotProcessors"
 sidebar_label: "ISnapshotProcessors"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [ISnapshotProcessors](isnapshotprocessors.md)
+[mobx-state-tree - v5.0.0](../index.md) › [ISnapshotProcessors](isnapshotprocessors.md)
 
 Snapshot processors.
 
@@ -35,7 +35,7 @@ Snapshot processors.
 
 ▸ **postProcessor**(`snapshot`: S): *CustomS*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts:175](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts#L175)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts:179](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts#L179)*
 
 Function that transforms an output snapshot.
 
@@ -53,7 +53,7 @@ ___
 
 ▸ **preProcessor**(`snapshot`: CustomC): *C*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts:170](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts#L170)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts:174](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts#L174)*
 
 Function that transforms an input snapshot.
 

--- a/docs/API/interfaces/itype.md
+++ b/docs/API/interfaces/itype.md
@@ -4,7 +4,7 @@ title: "IType"
 sidebar_label: "IType"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IType](itype.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IType](itype.md)
 
 A type, either complex or simple.
 
@@ -50,7 +50,7 @@ A type, either complex or simple.
 
 • **identifierAttribute**? : *undefined | string*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L86)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:86](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L86)*
 
 Name of the identifier attribute or null if none.
 
@@ -60,7 +60,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:81](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L81)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:81](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L81)*
 
 Friendly type name.
 
@@ -70,7 +70,7 @@ Friendly type name.
 
 ▸ **create**(`snapshot?`: [C](undefined), `env?`: any): *this["Type"]*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:93](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L93)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:93](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L93)*
 
 Creates an instance for the type given an snapshot input.
 
@@ -91,7 +91,7 @@ ___
 
 ▸ **describe**(): *string*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:115](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L115)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:115](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L115)*
 
 Gets the textual representation of the type as a string.
 
@@ -103,7 +103,7 @@ ___
 
 ▸ **is**(`thing`: any): *thing is C | this["Type"]*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:101](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L101)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:101](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L101)*
 
 Checks if a given snapshot / instance is of the given type.
 
@@ -123,7 +123,7 @@ ___
 
 ▸ **validate**(`thing`: C, `context`: [IValidationContext](../index.md#ivalidationcontext)): *[IValidationResult](../index.md#ivalidationresult)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type.ts#L110)*
+*Defined in [packages/mobx-state-tree/src/core/type/type.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type.ts#L110)*
 
 Run's the type's typechecker on the given value with the given validation context.
 

--- a/docs/API/interfaces/ivalidationcontextentry.md
+++ b/docs/API/interfaces/ivalidationcontextentry.md
@@ -4,7 +4,7 @@ title: "IValidationContextEntry"
 sidebar_label: "IValidationContextEntry"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IValidationContextEntry](ivalidationcontextentry.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IValidationContextEntry](ivalidationcontextentry.md)
 
 Validation context entry, this is, where the validation should run against which type
 
@@ -25,7 +25,7 @@ Validation context entry, this is, where the validation should run against which
 
 • **path**: *string*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type-checker.ts#L17)*
+*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type-checker.ts#L17)*
 
 Subpath where the validation should be run, or an empty string to validate it all
 
@@ -35,6 +35,6 @@ ___
 
 • **type**: *[IAnyType](ianytype.md)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:19](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type-checker.ts#L19)*
+*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:19](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type-checker.ts#L19)*
 
 Type to validate the subpath against

--- a/docs/API/interfaces/ivalidationerror.md
+++ b/docs/API/interfaces/ivalidationerror.md
@@ -4,7 +4,7 @@ title: "IValidationError"
 sidebar_label: "IValidationError"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [IValidationError](ivalidationerror.md)
+[mobx-state-tree - v5.0.0](../index.md) › [IValidationError](ivalidationerror.md)
 
 Type validation error
 
@@ -26,7 +26,7 @@ Type validation error
 
 • **context**: *[IValidationContext](../index.md#ivalidationcontext)*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:28](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type-checker.ts#L28)*
+*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:28](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type-checker.ts#L28)*
 
 Validation context
 
@@ -36,7 +36,7 @@ ___
 
 • **message**? : *undefined | string*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type-checker.ts#L32)*
+*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type-checker.ts#L32)*
 
 Error message
 
@@ -46,6 +46,6 @@ ___
 
 • **value**: *any*
 
-*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:30](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/core/type/type-checker.ts#L30)*
+*Defined in [packages/mobx-state-tree/src/core/type/type-checker.ts:30](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/core/type/type-checker.ts#L30)*
 
 Value that was being validated, either a snapshot or an instance

--- a/docs/API/interfaces/referenceoptionsgetset.md
+++ b/docs/API/interfaces/referenceoptionsgetset.md
@@ -4,7 +4,7 @@ title: "ReferenceOptionsGetSet"
 sidebar_label: "ReferenceOptionsGetSet"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [ReferenceOptionsGetSet](referenceoptionsgetset.md)
+[mobx-state-tree - v5.0.0](../index.md) › [ReferenceOptionsGetSet](referenceoptionsgetset.md)
 
 ## Type parameters
 
@@ -27,7 +27,7 @@ sidebar_label: "ReferenceOptionsGetSet"
 
 ▸ **get**(`identifier`: [ReferenceIdentifier](../index.md#referenceidentifier), `parent`: IAnyStateTreeNode | null): *ReferenceT‹IT›*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:464](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/reference.ts#L464)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:464](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/reference.ts#L464)*
 
 **Parameters:**
 
@@ -44,7 +44,7 @@ ___
 
 ▸ **set**(`value`: ReferenceT‹IT›, `parent`: IAnyStateTreeNode | null): *[ReferenceIdentifier](../index.md#referenceidentifier)*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:465](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/reference.ts#L465)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:465](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/reference.ts#L465)*
 
 **Parameters:**
 

--- a/docs/API/interfaces/referenceoptionsoninvalidated.md
+++ b/docs/API/interfaces/referenceoptionsoninvalidated.md
@@ -4,7 +4,7 @@ title: "ReferenceOptionsOnInvalidated"
 sidebar_label: "ReferenceOptionsOnInvalidated"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [ReferenceOptionsOnInvalidated](referenceoptionsoninvalidated.md)
+[mobx-state-tree - v5.0.0](../index.md) › [ReferenceOptionsOnInvalidated](referenceoptionsoninvalidated.md)
 
 ## Type parameters
 
@@ -26,4 +26,4 @@ sidebar_label: "ReferenceOptionsOnInvalidated"
 
 • **onInvalidated**: *[OnReferenceInvalidated](../index.md#onreferenceinvalidated)‹ReferenceT‹IT››*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:470](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/reference.ts#L470)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:470](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/reference.ts#L470)*

--- a/docs/API/interfaces/unionoptions.md
+++ b/docs/API/interfaces/unionoptions.md
@@ -4,7 +4,7 @@ title: "UnionOptions"
 sidebar_label: "UnionOptions"
 ---
 
-[mobx-state-tree - v4.0.2](../index.md) › [UnionOptions](unionoptions.md)
+[mobx-state-tree - v5.0.0](../index.md) › [UnionOptions](unionoptions.md)
 
 ## Hierarchy
 
@@ -23,7 +23,7 @@ sidebar_label: "UnionOptions"
 
 • **dispatcher**? : *[ITypeDispatcher](../index.md#itypedispatcher)*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L31)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L31)*
 
 ___
 
@@ -31,4 +31,4 @@ ___
 
 • **eager**? : *undefined | false | true*
 
-*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:30](https://github.com/mobxjs/mobx-state-tree/blob/3e60f786/packages/mobx-state-tree/src/types/utility-types/union.ts#L30)*
+*Defined in [packages/mobx-state-tree/src/types/utility-types/union.ts:30](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/union.ts#L30)*

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -9,7 +9,7 @@
         "title": "API_header"
       },
       "API/index": {
-        "title": "mobx-state-tree - v4.0.2",
+        "title": "mobx-state-tree - v5.0.0",
         "sidebar_label": "Globals"
       },
       "API/interfaces/customtypeoptions": {


### PR DESCRIPTION
This updates the docs (using `yarn build-docs`) for the 5.0.0 changes. Note this has already been deployed to the website, so I'm just catching up the repo to the website.