### PR TITLE
fix abort flow cause error

### DIFF
--- a/packages/mobx-state-tree/src/core/flow.ts
+++ b/packages/mobx-state-tree/src/core/flow.ts
@@ -120,7 +120,7 @@ export function createFlowSpawner(name: string, generator: Function) {
 
         function wrap(fn: any, type: IMiddlewareEventType, arg: any) {
             fn.$mst_middleware = (spawner as any).$mst_middleware // pick up any middleware attached to the flow
-            runWithActionContext(
+            return runWithActionContext(
                 {
                     ...contextBase,
                     type,
@@ -136,7 +136,7 @@ export function createFlowSpawner(name: string, generator: Function) {
                 gen = generator.apply(null, arguments)
                 onFulfilled(undefined) // kick off the flow
             }
-            ;(init as any).$mst_middleware = (spawner as any).$mst_middleware
+                ; (init as any).$mst_middleware = (spawner as any).$mst_middleware
 
             runWithActionContext(
                 {
@@ -151,7 +151,10 @@ export function createFlowSpawner(name: string, generator: Function) {
                 let ret
                 try {
                     // prettier-ignore
-                    wrap((r: any) => { ret = gen.next(r) }, "flow_resume", res)
+                    const cancelError: any = wrap((r: any) => { ret = gen.next(r) }, "flow_resume", res)
+                    if (cancelError instanceof Error) {
+                        ret = gen.throw(cancelError);
+                    }
                 } catch (e) {
                     // prettier-ignore
                     setImmediateWithFallback(() => {


### PR DESCRIPTION
in packages/mobx-state-tree/src/core/flow.ts,
before this fix, when middleware call abort(), 
```typescript
     function onFulfilled(res: any) {
                let ret
                try {
                    // prettier-ignore
                    const cancelError: any = wrap((r: any) => { ret = gen.next(r) }, "flow_resume", res)
                    if (cancelError instanceof Error) {
                        ret = gen.throw(cancelError);
                    }
                } catch (e) {
                    // prettier-ignore
                    setImmediateWithFallback(() => {
                        wrap((r: any) => { reject(e) }, "flow_throw", e)
                    })
                    return
                }
                next(ret)
                return
            }

      function next(ret: any) {
                if (ret.done) {
```
gen.next(r) will not be called, and variable "ret" must be undefined, so in function next, ret.done will raise access undefined's property exception.

I design when abort(Error), call `ret = gen.throw(cancelError)`, so ret is normal generator step's result (have .done/.value), it fix the undefined error ` TypeError: Cannot read properties of undefined (reading 'done') return;` , it also cause flow to fin (before, gen is just hung forever)。

see https://github.com/mobxjs/mobx-state-tree/issues/621