### PR TITLE
update ref link to docs page

### DIFF
--- a/docs/API/index.md
+++ b/docs/API/index.md
@@ -3992,7 +3992,7 @@ ___
 *Defined in [packages/mobx-state-tree/src/types/utility-types/reference.ts:486](https://github.com/mobxjs/mobx-state-tree/blob/48395a9d/packages/mobx-state-tree/src/types/utility-types/reference.ts#L486)*
 
 `types.reference` - Creates a reference to another type, which should have defined an identifier.
-See also the [reference and identifiers](https://github.com/mobxjs/mobx-state-tree#references-and-identifiers) section.
+See also the [reference and identifiers](https://mobx-state-tree.js.org/concepts/references) section. 
 
 **Type parameters:**
 


### PR DESCRIPTION
The "reference and identifiers" link from the API/#reference section is now pointing to /concepts/references (was sending users to the repo page)