### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/intro/getting-started.md
+++ b/docs/intro/getting-started.md
@@ -34,7 +34,7 @@ npx create-react-app mst-todo
 Next install `mobx`, `mobx-react-lite` and `mobx-state-tree` dependencies.
 
 ```
-yarn add mobx@5.15.7 mobx-react-lite@2.2.2 mobx-state-tree
+yarn add mobx mobx-react-lite mobx-state-tree
 ```
 
 Now you can run `npm run start` and a basic React page will show up. You're all set up and can begin editing the project files!


### PR DESCRIPTION
Unpin mobx and mobx-react-lite version from getting started example

Using what was documented, caused an error:

```
./node_modules/mobx-state-tree/dist/mobx-state-tree.module.js
Attempted import error: 'makeObservable' is not exported from 'mobx'
```

![image](https://user-images.githubusercontent.com/590297/114317810-e379f980-9ad7-11eb-94dc-50a768d4e789.png)
