### PR TITLE
Confusing wording on getTodosWhereDoneIs notice in getting-started

### DIFF
--- a/docs/intro/getting-started.md
+++ b/docs/intro/getting-started.md
@@ -464,7 +464,7 @@ const RootStore = types
 
 [View sample in the playground](https://codesandbox.io/s/x293k4q95o)
 
-Notice that the `getTodosWhereDoneIs` view can also be used outside of its model, for example it can be used inside views.
+Notice that other views and View components may call `getTodosWhereDoneIs` outside of the store definition.
 
 ## Going further: References
 


### PR DESCRIPTION
Currently on:

https://mobx-state-tree.js.org/intro/getting-started#model-views

> Notice that the getTodosWhereDoneIs view can also be used outside of its model, for example it can be used inside views.

Doesn't make sense to me. Is it trying to say that the view function can be called within other views and View components? Does this mean the get pendingCount() and get completedCount cannot be called in other views?