### PR TITLE
Test/add more test coverage for types model

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/model.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/model.test.ts
@@ -1,4 +1,4 @@
-import { applySnapshot, types } from "../../src"
+import { applySnapshot, getSnapshot, types } from "../../src"
 
 test("it should call preProcessSnapshot with the correct argument", () => {
     const onSnapshot = jest.fn((snapshot: any) => {
@@ -16,4 +16,153 @@ test("it should call preProcessSnapshot with the correct argument", () => {
     const model = Model.create({ val: 0 })
     applySnapshot(model, { val: 1 })
     expect(onSnapshot).lastCalledWith({ val: 1 })
+})
+describe("Model name", () => {
+    test("Providing a string as the first argument should set it as the model's name.", () => {
+        const Model = types.model("Name", {})
+
+        expect(Model.name).toBe("Name")
+    })
+    test("Providing an empty string as the first argument should set it as the model's name.", () => {
+        const Model = types.model("", {})
+
+        expect(Model.name).toBe("")
+    })
+    describe("Providing a non-string argument as the first argument should set the model's name as 'AnonymousModel'.", () => {
+        const testCases = [
+            {},
+            null,
+            undefined,
+            1,
+            true,
+            [],
+            function () {},
+            new Date(),
+            /a/,
+            new Map(),
+            new Set(),
+            Symbol(),
+            new Error(),
+            NaN,
+            Infinity
+        ]
+
+        testCases.forEach((testCase) => {
+            test(`Providing ${JSON.stringify(
+                testCase
+            )} as the first argument should set the model's name as 'AnonymousModel'.`, () => {
+                const Model = types.model(testCase as any)
+
+                expect(Model.name).toBe("AnonymousModel")
+            })
+        })
+    })
+})
+describe("Model properties", () => {
+    test("Providing a string as the first argument and an object as the second argument should use the object's properties in the model.", () => {
+        const Model = types.model("name", {
+            prop1: "prop1",
+            prop2: 2
+        })
+
+        expect(Model.properties).toHaveProperty("prop1")
+        expect(Model.properties).toHaveProperty("prop2")
+    })
+    test("Providing an object as the first argument should parse and use its properties.", () => {
+        const Model = types.model({
+            prop1: "prop1",
+            prop2: 2
+        })
+
+        expect(Model.properties).toHaveProperty("prop1")
+        expect(Model.properties).toHaveProperty("prop2")
+    })
+    test("Providing a string as the first argument and a falsy value as the second argument should result in an empty set of properties.", () => {
+        const Model = types.model("name", null as any)
+
+        expect(Model.properties).toEqual({})
+    })
+})
+describe("Model identifier", () => {
+    test("If no identifier attribute is provided, the identifierAttribute should be undefined.", () => {
+        const Model = types.model("name", {})
+
+        expect(Model.identifierAttribute).toBeUndefined()
+    })
+    test("If an identifier attribute is provided, the identifierAttribute should be set for the object.", () => {
+        const Model = types.model("name", {
+            id: types.identifier
+        })
+
+        expect(Model.identifierAttribute).toBe("id")
+    })
+    test("If an identifier attribute has already been provided, an error should be thrown when attempting to provide a second one.", () => {
+        expect(() => {
+            types.model("name", {
+                id: types.identifier,
+                id2: types.identifier
+            })
+        }).toThrowErrorMatchingInlineSnapshot(
+            `"[mobx-state-tree] Cannot define property 'id2' as object identifier, property 'id' is already defined as identifier property"`
+        )
+    })
+})
+describe("Edge case behavior", () => {
+    describe("when we provide no arguments to the function", () => {
+        test("the model will be named AnonymousModel", () => {
+            const Model = types.model()
+
+            expect(Model.name).toBe("AnonymousModel")
+        })
+        test("the model will have no properties", () => {
+            const Model = types.model()
+
+            const modelSnapshot = getSnapshot(Model.create())
+            expect(modelSnapshot).toEqual({})
+        })
+    })
+    describe("when we provide an invalid name value, but a valid property object", () => {
+        test("the model will be named AnonymousModel", () => {
+            const Model = types.model(null as any, {
+                prop1: "prop1",
+                prop2: 2
+            })
+
+            expect(Model.name).toBe("AnonymousModel")
+        })
+        test("the model will have no properties", () => {
+            const Model = types.model(null as any, {
+                prop1: "prop1",
+                prop2: 2
+            })
+
+            const modelSnapshot = getSnapshot(Model.create())
+            expect(modelSnapshot).toEqual({})
+        })
+    })
+    describe("when we provide three arguments to the function", () => {
+        test("the model gets the correct name", () => {
+            // @ts-ignore
+            const Model = types.model("name", {}, {})
+
+            expect(Model.name).toBe("name")
+        })
+        test("the model gets the correct properties", () => {
+            const Model = types.model(
+                "name",
+                {
+                    prop1: "prop1",
+                    prop2: 2
+                },
+                // @ts-ignore
+                {}
+            )
+
+            const modelSnapshot = getSnapshot(Model.create())
+            expect(modelSnapshot).toEqual({
+                prop1: "prop1",
+                prop2: 2
+            })
+        })
+    })
 })


### PR DESCRIPTION
I wrote this PR mostly to learn more about MobX-State-Tree internals - it adds some additional tests around `types.model`.

I personally learned a lot doing this, and I think the test coverage will be good! My intention is to keep doing things like this over the course of the next six months. Should accomplish two goals:

1. Get me more familiar with the library
2. The more test coverage we have about specific behaviors, the clearer it will be to us when PRs "break" the API. In an ideal state, we'd have appropriate tests to exercise the entire API surface, so that a passing test suite ensures us a changeset isn't breaking, and a failing test suite indicates we may have broken the API contract.

I also added the draft to a blog post. I intend to publish that on my [blog](https://coolsoftware.dev/blog/), but I wanted to include it in this PR for now to get some early feedback on it. I added it as a standalone commit, so we can rebase and drop it pretty easily.