### PR TITLE
docs: Add link to mst-query

### DIFF
--- a/docs/tips/resources.md
+++ b/docs/tips/resources.md
@@ -37,3 +37,7 @@ title: Talks & Blogs
 - [Reactotron](https://github.com/infinitered/reactotron)
 - [MobX DevTools](https://chrome.google.com/webstore/detail/mobx-developer-tools/pfgnfdagidkfgccljigdamigbcnndkod)
 - The Redux can be connected as well as demonstrated [here](https://github.com/mobxjs/mobx-state-tree/blob/1906a394906d2e8f2cc1c778e1e3228307c1b112/packages/mst-example-redux-todomvc/src/index.js#L6)
+
+## Addons, libraries and tools
+
+- [mst-query](https://github.com/ConrabOpto/mst-query/)

--- a/docs/tips/resources.md
+++ b/docs/tips/resources.md
@@ -40,4 +40,4 @@ title: Talks & Blogs
 
 ## Addons, libraries and tools
 
-- [mst-query](https://github.com/ConrabOpto/mst-query/)
+- [mst-query](https://github.com/ConrabOpto/mst-query/) - Query library for MST with support for auto normalization, garbage collection, infinite scroll & pagination, and more


### PR DESCRIPTION
@jamonholmgren suggested I add a link to mst-query (a query library for mobx-state-tree) to the docs. I didn't see any lists for addons or libraries so I added one in the resources file.