### PR TITLE
give complex types debug names

### DIFF
--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -122,7 +122,8 @@ export class ArrayType<IT extends IAnyType> extends ComplexType<
     }
 
     createNewInstance(childNodes: IChildNodesMap): this["T"] {
-        return observable.array(convertChildNodesToArray(childNodes), mobxShallow) as this["T"]
+        const options = { ...mobxShallow, name: this.describe() }
+        return observable.array(convertChildNodesToArray(childNodes), options) as this["T"]
     }
 
     finalizeNewInstance(node: this["N"], instance: this["T"]): void {

--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -140,8 +140,8 @@ export enum MapIdentifierMode {
 }
 
 class MSTMap<IT extends IAnyType> extends ObservableMap<string, any> {
-    constructor(initialData?: [string, any][] | IKeyValueMap<any> | Map<string, any> | undefined, options = {}) {
-        super(initialData, (observable.ref as any).enhancer, options)
+    constructor(initialData?: [string, any][] | IKeyValueMap<any> | Map<string, any> | undefined, name?: string) {
+        super(initialData, (observable.ref as any).enhancer, name)
     }
 
     get(key: string): IT["Type"] | undefined {
@@ -278,8 +278,7 @@ export class MapType<IT extends IAnyType> extends ComplexType<
     }
 
     createNewInstance(childNodes: IChildNodesMap): this["T"] {
-        const options = { name: this.describe() }
-        return new MSTMap(childNodes, options) as any
+        return new MSTMap(childNodes, this.describe()) as any
     }
 
     finalizeNewInstance(node: this["N"], instance: ObservableMap<string, any>): void {
@@ -291,11 +290,11 @@ export class MapType<IT extends IAnyType> extends ComplexType<
             Object.keys(hooks).forEach((name) => {
                 const hook = hooks[name as keyof typeof hooks]!
                 const actionInvoker = createActionInvoker(instance as IAnyStateTreeNode, name, hook)
-                ;(!devMode() ? addHiddenFinalProp : addHiddenWritableProp)(
-                    instance,
-                    name,
-                    actionInvoker
-                )
+                    ; (!devMode() ? addHiddenFinalProp : addHiddenWritableProp)(
+                        instance,
+                        name,
+                        actionInvoker
+                    )
             })
         })
 

--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -140,8 +140,8 @@ export enum MapIdentifierMode {
 }
 
 class MSTMap<IT extends IAnyType> extends ObservableMap<string, any> {
-    constructor(initialData?: [string, any][] | IKeyValueMap<any> | Map<string, any> | undefined) {
-        super(initialData, (observable.ref as any).enhancer)
+    constructor(initialData?: [string, any][] | IKeyValueMap<any> | Map<string, any> | undefined, options = {}) {
+        super(initialData, (observable.ref as any).enhancer, options)
     }
 
     get(key: string): IT["Type"] | undefined {
@@ -278,7 +278,8 @@ export class MapType<IT extends IAnyType> extends ComplexType<
     }
 
     createNewInstance(childNodes: IChildNodesMap): this["T"] {
-        return new MSTMap(childNodes) as any
+        const options = { name: this.describe() }
+        return new MSTMap(childNodes, options) as any
     }
 
     finalizeNewInstance(node: this["N"], instance: ObservableMap<string, any>): void {

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -554,7 +554,8 @@ export class ModelType<
     }
 
     createNewInstance(childNodes: IChildNodesMap): this["T"] {
-        return observable.object(childNodes, EMPTY_OBJECT, mobxShallow) as any
+        const options = { ...mobxShallow, name: this.describe() }
+        return observable.object(childNodes, EMPTY_OBJECT, options) as any
     }
 
     finalizeNewInstance(node: this["N"], instance: this["T"]): void {


### PR DESCRIPTION
https://github.com/mobxjs/mobx-state-tree/discussions/2011

This PR gives complex types (array, map, and object) [debug names](https://mobx.js.org/observable-state.html#options-). The human-readable names appear in MobX error messages and in the [trace utility](https://mobx.js.org/understanding-reactivity.html). MST already has a method called `describe` on each complex type that we can reuse for the MobX names.