### PR TITLE
docs: update links to Mobx documentation

### DIFF
--- a/docs/API/index.md
+++ b/docs/API/index.md
@@ -730,7 +730,7 @@ ___
 
 `types.array` - Creates an index based collection type who's children are all of a uniform declared type.
 
-This type will always produce [observable arrays](https://mobx.js.org/refguide/array.html)
+This type will always produce [observable arrays](https://mobx.js.org/api.html#observablearray)
 
 Example:
 ```ts
@@ -3523,7 +3523,7 @@ ___
 `types.map` - Creates a key based collection type who's children are all of a uniform declared type.
 If the type stored in a map has an identifier, it is mandatory to store the child under that identifier in the map.
 
-This type will always produce [observable maps](https://mobx.js.org/refguide/map.html)
+This type will always produce [observable maps](https://mobx.js.org/api.html#observablemap)
 
 Example:
 ```ts

--- a/docs/concepts/trees.md
+++ b/docs/concepts/trees.md
@@ -83,7 +83,7 @@ The _properties_ argument is a key-value set where each key indicates the introd
 
 1.  A type. This can be a simple primitive type like `types.boolean`, see `// 2`, or a complex, possibly pre-defined type (`// 4`)
 2.  A primitive. Using a primitive as type is syntactic sugar for introducing a property with a default value. See `// 3`, `endpoint: "http://localhost"` is the same as `endpoint: types.optional(types.string, "http://localhost")`. The primitive type is inferred from the default value. Properties with a default value can be omitted in snapshots.
-3.  A [computed property](https://mobx.js.org/refguide/computed-decorator.html), see `// 6`. Computed properties are tracked and memoized by MobX. Computed properties will not be stored in snapshots or emit patch events. It is possible to provide a setter for a computed property as well. A setter should always invoke an action.
+3.  A [computed property](https://mobx.js.org/computeds.html), see `// 6`. Computed properties are tracked and memoized by MobX. Computed properties will not be stored in snapshots or emit patch events. It is possible to provide a setter for a computed property as well. A setter should always invoke an action.
 4.  A view function (see `// 7`). A view function can, unlike computed properties, take arbitrary arguments. It won't be memoized, but its value can be tracked by MobX nonetheless. View functions are not allowed to change the model, but should rather be used to retrieve information from the model.
 
 _Tip: `(self) => ({ action1() { }, action2() { }})` is ES6 syntax for `function (self) { return { action1: function() { }, action2: function() { } }}`. In other words, it's short way of directly returning an object literal.

--- a/docs/concepts/views.md
+++ b/docs/concepts/views.md
@@ -15,9 +15,9 @@ title: Derived values
 </details>
 
 Any fact that can be derived from your state is called a "view" or "derivation".
-See the [Mobx concepts & principles](https://mobx.js.org/intro/concepts.html) for some background.
+See [The gist of MobX](https://mobx.js.org/the-gist-of-mobx.html) for some background.
 
-Views come in two flavors: views with arguments and views without arguments. The latter are called computed values, based on the [computed](https://mobx.js.org/refguide/computed-decorator.html) concept in MobX. The main difference between the two is that computed properties create an explicit caching point, but later they work the same and any other computed value or MobX based reaction like [`@observer`](https://mobx.js.org/refguide/observer-component.html) components can react to them. Computed values are defined using _getter_ functions.
+Views come in two flavors: views with arguments and views without arguments. The latter are called computed values, based on the [computed](https://mobx.js.org/computeds.html) concept in MobX. The main difference between the two is that computed properties create an explicit caching point, but later they work the same and any other computed value or MobX based reaction like [`@observer`](https://mobx.js.org/react-integration.html) components can react to them. Computed values are defined using _getter_ functions.
 
 Example:
 

--- a/docs/concepts/volatiles.md
+++ b/docs/concepts/volatiles.md
@@ -129,7 +129,7 @@ const Todo = types
 The object that is returned from the `volatile` initializer function can contain any piece of data and will result in an instance property with the same name. Volatile properties have the following characteristics:
 
 1.  They can be read from outside the model (if you want hidden volatile state, keep the state in your closure as shown in the previous section, and _only_ if it is not used on a view consider not making it observable)
-2.  The volatile properties will be only observable, see [observable _references_](https://mobx.js.org/refguide/modifiers.html). Values assigned to them will be unmodified and not automatically converted to deep observable structures.
+2.  The volatile properties will be only observable, see [observable _references_](https://mobx.js.org/api.html#observableref). Values assigned to them will be unmodified and not automatically converted to deep observable structures.
 3.  Like normal properties, they can only be modified through actions
 4.  Volatile props will not show up in snapshots, and cannot be updated by applying snapshots
 5.  Volatile props are preserved during the lifecycle of an instance. See also [reconciliation](reconciliation)

--- a/docs/intro/philosophy.md
+++ b/docs/intro/philosophy.md
@@ -77,7 +77,7 @@ Simply subscribing to the patch stream of a tree is another way to sync diffs wi
 
 ![patches](/img/patches.png)
 
-Since MST uses MobX behind the scenes, it integrates seamlessly with [mobx](https://mobx.js.org) and [mobx-react](https://github.com/mobxjs/mobx-react). See also this [egghead.io lesson: Render mobx-state-tree Models in React](https://egghead.io/lessons/react-render-mobx-state-tree-models-in-react).
+Since MST uses MobX behind the scenes, it integrates seamlessly with [mobx](https://mobx.js.org) and [mobx-react-lite (or mobx-react)](https://mobx.js.org/react-integration.html). See also this [egghead.io lesson: Render mobx-state-tree Models in React](https://egghead.io/lessons/react-render-mobx-state-tree-models-in-react).
 Even cooler, because it supports snapshots, middleware and replayable actions out of the box, it is possible to replace a Redux store and reducer with a MobX state tree.
 This makes it possible to connect the Redux devtools to MST. See the [Redux / MST TodoMVC example](https://github.com/mobxjs/mobx-state-tree/blob/1906a394906d2e8f2cc1c778e1e3228307c1b112/packages/mst-example-redux-todomvc/src/index.js#L6).
 

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -312,7 +312,7 @@ ArrayType.prototype.applySnapshot = action(ArrayType.prototype.applySnapshot)
 /**
  * `types.array` - Creates an index based collection type who's children are all of a uniform declared type.
  *
- * This type will always produce [observable arrays](https://mobx.js.org/refguide/array.html)
+ * This type will always produce [observable arrays](https://mobx.js.org/api.html#observablearray)
  *
  * Example:
  * ```ts

--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -491,7 +491,7 @@ MapType.prototype.applySnapshot = action(MapType.prototype.applySnapshot)
  * `types.map` - Creates a key based collection type who's children are all of a uniform declared type.
  * If the type stored in a map has an identifier, it is mandatory to store the child under that identifier in the map.
  *
- * This type will always produce [observable maps](https://mobx.js.org/refguide/map.html)
+ * This type will always produce [observable maps](https://mobx.js.org/api.html#observablemap)
  *
  * Example:
  * ```ts


### PR DESCRIPTION
The mobx documentation website has changed dramatically since the release of v6. Almost every page of the old website has turned into a "Not Found" error page.

The MST documentation has several references to mobx website which are now broken.

This PR fixes them.