### PR TITLE
chore: bump peer dependency of mst-middlewares

### DIFF
--- a/packages/mst-middlewares/package.json
+++ b/packages/mst-middlewares/package.json
@@ -54,7 +54,7 @@
         "typescript": "3.9.4"
     },
     "peerDependencies": {
-        "mobx-state-tree": "^3.11.0"
+        "mobx-state-tree": "^5.0.0"
     },
     "files": [
         "dist/"


### PR DESCRIPTION
The new npm peer dependency strategy requires major versions of peer deps to be compatible.
Bumping the version enables users of mobx-state-tree 5.x to use the mst-middlewares without using legacy peer dependencies.