### PR TITLE
docs: 📑 add "exception" to the sentence

### DIFF
--- a/docs/intro/philosophy.md
+++ b/docs/intro/philosophy.md
@@ -90,7 +90,7 @@ For futher reading: the conceptual difference between snapshots, patches and act
 Finally, MST has built-in support for references, identifiers, dependency injection, change recording and circular type definitions (even across files).
 Even fancier, it analyses liveliness of objects, failing early when you try to access accidentally cached information! (More on that later)
 
-A unique feature of MST is that it offers liveliness guarantees. MST will throw when reading or writing from objects that are no longer part of a state tree. This protects you against accidental stale reads of objects still referred by, for example, a closure.
+A unique feature of MST is that it offers liveliness guarantees. MST will throw an exception when reading or writing from objects that are no longer part of a state tree. This protects you against accidental stale reads of objects still referred by, for example, a closure.
 
 ```javascript
 const oldTodo = store.todos[0]


### PR DESCRIPTION
I think the word "exception" or "error" is missing from the sentence.

![image](https://user-images.githubusercontent.com/36589645/157803880-3f33e447-99c4-4451-9d64-0655637bde28.png)
