### PR TITLE
docs: make the maybe type description explicit about undefined being used to represent nullability

### DIFF
--- a/docs/overview/types.md
+++ b/docs/overview/types.md
@@ -49,7 +49,7 @@ Note that since MST v3 `types.array` and `types.map` are wrapped in `types.optio
 -   [`types.literal(value)`](/API/#literal) can be used to create a literal type, where the only possible value is specifically that value. This is very powerful in combination with `union`s. E.g. `temperature: types.union(types.literal("hot"), types.literal("cold"))`.
 -   [`types.enumeration(name?, options: string[])`](/API/#enumeration) creates an enumeration. This method is a shorthand for a union of string literals. If you are using typescript and want to create a type based on an string enum (e.g. `enum Color { ... }`) then use `types.enumeration<Color>("Color", Object.values(Color))`, where the `"Color"` name argument is optional.
 -   [`types.refinement(name?, baseType, (snapshot) => boolean)`](/API/#refinement) creates a type that is more specific than the base type, e.g. `types.refinement(types.string, value => value.length > 5)` to create a type of strings that can only be longer then 5.
--   [`types.maybe(type)`](/API/#maybe) makes a type optional and nullable, shorthand for `types.optional(types.union(type, types.literal(undefined)), undefined)`.
+-   [`types.maybe(type)`](/API/#maybe) makes a type optional and nullable. The value `undefined` will be used to represent nullability. Shorthand for `types.optional(types.union(type, types.literal(undefined)), undefined)`.
 -   [`types.maybeNull(type)`](/API/#maybeNull) like `maybe`, but uses `null` to represent the absence of a value.
 -   [`types.null`](/API/#const-nulltype) the type of `null`.
 -   [`types.undefined`](/API/#const-undefinedtype) the type of `undefined`.


### PR DESCRIPTION
I have added an explicit description to the `maybe` type about the value `undefined` being used to represent nullability, so it matches https://mobx-state-tree.js.org/API/index#maybe and the typescript definitions.