### PR TITLE
Include `Instance` import in docs

### DIFF
--- a/docs/tips/typescript.md
+++ b/docs/tips/typescript.md
@@ -49,7 +49,7 @@ There are four kinds of types available, plus one helper type:
 -   `TypeOfValue<typeof VARIABLE>` gets the original type for the given instance. Note that this only works for complex values (models, arrays, maps...) but not for simple values (number, string, boolean, string, undefined).
 
 ```typescript
-import { Instance } from "mobx-state-tree";
+import { types, Instance, SnapshotIn, SnapshotOut } from "mobx-state-tree";
 
 const Todo = types
     .model({

--- a/docs/tips/typescript.md
+++ b/docs/tips/typescript.md
@@ -49,6 +49,8 @@ There are four kinds of types available, plus one helper type:
 -   `TypeOfValue<typeof VARIABLE>` gets the original type for the given instance. Note that this only works for complex values (models, arrays, maps...) but not for simple values (number, string, boolean, string, undefined).
 
 ```typescript
+import { Instance } from "mobx-state-tree";
+
 const Todo = types
     .model({
         title: "hello"


### PR DESCRIPTION
It is unclear where `Instance` is coming from - I've thought it was a TS built-in for a while until I realized it somewhere else