### PR TITLE
Fix union reconciliation with snapshotPreprocessor

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/union.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/union.test.ts
@@ -6,8 +6,11 @@ import {
     getSnapshot,
     applySnapshot,
     getType,
-    setLivelinessChecking
+    setLivelinessChecking,
+    SnapshotIn,
+    Instance
 } from "../../src"
+import { snapshotProcessor } from "../../src/internal"
 
 const createTestFactories = () => {
     const Box = types.model("Box", {
@@ -181,20 +184,45 @@ test("961 - apply snapshot to union should not throw when union keeps models wit
 })
 
 describe("1045 - secondary union types with applySnapshot and ids", () => {
-    function initTest(useCreate: boolean, submodel1First: boolean, type: number) {
+    function initTest(useSnapshot: boolean, useCreate: boolean, submodel1First: boolean, type: number) {
         setLivelinessChecking("error")
 
-        const Submodel1 = types.model("Submodel1", {
+        const Submodel1NoSP = types.model("Submodel1", {
             id: types.identifier,
             extraField1: types.string,
             extraField2: types.maybe(types.string)
         })
 
-        const Submodel2 = types.model("Submodel2", {
+        const Submodel1SP = types.snapshotProcessor(Submodel1NoSP, {
+            preProcessor(sn: SnapshotIn<Instance<typeof Submodel1NoSP>>) {
+                const { id, extraField1, extraField2 } = sn
+                return {
+                    id,
+                    extraField1: extraField1.toUpperCase(),
+                    extraField2: extraField2?.toUpperCase(),
+                }
+            }
+        })
+
+        const Submodel2NoSP = types.model("Submodel2", {
             id: types.identifier,
             extraField1: types.maybe(types.string),
             extraField2: types.string
         })
+
+        const Submodel2SP = types.snapshotProcessor(Submodel2NoSP, {
+            preProcessor(sn: SnapshotIn<Instance<typeof Submodel2NoSP>>) {
+                const { id, extraField1, extraField2 } = sn
+                return {
+                    id,
+                    extraField1: extraField1?.toUpperCase(),
+                    extraField2: extraField2.toUpperCase(),
+                }
+            }
+        })
+
+        const Submodel1 = useSnapshot ? Submodel1SP : Submodel1NoSP;
+        const Submodel2 = useSnapshot ? Submodel2SP : Submodel2NoSP;
 
         const Submodel = submodel1First
             ? types.union(Submodel1, Submodel2)
@@ -219,41 +247,47 @@ describe("1045 - secondary union types with applySnapshot and ids", () => {
                 }
                 const sn = type === 1 ? sn1 : sn2
                 const submodel = type === 1 ? Submodel1 : Submodel2
+                const expected =
+                    useSnapshot ? { id: sn.id, extraField1: sn.extraField1?.toUpperCase(), extraField2: sn.extraField2?.toUpperCase() } : sn;
 
                 applySnapshot(store, [useCreate ? (submodel as any).create(sn) : sn])
 
                 expect(store.length).toBe(1)
-                expect(store[0]).toEqual(sn)
-                expect(getType(store[0])).toBe(submodel)
+                expect(store[0]).toEqual(expected)
+                expect(getType(store[0])).toBe(useSnapshot ? submodel.getSubTypes() : submodel)
             }
         }
     }
 
-    for (const submodel1First of [true, false]) {
-        describe(submodel1First ? "submodel1 first" : "submodel2 first", () => {
-            for (const useCreate of [false, true]) {
-                describe(useCreate ? "using create" : "not using create", () => {
-                    for (const type of [2, 1]) {
-                        describe(`snapshot is of type Submodel${type}`, () => {
-                            it(`apply snapshot works when the node is not touched`, () => {
-                                configure({
-                                    useProxies: "never"
+    for (const useSnapshot of [false, true]) {
+        describe(useSnapshot ? "with snapshotProcessor" : "without snapshotProcessor", () => {
+            for (const submodel1First of [true, false]) {
+                describe(submodel1First ? "submodel1 first" : "submodel2 first", () => {
+                    for (const useCreate of [false, true]) {
+                        describe(useCreate ? "using create" : "not using create", () => {
+                            for (const type of [2, 1]) {
+                                describe(`snapshot is of type Submodel${type}`, () => {
+                                    it(`apply snapshot works when the node is not touched`, () => {
+                                        configure({
+                                            useProxies: "never"
+                                        })
+
+                                        const t = initTest(useSnapshot, useCreate, submodel1First, type)
+                                        t.applySn()
+                                    })
+
+                                    it(`apply snapshot works when the node is touched`, () => {
+                                        configure({
+                                            useProxies: "never"
+                                        })
+
+                                        const t = initTest(useSnapshot, useCreate, submodel1First, type)
+                                        // tslint:disable-next-line:no-unused-expression
+                                        t.store[0]
+                                        t.applySn()
+                                    })
                                 })
-
-                                const t = initTest(useCreate, submodel1First, type)
-                                t.applySn()
-                            })
-
-                            it(`apply snapshot works when the node is touched`, () => {
-                                configure({
-                                    useProxies: "never"
-                                })
-
-                                const t = initTest(useCreate, submodel1First, type)
-                                // tslint:disable-next-line:no-unused-expression
-                                t.store[0]
-                                t.applySn()
-                            })
+                            }
                         })
                     }
                 })

--- a/packages/mobx-state-tree/src/core/node/BaseNode.ts
+++ b/packages/mobx-state-tree/src/core/node/BaseNode.ts
@@ -92,6 +92,10 @@ export abstract class BaseNode<C, S, T> {
         this.baseSetParent(parent, subpath)
     }
 
+    getReconciliationType() {
+        return this.type;
+    }
+
     private pathAtom?: IAtom
     protected baseSetParent(parent: AnyObjectNode | null, subpath: string) {
         this._parent = parent

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -482,8 +482,8 @@ function areSame(oldNode: AnyNode, newValue: any) {
         oldNode.identifier !== null &&
         oldNode.identifierAttribute &&
         isPlainObject(newValue) &&
-        oldNode.type.isMatchingSnapshotId(oldNode, newValue) &&
-        oldNode.type.is(newValue)
+        oldNode.type.is(newValue) &&
+        oldNode.type.isMatchingSnapshotId(oldNode, newValue)
     )
 }
 

--- a/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
@@ -12,11 +12,15 @@ import {
     isType,
     getSnapshot,
     devMode,
-    ComplexType
+    ComplexType,
+    typeCheckFailure
 } from "../../internal"
 
 /** @hidden */
 declare const $mstNotCustomized: unique symbol
+
+/** @hidden */
+const $preProcessorFailed: unique symbol = Symbol("$preProcessorFailed")
 
 /** @hidden */
 // tslint:disable-next-line:class-name
@@ -61,6 +65,14 @@ class SnapshotProcessor<IT extends IAnyType, CustomC, CustomS> extends BaseType<
         return sn as any
     }
 
+    private preProcessSnapshotSafe(sn: this["C"]): IT["CreationType"] | typeof $preProcessorFailed {
+        try {
+            return this.preProcessSnapshot(sn);
+        } catch (e) {
+            return $preProcessorFailed;
+        }
+    }
+
     private postProcessSnapshot(sn: IT["SnapshotType"]): this["S"] {
         if (this._processors.postProcessor) {
             return this._processors.postProcessor.call(null, sn) as any
@@ -75,6 +87,10 @@ class SnapshotProcessor<IT extends IAnyType, CustomC, CustomS> extends BaseType<
         const oldGetSnapshot = node.getSnapshot
         node.getSnapshot = () => {
             return this.postProcessSnapshot(oldGetSnapshot.call(node)) as any
+        }
+
+        node.getReconciliationType = () => {
+            return this;
         }
     }
 
@@ -121,7 +137,14 @@ class SnapshotProcessor<IT extends IAnyType, CustomC, CustomS> extends BaseType<
     }
 
     isValidSnapshot(value: this["C"], context: IValidationContext): IValidationResult {
-        const processedSn = this.preProcessSnapshot(value)
+        const processedSn = this.preProcessSnapshotSafe(value);
+        if (processedSn === $preProcessorFailed) {
+            return typeCheckFailure(
+                context,
+                value,
+                "Failed to preprocess value"
+            )
+        }
         return this._subtype.validate(processedSn, context)
     }
 
@@ -134,7 +157,10 @@ class SnapshotProcessor<IT extends IAnyType, CustomC, CustomS> extends BaseType<
             ? this._subtype
             : isStateTreeNode(thing)
             ? getSnapshot(thing, false)
-            : this.preProcessSnapshot(thing)
+            : this.preProcessSnapshotSafe(thing)
+        if (value === $preProcessorFailed) {
+            return false
+        }
         return this._subtype.validate(value, [{ path: "", type: this._subtype }]).length === 0
     }
 

--- a/packages/mobx-state-tree/src/types/utility-types/union.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/union.ts
@@ -85,7 +85,7 @@ export class Union extends BaseType<any, any, any> {
         parent: AnyObjectNode,
         subpath: string
     ): this["N"] {
-        const type = this.determineType(newValue, current.type)
+        const type = this.determineType(newValue, current.getReconciliationType())
         if (!type) throw fail("No matching type for union " + this.describe()) // can happen in prod builds
         return type.reconcile(current, newValue, parent, subpath)
     }


### PR DESCRIPTION
Adds a `getReconcilationType` method to `BaseNode`, which returns the type which should be used for reconcilating the node. This is normally the node's `type`, but in the case of `snapshotProcessor` it is overridden to be the `snapshotProcessor` type. This is necessary so that the union type `reconcile` can correctly reconcile the "current" node first if it's possible. This fixes #1791.

Fixes the `snapshotProcessor` type's `isValidSnapshot` and `is` methods to return a validation error and not to throw if the specified preprocessor fails, which can happen when checking if an arbitrary snapshot is valid input (e.g. when determining a union type). We can't expect preprocessors to accept any arbitrary input, so we must assume they can throw when provided with invalid snapshots. This also fixes #1777.

Fixes the array's `areSame` utility to first check that the provided value is a valid snapshot before calling `isMatchingSnapshotId`, to avoid the preprocessor throwing an error if the provided snapshot is invalid.