### PR TITLE
mobx 6.1.0 compatibility

### DIFF
--- a/packages/mobx-state-tree/package.json
+++ b/packages/mobx-state-tree/package.json
@@ -56,7 +56,7 @@
         "jest": "^26.1.0",
         "jest-junit": "^11.0.1",
         "lerna": "^3.13.1",
-        "mobx": "^6.0.4",
+        "mobx": "^6.1.0",
         "rollup": "^2.18.1",
         "rollup-plugin-commonjs": "^10.0.0",
         "rollup-plugin-filesize": "^9.0.1",
@@ -75,7 +75,7 @@
         "typescript": "^3.5.3"
     },
     "peerDependencies": {
-        "mobx": "^6.0.0"
+        "mobx": "^6.1.0"
     },
     "keywords": [
         "mobx",

--- a/packages/mobx-state-tree/src/core/node/scalar-node.ts
+++ b/packages/mobx-state-tree/src/core/node/scalar-node.ts
@@ -8,7 +8,7 @@ import {
     SimpleType,
     devMode
 } from "../../internal"
-import { action, makeObservable } from "mobx"
+import { action } from "mobx"
 
 /**
  * @internal
@@ -31,8 +31,6 @@ export class ScalarNode<C, S, T> extends BaseNode<C, S, T> {
         initialSnapshot: C
     ) {
         super(simpleType, parent, subpath, environment)
-        makeObservable(this)
-
         try {
             this.storedValue = simpleType.createNewInstance(initialSnapshot)
         } catch (e) {
@@ -95,7 +93,6 @@ export class ScalarNode<C, S, T> extends BaseNode<C, S, T> {
         return `${this.type.name}@${path}${this.isAlive ? "" : " [dead]"}`
     }
 
-    @action
     die(): void {
         if (!this.isAlive || this.state === NodeLifeCycle.DETACHING) return
         this.aboutToDie()
@@ -118,3 +115,4 @@ export class ScalarNode<C, S, T> extends BaseNode<C, S, T> {
         this.fireInternalHook(name)
     }
 }
+ScalarNode.prototype.die = action(ScalarNode.prototype.die)

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -1,4 +1,4 @@
-import { action, makeObservable } from "mobx"
+import { action } from "mobx"
 
 import {
     fail,
@@ -292,11 +292,9 @@ export abstract class BaseType<C, S, T, N extends BaseNode<any, any, any> = Base
     readonly name: string
 
     constructor(name: string) {
-        makeObservable(this)
         this.name = name
     }
 
-    @action
     create(snapshot?: C, environment?: any) {
         typecheckInternal(this, snapshot)
         return this.instantiate(null, "", environment, snapshot!).value
@@ -396,7 +394,6 @@ export abstract class ComplexType<C, S, T> extends BaseType<C, S, T, ObjectNode<
         super(name)
     }
 
-    @action
     create(snapshot: C = this.getDefaultSnapshot(), environment?: any) {
         return super.create(snapshot, environment)
     }
@@ -476,6 +473,7 @@ export abstract class ComplexType<C, S, T> extends BaseType<C, S, T, ObjectNode<
         return null
     }
 }
+ComplexType.prototype.create = action(ComplexType.prototype.create)
 
 /**
  * @internal
@@ -520,6 +518,7 @@ export abstract class SimpleType<C, S, T> extends BaseType<C, S, T, ScalarNode<C
         return null
     }
 }
+BaseType.prototype.create = action(BaseType.prototype.create)
 
 /**
  * Returns if a given value represents a type.

--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -366,6 +366,7 @@ export abstract class BaseType<C, S, T, N extends BaseNode<any, any, any> = Base
 
     abstract getSubTypes(): IAnyType[] | IAnyType | null | typeof cannotDetermineSubtype
 }
+BaseType.prototype.create = action(BaseType.prototype.create)
 
 /**
  * @internal
@@ -518,7 +519,6 @@ export abstract class SimpleType<C, S, T> extends BaseType<C, S, T, ScalarNode<C
         return null
     }
 }
-BaseType.prototype.create = action(BaseType.prototype.create)
 
 /**
  * Returns if a given value represents a type.

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -8,8 +8,7 @@ import {
     intercept,
     IObservableArray,
     observable,
-    observe,
-    makeObservable
+    observe
 } from "mobx"
 import {
     addHiddenFinalProp,
@@ -94,7 +93,6 @@ export class ArrayType<IT extends IAnyType> extends ComplexType<
         hookInitializers: Array<IHooksGetter<IMSTArray<IT>>> = []
     ) {
         super(name)
-        makeObservable(this)
         this.hookInitializers = hookInitializers
     }
 
@@ -279,7 +277,6 @@ export class ArrayType<IT extends IAnyType> extends ComplexType<
         }
     }
 
-    @action
     applySnapshot(node: this["N"], snapshot: this["C"]): void {
         typecheckInternal(this, snapshot)
         const target = node.storedValue
@@ -310,6 +307,7 @@ export class ArrayType<IT extends IAnyType> extends ComplexType<
         node.storedValue.splice(Number(subpath), 1)
     }
 }
+ArrayType.prototype.applySnapshot = action(ArrayType.prototype.applySnapshot)
 
 /**
  * `types.array` - Creates an index based collection type who's children are all of a uniform declared type.

--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -10,8 +10,7 @@ import {
     observable,
     ObservableMap,
     observe,
-    values,
-    makeObservable
+    values
 } from "mobx"
 import {
     ComplexType,
@@ -236,7 +235,6 @@ export class MapType<IT extends IAnyType> extends ComplexType<
         super(name)
         this._determineIdentifierMode()
         this.hookInitializers = hookInitializers
-        makeObservable(this)
     }
 
     hooks(hooks: IHooksGetter<IMSTMap<IT>>) {
@@ -444,7 +442,6 @@ export class MapType<IT extends IAnyType> extends ComplexType<
         }
     }
 
-    @action
     applySnapshot(node: this["N"], snapshot: this["C"]): void {
         typecheckInternal(this, snapshot)
         const target = node.storedValue
@@ -488,6 +485,7 @@ export class MapType<IT extends IAnyType> extends ComplexType<
         node.storedValue.delete(subpath)
     }
 }
+MapType.prototype.applySnapshot = action(MapType.prototype.applySnapshot)
 
 /**
  * `types.map` - Creates a key based collection type who's children are all of a uniform declared type.

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -11,8 +11,7 @@ import {
     observe,
     set,
     IObjectDidChange,
-    makeObservable,
-    extendObservable
+    makeObservable
 } from "mobx"
 import {
     addHiddenFinalProp,
@@ -345,7 +344,6 @@ export class ModelType<
 
     constructor(opts: ModelTypeConfig) {
         super(opts.name || defaultObjectOptions.name)
-        makeObservable(this)
         Object.assign(this, defaultObjectOptions, opts)
         // ensures that any default value gets converted to its related type
         this.properties = toPropertiesObject(this.properties) as PROPS
@@ -673,7 +671,6 @@ export class ModelType<
         ;(node.storedValue as any)[subpath] = patch.value
     }
 
-    @action
     applySnapshot(node: this["N"], snapshot: this["C"]): void {
         const preProcessedSnapshot = this.applySnapshotPreProcessor(snapshot)
         typecheckInternal(this, preProcessedSnapshot)
@@ -739,6 +736,7 @@ export class ModelType<
         ;(node.storedValue as any)[subpath] = undefined
     }
 }
+ModelType.prototype.applySnapshot = action(ModelType.prototype.applySnapshot)
 
 export function model<P extends ModelPropertiesDeclaration = {}>(
     name: string,

--- a/packages/mobx-state-tree/src/utils.ts
+++ b/packages/mobx-state-tree/src/utils.ts
@@ -353,15 +353,6 @@ export function argsToArray(args: IArguments): any[] {
  * @internal
  * @hidden
  */
-export function invalidateComputed(target: any, propName: string) {
-    const atom = getAtom(target, propName) as any
-    atom.trackAndCompute()
-}
-
-/**
- * @internal
- * @hidden
- */
 export function stringStartsWith(str: string, beginning: string) {
     return str.indexOf(beginning) === 0
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6852,6 +6852,11 @@ mobx@^6.0.4:
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.0.4.tgz#8fc3e3629a3346f8afddf5bd954411974744dad1"
   integrity sha512-wT2QJT9tW19VSHo9x7RPKU3z/I2Ps6wUS8Kb1OO+kzmg7UY3n4AkcaYG6jq95Lp1R9ohjC/NGYuT2PtuvBjhFg==
 
+mobx@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.1.0.tgz#4a50d151c7396abc7058db8f4153ef866fb7d6b4"
+  integrity sha512-AU3z1oIep0wu7BdFFjd/0e0K1SGVcXi0TX8GPKKCkdnQEjJ3w/PgOct63Yk7V0/di/bnxb8+UehWC/Lld+MmeA==
+
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"


### PR DESCRIPTION
Fixes #1653

Replaced `makeObservable` by manual creation of actions/computed - a bit inconvinient DX wise, but it should perform a lot better.