### PR TITLE
Removes deprecation notice for preProcessSnapshot & postProcessSnapshot

### DIFF
--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -78,23 +78,22 @@ export interface ModelPropertiesDeclaration {
  *
  * @hidden
  */
-export type ModelPropertiesDeclarationToProperties<
-    T extends ModelPropertiesDeclaration
-> = T extends { [k: string]: IAnyType } // optimization to reduce nesting
-    ? T
-    : {
-          [K in keyof T]: T[K] extends IAnyType // keep IAnyType check on the top to reduce nesting
-              ? T[K]
-              : T[K] extends string
-              ? IType<string | undefined, string, string>
-              : T[K] extends number
-              ? IType<number | undefined, number, number>
-              : T[K] extends boolean
-              ? IType<boolean | undefined, boolean, boolean>
-              : T[K] extends Date
-              ? IType<number | Date | undefined, number, Date>
-              : never
-      }
+export type ModelPropertiesDeclarationToProperties<T extends ModelPropertiesDeclaration> =
+    T extends { [k: string]: IAnyType } // optimization to reduce nesting
+        ? T
+        : {
+              [K in keyof T]: T[K] extends IAnyType // keep IAnyType check on the top to reduce nesting
+                  ? T[K]
+                  : T[K] extends string
+                  ? IType<string | undefined, string, string>
+                  : T[K] extends number
+                  ? IType<number | undefined, number, number>
+                  : T[K] extends boolean
+                  ? IType<boolean | undefined, boolean, boolean>
+                  : T[K] extends Date
+                  ? IType<number | Date | undefined, number, Date>
+                  : never
+          }
 
 /**
  * Checks if a value is optional (undefined, any or unknown).
@@ -135,8 +134,7 @@ export interface NonEmptyObject {
 export type ExtractCFromProps<P extends ModelProperties> = { [k in keyof P]: P[k]["CreationType"] }
 
 /** @hidden */
-export type ModelCreationType<PC> = { [P in DefinablePropsNames<PC>]: PC[P] } &
-    Partial<PC> &
+export type ModelCreationType<PC> = { [P in DefinablePropsNames<PC>]: PC[P] } & Partial<PC> &
     NonEmptyObject
 
 /** @hidden */
@@ -148,8 +146,7 @@ export type ModelCreationType2<P extends ModelProperties, CustomC> = _CustomOrOt
 /** @hidden */
 export type ModelSnapshotType<P extends ModelProperties> = {
     [K in keyof P]: P[K]["SnapshotType"]
-} &
-    NonEmptyObject
+} & NonEmptyObject
 
 /** @hidden */
 export type ModelSnapshotType2<P extends ModelProperties, CustomS> = _CustomOrOther<
@@ -161,8 +158,9 @@ export type ModelSnapshotType2<P extends ModelProperties, CustomS> = _CustomOrOt
  * @hidden
  * we keep this separate from ModelInstanceType to shorten model instance types generated declarations
  */
-export type ModelInstanceTypeProps<P extends ModelProperties> = { [K in keyof P]: P[K]["Type"] } &
-    NonEmptyObject
+export type ModelInstanceTypeProps<P extends ModelProperties> = {
+    [K in keyof P]: P[K]["Type"]
+} & NonEmptyObject
 
 /**
  * @hidden
@@ -180,8 +178,7 @@ export interface IModelType<
     OTHERS,
     CustomC = _NotCustomized,
     CustomS = _NotCustomized
->
-    extends IType<
+> extends IType<
         ModelCreationType2<PROPS, CustomC>,
         ModelSnapshotType2<PROPS, CustomS>,
         ModelInstanceType<PROPS, OTHERS>
@@ -212,12 +209,10 @@ export interface IModelType<
         fn: (self: Instance<this>) => { actions?: A; views?: V; state?: VS }
     ): IModelType<PROPS, OTHERS & A & V & VS, CustomC, CustomS>
 
-    /** @deprecated See `types.snapshotProcessor` */
     preProcessSnapshot<NewC = ModelCreationType2<PROPS, CustomC>>(
         fn: (snapshot: NewC) => ModelCreationType2<PROPS, CustomC>
     ): IModelType<PROPS, OTHERS, NewC, CustomS>
 
-    /** @deprecated See `types.snapshotProcessor` */
     postProcessSnapshot<NewS = ModelSnapshotType2<PROPS, CustomS>>(
         fn: (snapshot: ModelSnapshotType2<PROPS, CustomS>) => NewS
     ): IModelType<PROPS, OTHERS, CustomC, NewS>
@@ -318,18 +313,19 @@ function toPropertiesObject(declaredProps: ModelPropertiesDeclaration): ModelPro
  * @hidden
  */
 export class ModelType<
-    PROPS extends ModelProperties,
-    OTHERS,
-    CustomC,
-    CustomS,
-    MT extends IModelType<PROPS, OTHERS, CustomC, CustomS>
->
+        PROPS extends ModelProperties,
+        OTHERS,
+        CustomC,
+        CustomS,
+        MT extends IModelType<PROPS, OTHERS, CustomC, CustomS>
+    >
     extends ComplexType<
         ModelCreationType2<PROPS, CustomC>,
         ModelSnapshotType2<PROPS, CustomS>,
         ModelInstanceType<PROPS, OTHERS>
     >
-    implements IModelType<PROPS, OTHERS, CustomC, CustomS> {
+    implements IModelType<PROPS, OTHERS, CustomC, CustomS>
+{
     readonly flags = TypeFlags.Object
 
     /*


### PR DESCRIPTION
`preProcessSnapshot` and `postProcessSnapshot` were deprecated in #1165, but have proven to be very popular in normal usage still (over `types.snapshotProcessor`, the replacement), and developers seem to prefer the ergonomics of them. So this PR un-deprecates them, as we don't intend to remove them.

(There is a bunch of (unavoidable, mostly) prettier cleanup in this file, but I've noted the specific two lines that have been removed.)

cc @xaviergonz if you're interested
