### PR TITLE
Fix: Don't override reconciliation type for unions in snapshotProcessors

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/snapshotProcessor.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/snapshotProcessor.test.ts
@@ -782,4 +782,27 @@ describe("snapshotProcessor", () => {
         store.setItem(undefined)
         expect(store.item).toBeUndefined()
     })
+
+    test("1849 - Wrapped unions don't cause infinite recursion", () => {
+        const Store = types
+            .model({
+                prop: types.optional(
+                    types.snapshotProcessor(
+                        types.union(types.literal("a"), types.literal("b")),
+                        {}
+                    ),
+                    "a"
+                )
+            })
+            .actions((self) => ({
+                setProp(prop: typeof self.prop) {
+                    self.prop = prop
+                }
+            }))
+
+        const store = Store.create()
+        expect(store.prop).toBe("a")
+        expect(() => store.setProp("b")).not.toThrow()
+        expect(store.prop).toBe("b")
+    })
 })

--- a/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/snapshotProcessor.ts
@@ -13,7 +13,8 @@ import {
     getSnapshot,
     devMode,
     ComplexType,
-    typeCheckFailure
+    typeCheckFailure,
+    isUnionType
 } from "../../internal"
 
 /** @hidden */
@@ -89,8 +90,10 @@ class SnapshotProcessor<IT extends IAnyType, CustomC, CustomS> extends BaseType<
             return this.postProcessSnapshot(oldGetSnapshot.call(node)) as any
         }
 
-        node.getReconciliationType = () => {
-            return this
+        if (!isUnionType(this._subtype)) {
+            node.getReconciliationType = () => {
+                return this
+            }
         }
     }
 


### PR DESCRIPTION
closes #1849 