### PR TITLE
Type inference with types.maybe doesn't make property optional

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/optional.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/optional.test.ts
@@ -1,4 +1,4 @@
-import { getSnapshot, types, unprotect, applySnapshot, cast } from "../../src"
+import { getSnapshot, types, unprotect, applySnapshot, cast, Instance } from "../../src"
 
 test("it should provide a default value, if no snapshot is provided", () => {
     const Row = types.model({
@@ -145,4 +145,13 @@ test("undefined can work as a missing value", () => {
     expect(m2.x).toBe(undefined)
     const m3 = M.create({}) // is ok as well (even in TS)
     expect(m3.x).toBe(undefined)
+
+    // can omit optional values in inferred types
+    type MType = Instance<typeof M>
+    const m4: MType = { x: 5 }
+    expect(m4.x).toBe(5)
+    const m5: MType = { x: undefined }
+    expect(m5.x).toBe(undefined)
+    const m6: MType = {} // should be okay in typescript too
+    expect(m6.x).toBe(undefined)
 })


### PR DESCRIPTION
With this model definition:

```ts
const SomeStore = types.model("SomeStore", {
  someData: types.maybe(types.frozen())
});

interface SomeStoreType extends Instance<typeof SomeStore> {}
```

... `someData` should be optional when using the inferred type, but, but isn't.

```ts
const store: SomeStoreType = {
  // why do we need someData here
};
```

[CodeSandbox](https://codesandbox.io/s/practical-violet-1vc1wb?file=/src/App.tsx)

[TypeScript Playground of minimal repro](https://www.typescriptlang.org/play?#code/FAYw9gdgzgLgBGARgKwKYhgRjgXjgb2DjgEMAuObEqOCAVwFtFUAnAGiLkQoCIALVABtBYHqRr8hIsQB84PAOZgwAE0QBPVDw7EQFOhBWoAZgEsIqFeLiwW5hXDkGjZiyuABfYMBjqADqhwALLqACr+gXi+AWDGCCjoWN7g0PBIaBgATBQh4QG4BJzkcACsOly8SqoaWuUA9HVw4HSCVgCScAwkANaBIAh+MKaQJIJwAiyobDZgDKh8YADuAPye3kA)

This PR adds a test that demonstrates the issue. If we find a fix, we'll add it to this PR.