### PR TITLE
call lifecycle hooks after children are created

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/object.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/object.test.ts
@@ -918,7 +918,7 @@ test("#993-1 - after attach should have a parent when accesing a reference direc
     }
 })
 
-test("#993-2 - references should have a parent event when the parent has not been accesed before", () => {
+test("#993-2 - references should have a parent even when the parent has not been accessed before", () => {
     const events: string[] = []
 
     const L4 = types
@@ -995,6 +995,7 @@ test("#993-2 - references should have a parent event when the parent has not bee
         "l4-ac",
         "l4-at",
         "onSnapshot",
+        "-",
         "onSnapshot"
     ]
 
@@ -1006,11 +1007,26 @@ test("#993-2 - references should have a parent event when the parent has not bee
         })
 
         l1.l2.l3.l4.toggle()
+        events.push("-")
         l1.selected.toggle()
         expect(events).toEqual(expectedEvents)
     }
 
+    const expectedEvents2 = [
+        "l1-ac",
+        "l4-ac",
+        "l3-ac",
+        "l2-ac",
+        "l2-at",
+        "l3-at",
+        "l4-at",
+        "onSnapshot",
+        "-",
+        "onSnapshot"
+    ]
+
     // test 2, reference first
+    // the order of hooks is different but they are all called
     events.length = 0
     {
         const l1 = createL1()
@@ -1019,8 +1035,9 @@ test("#993-2 - references should have a parent event when the parent has not bee
         })
 
         l1.selected.toggle()
+        events.push("-")
         l1.l2.l3.l4.toggle()
-        expect(events).toEqual(expectedEvents)
+        expect(events).toEqual(expectedEvents2)
     }
 
     // test 3, reference get parent should be available from the beginning and all the way to the root

--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -171,13 +171,13 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
         }
     }
 
-    createObservableInstanceIfNeeded(runHooks = true): void {
+    createObservableInstanceIfNeeded(fireHooks = true): void {
         if (this._observableInstanceState === ObservableInstanceLifecycle.UNINITIALIZED) {
-            this.createObservableInstance(runHooks)
+            this.createObservableInstance(fireHooks)
         }
     }
 
-    createObservableInstance(runHooks = true): void {
+    createObservableInstance(fireHooks = true): void {
         if (devMode()) {
             if (this.state !== NodeLifeCycle.INITIALIZING) {
                 // istanbul ignore next
@@ -208,6 +208,7 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
 
         // initialize the uninitialized parent chain from parent to child
         for (const p of parentChain) {
+            // delay firing hooks until after all parents have been created
             p.createObservableInstanceIfNeeded(false)
         }
 
@@ -239,16 +240,16 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
 
         this.state = NodeLifeCycle.CREATED
 
-        if (runHooks) {
+        if (fireHooks) {
             this.fireHook(Hook.afterCreate)
             // Note that the parent might not be finalized at this point
-            // so afterAttach won't be called in that case
+            // so afterAttach won't be called until later in that case
             this.finalizeCreation()
 
-            // run the hooks of the parents that we created
+            // fire the hooks of the parents that we created
             for (const p of parentChain.reverse()) {
                 p.fireHook(Hook.afterCreate)
-                // This will call afterAttach on the child
+                // This will call afterAttach on the child if necessary
                 p.finalizeCreation()
             }
         }

--- a/packages/mobx-state-tree/src/core/node/object-node.ts
+++ b/packages/mobx-state-tree/src/core/node/object-node.ts
@@ -171,13 +171,13 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
         }
     }
 
-    createObservableInstanceIfNeeded(): void {
+    createObservableInstanceIfNeeded(runHooks = true): void {
         if (this._observableInstanceState === ObservableInstanceLifecycle.UNINITIALIZED) {
-            this.createObservableInstance()
+            this.createObservableInstance(runHooks)
         }
     }
 
-    createObservableInstance(): void {
+    createObservableInstance(runHooks = true): void {
         if (devMode()) {
             if (this.state !== NodeLifeCycle.INITIALIZING) {
                 // istanbul ignore next
@@ -208,7 +208,7 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
 
         // initialize the uninitialized parent chain from parent to child
         for (const p of parentChain) {
-            p.createObservableInstanceIfNeeded()
+            p.createObservableInstanceIfNeeded(false)
         }
 
         const type = this.type
@@ -238,9 +238,20 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
         this._childNodes = EMPTY_OBJECT
 
         this.state = NodeLifeCycle.CREATED
-        this.fireHook(Hook.afterCreate)
 
-        this.finalizeCreation()
+        if (runHooks) {
+            this.fireHook(Hook.afterCreate)
+            // Note that the parent might not be finalized at this point
+            // so afterAttach won't be called in that case
+            this.finalizeCreation()
+
+            // run the hooks of the parents that we created
+            for (const p of parentChain.reverse()) {
+                p.fireHook(Hook.afterCreate)
+                // This will call afterAttach on the child
+                p.finalizeCreation()
+            }
+        }
     }
 
     get root(): AnyObjectNode {


### PR DESCRIPTION
Previously, in some cases, the parent lifecycle hooks would be called before the children were created.

Fixes #1951
Maybe fixes #1680

Note: This will change the order of the hooks in some cases. You can see this change when references are accessed by looking at the changes in `object.test.ts`.  The order should be changed in other cases too. I believe the order is still consistent with the intent. Ie afterCreate is always called before afterAttach for a node. And afterAttach should not be called until the parent is created. If you'd like I could add additional tests illustrating this order change.
