### PR TITLE
pass parent to default value function in t.optional

### DIFF
--- a/packages/mobx-state-tree/src/types/utility-types/optional.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/optional.ts
@@ -16,7 +16,7 @@ import {
     devMode
 } from "../../internal"
 
-type IFunctionReturn<T> = () => T
+type IFunctionReturn<T> = (parent?: AnyObjectNode) => T
 
 type IOptionalValue<C, T> = C | IFunctionReturn<C | T>
 

--- a/packages/mobx-state-tree/src/types/utility-types/optional.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/optional.ts
@@ -16,7 +16,7 @@ import {
     devMode
 } from "../../internal"
 
-type IFunctionReturn<T> = (parent?: AnyObjectNode) => T
+type IFunctionReturn<T> = (parent: AnyObjectNode | null) => T
 
 type IOptionalValue<C, T> = C | IFunctionReturn<C | T>
 
@@ -88,7 +88,7 @@ export class OptionalValue<
         )
     }
 
-    getDefaultInstanceOrSnapshot(parent?: AnyObjectNode | null): this["C"] | this["T"] {
+    getDefaultInstanceOrSnapshot(parent: AnyObjectNode | null): this["C"] | this["T"] {
         const defaultInstanceOrSnapshot =
             typeof this._defaultValue === "function"
                 ? (this._defaultValue as IFunctionReturn<this["C"] | this["T"]>)(parent)

--- a/packages/mobx-state-tree/src/types/utility-types/optional.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/optional.ts
@@ -61,7 +61,7 @@ export class OptionalValue<
         initialValue: this["C"] | this["T"]
     ): this["N"] {
         if (this.optionalValues.indexOf(initialValue) >= 0) {
-            const defaultInstanceOrSnapshot = this.getDefaultInstanceOrSnapshot()
+            const defaultInstanceOrSnapshot = this.getDefaultInstanceOrSnapshot(parent)
             return this._subtype.instantiate(
                 parent,
                 subpath,
@@ -82,16 +82,16 @@ export class OptionalValue<
             current,
             this.optionalValues.indexOf(newValue) < 0 && this._subtype.is(newValue)
                 ? newValue
-                : this.getDefaultInstanceOrSnapshot(),
+                : this.getDefaultInstanceOrSnapshot(parent),
             parent,
             subpath
         )
     }
 
-    getDefaultInstanceOrSnapshot(): this["C"] | this["T"] {
+    getDefaultInstanceOrSnapshot(parent?: AnyObjectNode | null): this["C"] | this["T"] {
         const defaultInstanceOrSnapshot =
             typeof this._defaultValue === "function"
-                ? (this._defaultValue as IFunctionReturn<this["C"] | this["T"]>)()
+                ? (this._defaultValue as IFunctionReturn<this["C"] | this["T"]>)(parent)
                 : this._defaultValue
 
         // while static values are already snapshots and checked on types.optional


### PR DESCRIPTION
This PR allows the default value function in [t.optional](https://mobx-state-tree.js.org/API/#optional) to access the parent context via an argument.

This is useful when you want the default value to be a function of the parent state. For example, if we had a user model and wanted to deterministically generate a unique color based on their userName, we could do the following:

```ts
import { types as t } from "mobx-state-tree" 
const User = t.model("User", {
  id: t.identifier,
  userName: t.string,
  color: t.optional(t.string, (snapshot) => hashStringToColor(snapshot.userName))
})

const user = User.create({ id: uuid(), userName: "brian" });
console.log("color", user.color);
```

Right now, there isn't a way to generate the default value based on some state node.

Test cases would probably look like the situation above, plus an additional test case checking that the argument is null when the type is not a direct child of a model type.

```ts
const color = t.optional(t.string, snapshot => {
  console.log("snapshot", snapshot == null)
  return "#000";
});

color.create()
```
