### PR TITLE
Add includeHooks flag to UndoManager middleware

### DIFF
--- a/packages/mst-middlewares/README.md
+++ b/packages/mst-middlewares/README.md
@@ -296,6 +296,35 @@ export const setUndoManager = (targetStore) => {
 }
 ```
 
+If you want to record changes in lifecycle hooks as well, you must provide an `includeHooks` flag:
+
+```js
+import { UndoManager } from "mst-middlewares"
+
+export const Store = types
+    .model({
+        todos: types.array(Todo)
+    })
+    .actions((self) => {
+        setUndoManager(self)
+
+        return {
+            afterCreate() {
+                self.todos.push({ title: 'New Todo' })
+            },
+            addTodo(todo) {
+                self.todos.push(todo)
+            }
+        }
+    })
+
+export let undoManager = {}
+export const setUndoManager = (targetStore) => {
+    undoManager = UndoManager.create({}, { targetStore, includeHooks: true })
+}
+const store = Store.create()
+```
+
 Undo/ Redo:
 
 ```js

--- a/packages/mst-middlewares/src/undo-manager.ts
+++ b/packages/mst-middlewares/src/undo-manager.ts
@@ -41,6 +41,7 @@ const UndoManager = types
         }
     }))
     .actions((self) => {
+        let includeHooks = false
         let targetStore: IAnyStateTreeNode
         let recordingDisabled = 0
 
@@ -137,7 +138,12 @@ const UndoManager = types
                         "UndoManager should be created as part of a tree, or with `targetStore` in it's environment"
                     )
                 }
-                addDisposer(self, addMiddleware(targetStore, undoRedoMiddleware, false))
+
+                if (typeof getEnv(self).includeHooks === "boolean") {
+                    includeHooks = getEnv(self).includeHooks
+                }
+
+                addDisposer(self, addMiddleware(targetStore, undoRedoMiddleware, includeHooks))
             },
             undo: decorate(atomic, () => {
                 skipRecording(() => {


### PR DESCRIPTION
It adds the possibility to receive an `includeHooks` flag in the environment data so the UndoManager can record any changes made inside lifecycle hooks.