### PR TITLE
#1666: remove dropped mobx methods from map interface

### DIFF
--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -93,19 +93,7 @@ export interface IMSTMap<IT extends IAnyType> {
             | any
     ): this
 
-    /**
-     * Returns a plain object that represents this map.
-     * Note that all the keys being stringified.
-     * If there are duplicating keys after converting them to strings, behaviour is undetermined.
-     */
-    toPOJO(): IKeyValueMap<IT["SnapshotType"]>
     toJSON(): IKeyValueMap<IT["SnapshotType"]>
-
-    /**
-     * Returns a shallow non observable object clone of this map.
-     * Note that the values might still be observable. For a deep clone use mobx.toJS.
-     */
-    toJS(): Map<string, IT["Type"]>
 
     toString(): string
     [Symbol.toStringTag]: "Map"


### PR DESCRIPTION
#1666: remove dropped mobx methods from map interface

The [MobX Changelogs](https://github.com/mobxjs/mobx/blob/8a1c5ba2cdaaaba4005f34dc45c5ae8fc80a6121/packages/mobx/CHANGELOG.md#600) state that those methods have been dropped in v6.0