### PR TITLE
NOTE: This is not a bot. This change was made by and comments will be…

### DIFF
--- a/packages/mst-example-bookshop/package.json
+++ b/packages/mst-example-bookshop/package.json
@@ -24,6 +24,11 @@
     "test": "react-scripts test",
     "prepare": "relative-deps"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mobxjs/mobx-state-tree.git",
+    "directory": "packages/mst-example-bookshop"
+  },
   "browserslist": [
     ">0.2%",
     "not dead",

--- a/packages/mst-example-redux-todomvc/package.json
+++ b/packages/mst-example-redux-todomvc/package.json
@@ -28,6 +28,11 @@
     "test": "react-scripts test",
     "prepare": "relative-deps"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mobxjs/mobx-state-tree.git",
+    "directory": "packages/mst-example-redux-todomvc"
+  },
   "browserslist": [
     ">0.2%",
     "not dead",

--- a/packages/mst-example-todomvc/package.json
+++ b/packages/mst-example-todomvc/package.json
@@ -24,6 +24,11 @@
         "eject": "react-scripts eject",
         "test": "react-scripts test"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/mobxjs/mobx-state-tree.git",
+        "directory": "packages/mst-example-todomvc"
+    },
     "browserslist": [
         ">0.2%",
         "not dead",

--- a/packages/mst-middlewares/package.json
+++ b/packages/mst-middlewares/package.json
@@ -29,6 +29,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/mobxjs/mobx-state-tree.git",
+        "directory": "packages/mst-middlewares"
+    },
     "devDependencies": {
         "@types/jest": "^26.0.3",
         "@types/node": "^12.0.2",


### PR DESCRIPTION
… reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR.

Published NPM packages with repository information:
• mst-middlewares
• mst-example-todomvc
• mst-example-redux-todomvc
• mst-example-bookshop