### PR TITLE
Fix code example for simulated inheritance

### DIFF
--- a/docs/tips/inheritance.md
+++ b/docs/tips/inheritance.md
@@ -17,6 +17,7 @@ const Square = types
         }
     )
     .views(self => ({
+        // note: this is not a getter! this is just a function that is evaluated
         surface() {
             return self.width * self.width
         }
@@ -26,7 +27,9 @@ const Square = types
 const Box = Square
     .named("Box")
     .views(self => {
-        // save the base implementation of surface
+        // save the base implementation of surface, again, this is a function.
+        // if it was a getter, the getter would be evaluated only once here
+        // instead of being able to evaluate dynamically at time-of-use
         const superSurface = self.surface
 
         return {

--- a/docs/tips/inheritance.md
+++ b/docs/tips/inheritance.md
@@ -6,7 +6,6 @@ title: Simulate inheritance by using type composition
 
 <div id="codefund"></div>
 
-
 There is no notion of inheritance in MST. The recommended approach is to keep references to the original configuration of a model in order to compose it into a new one, for example by using `types.compose` (which combines two types) or producing fresh types using `.props|.views|.actions`. An example of classical inheritance could be expressed using composition as follows:
 
 ```javascript
@@ -36,19 +35,24 @@ const Box = Square
                 return superSurface() * 1
             },
             volume() {
-                return self.surface * self.width
+                return self.surface() * self.width
             }
         }
     }))
 
 // no inheritance, but, union types and code reuse
 const Shape = types.union(Box, Square)
+
+const instance = Shape.create({type:"Box",width:4})
+console.log(instance.width)
+console.log(instance.surface()) // calls Box.surface()
+console.log(instance.volume()) // calls Box.volume()
 ```
 
 Similarly, compose can be used to simply mix in types:
 
 ```javascript
-const CreationLogger = types.model().actions(self => ({
+const CreationLogger = types.model().actions((self) => ({
     afterCreate() {
         console.log("Instantiated " + getType(self).name)
     }
@@ -58,7 +62,7 @@ const BaseSquare = types
     .model({
         width: types.number
     })
-    .views(self => ({
+    .views((self) => ({
         surface() {
             return self.width * self.width
         }


### PR DESCRIPTION
Hi there!
I saw that potentially the example for doing simulated inheritance was wrong, and doesn't have a parentheses to call the self.surface function

This was also just maybe worth clarifying via some comments to be clear that self.surface and superSurface are functions that need calling instead of being getters

When currently run, the volume returns NaN, so this fixes it (returns 64 if width is 4)
