### PR TITLE
docs: update references to example repos that will move external

### DIFF
--- a/docs/concepts/async-actions.md
+++ b/docs/concepts/async-actions.md
@@ -21,8 +21,8 @@ _Warning: don't import `flow` from `"mobx"`, but from `"mobx-state-tree"` instea
 ```javascript
 import { types, flow } from "mobx-state-tree"
 
-someModel.actions(self => {
-    const fetchProjects = flow(function*() {
+someModel.actions((self) => {
+    const fetchProjects = flow(function* () {
         // <- note the star, this is a generator function!
         self.state = "pending"
         try {
@@ -60,11 +60,12 @@ This means that each step in an asynchronous flow that needs to actually change 
 For example:
 
 ```javascript
-const Store = types.model({
+const Store = types
+    .model({
         githubProjects: types.array(types.frozen),
         state: types.enumeration("State", ["pending", "done", "error"])
     })
-    .actions(self => ({
+    .actions((self) => ({
         fetchProjects() {
             self.githubProjects = []
             self.state = "pending"
@@ -83,8 +84,7 @@ const Store = types.model({
             console.error("Failed to fetch projects", error)
             self.state = "error"
         }
-    }
-))
+    }))
 ```
 
 This approach works fine and has great type inference, but comes with a few downsides:
@@ -100,12 +100,14 @@ Generators might sound scary, but they are very suitable for expressing asynchro
 ```javascript
 import { flow } from "mobx-state-tree"
 
-const Store = types.model({
+const Store = types
+    .model({
         githubProjects: types.array(types.frozen),
         state: types.enumeration("State", ["pending", "done", "error"])
     })
-    .actions(self => ({
-        fetchProjects: flow(function* fetchProjects() { // <- note the star, this a generator function!
+    .actions((self) => ({
+        fetchProjects: flow(function* fetchProjects() {
+            // <- note the star, this a generator function!
             self.githubProjects = []
             self.state = "pending"
             try {
@@ -144,7 +146,7 @@ For example, the `onAction` middleware will only record starting asynchronous fl
 After all, when replaying the invocation will lead to the other steps being executed automatically.
 Besides that, each step in the generator is allowed to modify its own instance, and there is no need to expose the individual flow steps as actions.
 
-See the [bookshop example sources](https://github.com/mobxjs/mobx-state-tree/blob/5a4bd43ac874cddbf91b40eeef20043198477084/packages/mst-example-bookshop/src/stores/BookStore.js#L25) for a more extensive example.
+See the [bookshop example sources](https://github.com/coolsoftwaretyler/mst-example-bookshop/blob/main/src/stores/BookStore.js#L25) for a more extensive example.
 
 Using generators requires Promises and generators to be available. Promises can easily be polyfilled although they tend to be available on every modern JS environment. Generators are well supported as well, and both TypeScript and Babel can compile generators to ES5.
 

--- a/docs/intro/examples.md
+++ b/docs/intro/examples.md
@@ -11,7 +11,7 @@ To run the examples:
 2.  navigate to the example folder (e.g. `packages/mst-example-bookshop`)
 3.  run `yarn install` and `yarn start`
 
--   [Bookshop](https://github.com/mobxjs/mobx-state-tree/tree/master/packages/mst-example-bookshop) Example webshop application with references, identifiers, routing, testing, etc.
--   [Boxes](https://github.com/mobxjs/mobx-state-tree/tree/master/packages/mst-example-boxes) Example app where one can draw, drag, and drop boxes. With time-travelling and multi-client synchronization over websockets.
--   [TodoMVC](https://github.com/mobxjs/mobx-state-tree/tree/master/packages/mst-example-todomvc) Classic example app using React and MST.
--   [Redux TodoMVC](https://github.com/mobxjs/mobx-state-tree/tree/master/packages/mst-example-redux-todomvc) Redux TodoMVC application, except that the reducers are replaced with a MST. Tip: open the Redux devtools; they will work!
+-   [Bookshop](https://github.com/coolsoftwaretyler/mst-example-bookshop/) Example webshop application with references, identifiers, routing, testing, etc.
+-   [Boxes](https://github.com/coolsoftwaretyler/mst-example-boxes) Example app where one can draw, drag, and drop boxes. With time-travelling and multi-client synchronization over websockets.
+-   [TodoMVC](https://github.com/coolsoftwaretyler/mst-example-todomvc) Classic example app using React and MST.
+-   [Redux TodoMVC](https://github.com/coolsoftwaretyler/mst-example-redux-todomvc) Redux TodoMVC application, except that the reducers are replaced with a MST. Tip: open the Redux devtools; they will work!

--- a/docs/intro/installation.md
+++ b/docs/intro/installation.md
@@ -20,4 +20,4 @@ Supported devtools:
 
 -   [Reactotron](https://github.com/infinitered/reactotron)
 -   [MobX DevTools](https://chrome.google.com/webstore/detail/mobx-developer-tools/pfgnfdagidkfgccljigdamigbcnndkod)
--   The Redux DevTools can be connected as well as demonstrated [here](https://github.com/mobxjs/mobx-state-tree/blob/1906a394906d2e8f2cc1c778e1e3228307c1b112/packages/mst-example-redux-todomvc/src/index.js#L6)
+-   The Redux DevTools can be connected as well as demonstrated [here](https://github.com/coolsoftwaretyler/mst-example-redux-todomvc/blob/main/src/index.js#L6)

--- a/docs/intro/philosophy.md
+++ b/docs/intro/philosophy.md
@@ -52,7 +52,7 @@ store.todos[0].toggle()
 ```
 
 By using the type information available, snapshots can be converted to living trees, and vice versa, with zero effort.
-Because of this, [time travelling](https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mst-example-boxes/src/stores/time.js) is supported out of the box, and tools like HMR are trivial to support [example](https://github.com/mobxjs/mobx-state-tree/blob/4c2b19ec4a6a8d74064e4b8a87c0f8b46e97e621/examples/boxes/src/stores/domain-state.js#L94).
+Because of this, [time travelling](https://github.com/coolsoftwaretyler/mst-example-boxes/blob/main/src/stores/time.js) is supported out of the box, and tools like HMR are trivial to support [example](https://github.com/coolsoftwaretyler/mst-example-boxes/blob/main/src/stores/domain-state.js#L94).
 
 The type information is designed in such a way that it is used both at design- and run-time to verify type correctness (Design time type checking works in TypeScript only at the moment; Flow PR's are welcome!)
 
@@ -70,16 +70,16 @@ Because state trees are living, mutable models, actions are straight-forward to 
 
 Although mutable sounds scary to some, fear not, actions have many interesting properties.
 By default trees can only be modified by using an action that belongs to the same subtree.
-Furthermore, actions are replayable and can be used to distribute changes ([example](https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mst-example-boxes/src/stores/socket.js)).
+Furthermore, actions are replayable and can be used to distribute changes ([example](https://github.com/coolsoftwaretyler/mst-example-boxes/blob/main/src/stores/socket.js)).
 
 Moreover, because changes can be detected on a fine grained level, JSON patches are supported out of the box.
-Simply subscribing to the patch stream of a tree is another way to sync diffs with, for example, back-end servers or other clients ([example](https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mst-example-boxes/src/stores/socket.js)).
+Simply subscribing to the patch stream of a tree is another way to sync diffs with, for example, back-end servers or other clients ([example](https://github.com/coolsoftwaretyler/mst-example-boxes/blob/main/src/stores/socket.js)).
 
 ![patches](/img/patches.png)
 
 Since MST uses MobX behind the scenes, it integrates seamlessly with [mobx](https://mobx.js.org) and [mobx-react-lite (or mobx-react)](https://mobx.js.org/react-integration.html). See also this [egghead.io lesson: Render mobx-state-tree Models in React](https://egghead.io/lessons/react-render-mobx-state-tree-models-in-react).
 Even cooler, because it supports snapshots, middleware and replayable actions out of the box, it is possible to replace a Redux store and reducer with a MobX state tree.
-This makes it possible to connect the Redux devtools to MST. See the [Redux / MST TodoMVC example](https://github.com/mobxjs/mobx-state-tree/blob/1906a394906d2e8f2cc1c778e1e3228307c1b112/packages/mst-example-redux-todomvc/src/index.js#L6).
+This makes it possible to connect the Redux devtools to MST. See the [Redux / MST TodoMVC example](https://github.com/coolsoftwaretyler/mst-example-redux-todomvc/blob/main/src/index.js#L6).
 
 ---
 

--- a/docs/tips/faq.md
+++ b/docs/tips/faq.md
@@ -11,7 +11,6 @@ No, or not necessarily. An application can use both state trees and vanilla MobX
 State trees are primarily designed to store your domain data as this kind of state is often distributed and not very local.
 For local component state, for example, vanilla MobX observables might often be simpler to use.
 
-
 ### When not to use MST?
 
 MST provides access to snapshots, patches and interceptable actions. Also, it fixes the `this` problem.
@@ -21,7 +20,6 @@ If you have a performance critical application that handles a huge amount of mut
 off by using 'raw' MobX, which has a predictable and well-known performance and much less overhead.
 
 Likewise, if your application mainly processes stateless information (such as a logging system), MST won't add much value.
-
 
 ### Can I use Hot Module Reloading?
 
@@ -34,7 +32,7 @@ Likewise, if your application mainly processes stateless information (such as a 
     <a style="font-style:italic;padding:5px;margin:5px;"  href="https://egghead.io/lessons/react-restore-the-model-tree-state-using-hot-module-reloading-when-model-definitions-change">Hosted on egghead.io</a>
 </details>
 
-Yes, with MST it is pretty straight forward to setup hot reloading for your store definitions while preserving state. See the [todomvc example](https://github.com/mobxjs/mobx-state-tree/blob/745904101fdaeb51f16f40ebb80cd7fecf742572/packages/mst-example-todomvc/src/index.js#L60-L64).
+Yes, with MST it is pretty straight forward to setup hot reloading for your store definitions while preserving state. See the [todomvc example](https://github.com/coolsoftwaretyler/mst-example-todomvc/blob/main/src/index.js#L59C1-L64C1).
 
 ### How does MST compare to Redux
 

--- a/docs/tips/resources.md
+++ b/docs/tips/resources.md
@@ -7,9 +7,9 @@ title: Talks & Blogs
 
 ## Official resources
 
-* Introduction blog post [The curious case of MobX state tree](https://medium.com/@mweststrate/the-curious-case-of-mobx-state-tree-7b4e22d461f)
-* Free [egghead.io](https://egghead.io/courses/manage-application-state-with-mobx-state-tree) MST course
-* [Introduction tutorial](../intro/getting-started)
+-   Introduction blog post [The curious case of MobX state tree](https://medium.com/@mweststrate/the-curious-case-of-mobx-state-tree-7b4e22d461f)
+-   Free [egghead.io](https://egghead.io/courses/manage-application-state-with-mobx-state-tree) MST course
+-   [Introduction tutorial](../intro/getting-started)
 
 ## Talks
 
@@ -21,23 +21,22 @@ title: Talks & Blogs
 -   Talk FrontendLove 2018: [MobX State Tree + React: pure reactivity served](https://www.youtube.com/watch?v=HS9revHrNRI) by [Luca Mezzalira](https://lucamezzalira.com/) ([slides](https://docs.google.com/presentation/d/1f18RhN9hz1GPAdY4binWVNZDKm3k7EfNvV48lWnzdjQ/edit#slide=id.g35f391192_00)).
 -   Talk React Native EU 2019: [Resolving the Great State Debate with Hooks, Context, and MobX-State-Tree](https://www.youtube.com/watch?v=Wx9slbOTD6Q) by [Jamon Holmgren](https://jamonholmgren.com/) ([slides](https://infinite-red.slides.com/infinitered/resolving-the-great-state-debate))
 -   International JavaScript Conference 2019, Londen [You don’t know MobX State Tree](https://www.youtube.com/watch?v=LKyCJB27oNM), by [Max Gallo](https://twitter.com/_maxgallo)
-- React Europe 2019: [Combining GraphQL + mobx-state-tree](https://www.youtube.com/watch?v=Sq2M00vghqY)
+-   React Europe 2019: [Combining GraphQL + mobx-state-tree](https://www.youtube.com/watch?v=Sq2M00vghqY)
 
 ## Blogs / Vlogs
 
-- [Introduction to MobX State Tree](https://www.youtube.com/watch?v=pPgOrecfcg4) by [Leigh Halliday](https://twitter.com/leighchalliday)
-- [Creating a Trivia App with Ignite Bowser](https://shift.infinite.red/creating-a-trivia-app-with-ignite-bowser-part-1-1987cc6e93a1) by [Robin Heinze](https://twitter.com/robin_heinze)
-- <img src="https://raw.githubusercontent.com/mobxjs/mobx/master/docs/assets/book.jpg" height="80px"/> [The MobX book](https://books.google.nl/books?id=ALFmDwAAQBAJ&pg=PP1&lpg=PP1&dq=michel+weststrate+mobx+quick+start+guide:+supercharge+the+client+state+in+your+react+apps+with+mobx&source=bl&ots=D460fxti0F&sig=ivDGTxsPNwlOjLHrpKF1nweZFl8&hl=nl&sa=X&ved=2ahUKEwiwl8XO--ncAhWPmbQKHWOYBqIQ6AEwAnoECAkQAQ#v=onepage&q=michel%20weststrate%20mobx%20quick%20start%20guide%3A%20supercharge%20the%20client%20state%20in%20your%20react%20apps%20with%20mobx&f=false) by Pavan Podila and Michel Weststrate, discusses MobX-State-Tree as well.
-- [How to: mobx-state-tree + react + typescript](https://dev.to/margaretkrutikova/how-to-mobx-state-tree-react-typescript-3d5j) by [Margarita Krutikova](https://twitter.com/rita_krutikova)
-- [MobX-state-tree: A step by step guide for React Apps](https://medium.com/mr-frontend-community/mobx-state-tree-a-step-by-step-guide-for-react-apps-e65716a219d2) by [Faris Tangastani](https://medium.com/@ftangastani)
-
+-   [Introduction to MobX State Tree](https://www.youtube.com/watch?v=pPgOrecfcg4) by [Leigh Halliday](https://twitter.com/leighchalliday)
+-   [Creating a Trivia App with Ignite Bowser](https://shift.infinite.red/creating-a-trivia-app-with-ignite-bowser-part-1-1987cc6e93a1) by [Robin Heinze](https://twitter.com/robin_heinze)
+-   <img src="https://raw.githubusercontent.com/mobxjs/mobx/master/docs/assets/book.jpg" height="80px"/> [The MobX book](https://books.google.nl/books?id=ALFmDwAAQBAJ&pg=PP1&lpg=PP1&dq=michel+weststrate+mobx+quick+start+guide:+supercharge+the+client+state+in+your+react+apps+with+mobx&source=bl&ots=D460fxti0F&sig=ivDGTxsPNwlOjLHrpKF1nweZFl8&hl=nl&sa=X&ved=2ahUKEwiwl8XO--ncAhWPmbQKHWOYBqIQ6AEwAnoECAkQAQ#v=onepage&q=michel%20weststrate%20mobx%20quick%20start%20guide%3A%20supercharge%20the%20client%20state%20in%20your%20react%20apps%20with%20mobx&f=false) by Pavan Podila and Michel Weststrate, discusses MobX-State-Tree as well.
+-   [How to: mobx-state-tree + react + typescript](https://dev.to/margaretkrutikova/how-to-mobx-state-tree-react-typescript-3d5j) by [Margarita Krutikova](https://twitter.com/rita_krutikova)
+-   [MobX-state-tree: A step by step guide for React Apps](https://medium.com/mr-frontend-community/mobx-state-tree-a-step-by-step-guide-for-react-apps-e65716a219d2) by [Faris Tangastani](https://medium.com/@ftangastani)
 
 ## Supported devtools:
 
-- [Reactotron](https://github.com/infinitered/reactotron)
-- [MobX DevTools](https://chrome.google.com/webstore/detail/mobx-developer-tools/pfgnfdagidkfgccljigdamigbcnndkod)
-- The Redux can be connected as well as demonstrated [here](https://github.com/mobxjs/mobx-state-tree/blob/1906a394906d2e8f2cc1c778e1e3228307c1b112/packages/mst-example-redux-todomvc/src/index.js#L6)
+-   [Reactotron](https://github.com/infinitered/reactotron)
+-   [MobX DevTools](https://chrome.google.com/webstore/detail/mobx-developer-tools/pfgnfdagidkfgccljigdamigbcnndkod)
+-   The Redux can be connected as well as demonstrated [here](https://github.com/coolsoftwaretyler/mst-example-redux-todomvc/blob/main/src/index.js#L6)
 
 ## Addons, libraries and tools
 
-- [mst-query](https://github.com/ConrabOpto/mst-query/) - Query library for MST with support for auto normalization, garbage collection, infinite scroll & pagination, and more
+-   [mst-query](https://github.com/ConrabOpto/mst-query/) - Query library for MST with support for auto normalization, garbage collection, infinite scroll & pagination, and more

--- a/packages/mst-middlewares/README.md
+++ b/packages/mst-middlewares/README.md
@@ -310,7 +310,7 @@ export const Store = types
 
         return {
             afterCreate() {
-                self.todos.push({ title: 'New Todo' })
+                self.todos.push({ title: "New Todo" })
             },
             addTodo(todo) {
                 self.todos.push(todo)
@@ -465,11 +465,11 @@ The Redux 'middleware' is not literally middleware, but provides two useful meth
 `asReduxStore(mstStore, middlewares?)` creates a tiny proxy around a MST tree that conforms to the redux store api.
 This makes it possible to use MST inside a redux application.
 
-See the [redux-todomvc example](https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mst-example-redux-todomvc/src/index.js#L20) for more details.
+See the [redux-todomvc example](https://github.com/coolsoftwaretyler/mst-example-redux-todomvc/blob/main/src/index.js#L20) for more details.
 
 ## connectReduxDevtools
 
-`connectReduxDevtools(remoteDevDependency, mstStore, options?)` connects a MST tree to the Redux devtools. Pass in the `remoteDev` dependency to set up the connect (only one at a time). See this [example](https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mst-example-redux-todomvc/src/index.js#L21) for a setup example.
+`connectReduxDevtools(remoteDevDependency, mstStore, options?)` connects a MST tree to the Redux devtools. Pass in the `remoteDev` dependency to set up the connect (only one at a time). See this [example](https://github.com/coolsoftwaretyler/mst-example-redux-todomvc/blob/main/src/index.js#L21) for a setup example.
 
 The options object is optional and has the following options:
 


### PR DESCRIPTION
This PR updates references to the four example repositories which I have moved to external repositories (@jamonholmgren also has access to these).

Closes #2015 

Closes #2019 

Closes #2022 

Closes #2025

Once we do this, we can remove those directories and all their monorepo configuration.