### PR TITLE
Warn against using spread syntax with React

### DIFF
--- a/docs/concepts/react.md
+++ b/docs/concepts/react.md
@@ -14,8 +14,13 @@ title: React and MST
     <a style="font-style:italic;padding:5px;margin:5px;"  href="https://egghead.io/lessons/react-render-mobx-state-tree-models-in-react">Hosted on egghead.io</a>
 </details>
 
-Can I use React and MST together?
+### Can I use React and MST together?
+
 Yep, that works perfectly fine, everything that applies to MobX and React applies to MST and React as well.  `observer`, `autorun`, etc. will work as expected.
 To share MST trees between components we recommend to use `React.createContext`.
 
 In the examples folder several examples of React and MST can be found, or check this [example](https://github.com/impulse/react-hooks-mobx-state-tree) which uses hooks (recommended).
+
+### Tips
+
+When passing models in to a component **do not** use the spread syntax, e.g. `<Component foo={bar} {...model}>`. See [here](https://github.com/mobxjs/mobx-state-tree/issues/726).


### PR DESCRIPTION
This caught me out too, it's a not uncommon pattern in React, so it's worth calling it out for anyone reading the docs.
https://github.com/mobxjs/mobx-state-tree/issues/726