### PR TITLE
Prevent snapshot being preprocessed twice

### DIFF
--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -386,7 +386,7 @@ function reconcileArrayChildren<TT>(
             nothingChanged = false
             const newNode = valueAsNode(childType, parent, newPath, newValue)
             oldNodes.splice(i, 0, newNode)
-        } else if (areSame(oldNode, newValue)) {
+        } else if (areSame(childType, oldNode, newValue)) {
             // both are the same, reconcile
             oldNodes[i] = valueAsNode(childType, parent, newPath, newValue, oldNode)
         } else {
@@ -395,7 +395,7 @@ function reconcileArrayChildren<TT>(
 
             // find a possible candidate to reuse
             for (let j = i; j < oldNodes.length; j++) {
-                if (areSame(oldNodes[j], newValue)) {
+                if (areSame(childType, oldNodes[j], newValue)) {
                     oldMatch = oldNodes.splice(j, 1)[0]
                     break
                 }
@@ -459,7 +459,7 @@ function valueAsNode(
 /**
  * Check if a node holds a value.
  */
-function areSame(oldNode: AnyNode, newValue: any) {
+function areSame(childType: IAnyType, oldNode: AnyNode, newValue: any) {
     // never consider dead old nodes for reconciliation
     if (!oldNode.isAlive) {
         return false
@@ -482,8 +482,8 @@ function areSame(oldNode: AnyNode, newValue: any) {
         oldNode.identifier !== null &&
         oldNode.identifierAttribute &&
         isPlainObject(newValue) &&
-        oldNode.type.is(newValue) &&
-        oldNode.type.isMatchingSnapshotId(oldNode, newValue)
+        childType.is(newValue) &&
+        (childType as any).isMatchingSnapshotId(oldNode, newValue)
     )
 }
 

--- a/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
@@ -82,7 +82,7 @@ class SnapshotProcessor<IT extends IAnyType, CustomC, CustomS> extends BaseType<
 
     private _fixNode(node: this["N"]): void {
         // the node has to use these methods rather than the original type ones
-        proxyNodeTypeMethods(node.type, this, "create", "is", "isMatchingSnapshotId")
+        proxyNodeTypeMethods(node.type, this, "create")
 
         const oldGetSnapshot = node.getSnapshot
         node.getSnapshot = () => {
@@ -169,11 +169,7 @@ class SnapshotProcessor<IT extends IAnyType, CustomC, CustomS> extends BaseType<
             return false
         }
         const processedSn = this.preProcessSnapshot(snapshot)
-        return ComplexType.prototype.isMatchingSnapshotId.call(
-            this._subtype,
-            current as any,
-            processedSn
-        )
+        return this._subtype.isMatchingSnapshotId(current as any, processedSn)
     }
 }
 


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/mobxjs/mobx-state-tree/pull/1792 where a snapshot preprocessor gets called on an already preprocessed snapshot, resulting in potential errors.

This issue was occurring because `isMatchingSnapshotId` on the underlying model was proxied to run the preprocessor, but it was being called by `reconcile` with an already preprocessed snapshot.

This fix removes the proxying of `is` and `isMatchingSnapshotId` on snapshot processor's underlying type, while fixing the array's `areSame` utility to get the actual child-type as an argument rather than inferring it from the node. This is necessary because the node stored in the array is the underlying model, while the child-type is the `snapshotProcessor` which is needed to correctly match unprocessed snapshots to processed nodes.

The cast to `any` in `areSame` is needed because the `SnapshotProcessor` type doesn't inherit from `ComplexType`, so there's no easy way to get proper type safety on the call, but we can safely assume that the type is either a `ComplexType` or a `SnapshotProcessor` if the node is an `ObjectNode`.