### PR TITLE
bugfix: run preprocessor of types.snapshotProcessor before running applySnapshot

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/snapshotProcessor.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/snapshotProcessor.test.ts
@@ -6,7 +6,8 @@ import {
     detach,
     clone,
     SnapshotIn,
-    getNodeId
+    getNodeId,
+    applySnapshot
 } from "../../src"
 
 describe("snapshotProcessor", () => {
@@ -556,6 +557,21 @@ describe("snapshotProcessor", () => {
 
             expect(store.instance).toBe(todo)
         })
+    })
+
+    test("applySnapshot runs preprocessors before applying", () => {
+        const M = types.snapshotProcessor(types.model({ x: types.number }), {
+            preProcessor(snapshot: { x: string }) {
+                return { x: Number(snapshot.x) }
+            },
+            postProcessor(snapshot) {
+                return { x: String(snapshot.x) }
+            }
+        })
+
+        const m = M.create({ x: "1" })
+
+        expect(() => applySnapshot(m, { x: "2" })).not.toThrow()
     })
 
     test("cached initial snapshots are ok", () => {

--- a/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
@@ -92,6 +92,11 @@ class SnapshotProcessor<IT extends IAnyType, CustomC, CustomS> extends BaseType<
         node.getReconciliationType = () => {
             return this
         }
+
+        const oldApplySnapshot = node.applySnapshot
+        node.applySnapshot = (snapshot) => { 
+            return oldApplySnapshot.call(node, this.preProcessSnapshot(snapshot)) as any
+        }
     }
 
     instantiate(


### PR DESCRIPTION
Resolves https://github.com/mobxjs/mobx-state-tree/issues/1317

When using `types.snapshotProcessor` & using `applySnapshot`, the snapshot wasn't being processed currently.