### PR TITLE
fix: Compatible with TypeScript 3.9 non-enumerable properties

### DIFF
--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -489,7 +489,7 @@ export class ModelType<
         // check views return
         if (!isPlainObject(views))
             throw fail(`views initializer should return a plain object containing views`)
-        Object.keys(views).forEach((key) => {
+        Object.getOwnPropertyNames(views).forEach((key) => {
             // is this a computed property?
             const descriptor = Object.getOwnPropertyDescriptor(views, key)!
             if ("get" in descriptor) {


### PR DESCRIPTION
TypeScript 3.9 changes the behavior of [getter/setters so that they are no longer enumerable](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#getterssetters-are-no-longer-enumerable).

The above change breaks mobx-state-tree because it uses `Object.keys(views)` which only return enumerable properties. The correct behavior is to use `Object.getOwnPropertyNames(views)` to retrieve the list of properties to include getter/setters.

This fix updates the code to use `Object.getOwnPropertyNames(views)` and thus be compatible with TypeScript 3.9

Closes #1899