### PR TITLE
Fix array reconciliation with snapshotPreprocessor

### DIFF
--- a/packages/mobx-state-tree/src/core/type/type.ts
+++ b/packages/mobx-state-tree/src/core/type/type.ts
@@ -419,6 +419,14 @@ export abstract class ComplexType<C, S, T> extends BaseType<C, S, T, ObjectNode<
     abstract initializeChildNodes(node: this["N"], snapshot: any): IChildNodesMap
     abstract removeChild(node: this["N"], subpath: string): void
 
+    isMatchingSnapshotId(current: this["N"], snapshot: C): boolean {
+        return (
+            !current.identifierAttribute ||
+            current.identifier ===
+            normalizeIdentifier((snapshot as any)[current.identifierAttribute])
+        )
+    }
+
     private tryToReconcileNode(current: this["N"], newValue: C | T) {
         if (current.isDetaching) return false
         if ((current.snapshot as any) === newValue) {
@@ -433,9 +441,7 @@ export abstract class ComplexType<C, S, T> extends BaseType<C, S, T, ObjectNode<
             current.type === this &&
             isMutable(newValue) &&
             !isStateTreeNode(newValue) &&
-            (!current.identifierAttribute ||
-                current.identifier ===
-                    normalizeIdentifier((newValue as any)[current.identifierAttribute]))
+            this.isMatchingSnapshotId(current, newValue as any)
         ) {
             // the newValue has no node, so can be treated like a snapshot
             // we can reconcile

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -482,7 +482,7 @@ function areSame(oldNode: AnyNode, newValue: any) {
         oldNode.identifier !== null &&
         oldNode.identifierAttribute &&
         isPlainObject(newValue) &&
-        oldNode.identifier === normalizeIdentifier(newValue[oldNode.identifierAttribute]) &&
+        oldNode.type.isMatchingSnapshotId(oldNode, newValue) &&
         oldNode.type.is(newValue)
     )
 }

--- a/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
@@ -11,7 +11,8 @@ import {
     assertIsType,
     isType,
     getSnapshot,
-    devMode
+    devMode,
+    ComplexType
 } from "../../internal"
 
 /** @hidden */
@@ -69,7 +70,7 @@ class SnapshotProcessor<IT extends IAnyType, CustomC, CustomS> extends BaseType<
 
     private _fixNode(node: this["N"]): void {
         // the node has to use these methods rather than the original type ones
-        proxyNodeTypeMethods(node.type, this, "create")
+        proxyNodeTypeMethods(node.type, this, "create", "is", "isMatchingSnapshotId")
 
         const oldGetSnapshot = node.getSnapshot
         node.getSnapshot = () => {
@@ -139,6 +140,14 @@ class SnapshotProcessor<IT extends IAnyType, CustomC, CustomS> extends BaseType<
 
     isAssignableFrom(type: IAnyType): boolean {
         return this._subtype.isAssignableFrom(type)
+    }
+
+    isMatchingSnapshotId(current: this["N"], snapshot: this["C"]): boolean {
+        if (!(this._subtype instanceof ComplexType)) {
+            return false
+        }
+        const processedSn = this.preProcessSnapshot(snapshot)
+        return ComplexType.prototype.isMatchingSnapshotId.call(this._subtype, current as any, processedSn)
     }
 }
 


### PR DESCRIPTION
Adds an `isMatchingSnapshotId` method to `ComplexType`, to be used instead of manually comparing identifier values between an existing node and a new snapshot.

Overrides the `isMatchingSnapshotId` method with the `SnapshotProcessor` type to run the preprocessor before attempting to get the identifier value from the new snapshot.

Patches the `is` method on the sub-type of the snapshotProcessor so that the specified snapshot is preprocessed before validation.

Closes #1776