### PR TITLE
fix splitCache, extra nodes were being removed

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/identifier.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/identifier.test.ts
@@ -306,5 +306,6 @@ test("items detached from arrays don't corrupt identifierCache", () => {
     expect(largeArray.items.length).toBe(10)
     expect(resolveIdentifier(Item, largeArray, "B")).toBeUndefined()
     expect(resolveIdentifier(Item, largeArray, "J")).toBeDefined()
+    // The following expectation was failing in version 5.1.8 and earlier
     expect(resolveIdentifier(Item, largeArray, "K")).toBeDefined()
 })

--- a/packages/mobx-state-tree/src/core/node/identifier-cache.ts
+++ b/packages/mobx-state-tree/src/core/node/identifier-cache.ts
@@ -70,6 +70,9 @@ export class IdentifierCache {
 
     splitCache(splitNode: AnyObjectNode): IdentifierCache {
         const newCache = new IdentifierCache()
+        // The slash is added here so we only match children of the splitNode. In version 5.1.8 and
+        // earlier there was no trailing slash, so non children that started with the same path string
+        // were being matched incorrectly.
         const basePath = splitNode.path + "/"
         entries(this.cache).forEach(([id, nodes]) => {
             let modified = false

--- a/packages/mobx-state-tree/src/core/node/identifier-cache.ts
+++ b/packages/mobx-state-tree/src/core/node/identifier-cache.ts
@@ -68,15 +68,20 @@ export class IdentifierCache {
         }
     }
 
-    splitCache(node: AnyObjectNode): IdentifierCache {
-        const res = new IdentifierCache()
-        const basePath = node.path
+    splitCache(splitNode: AnyObjectNode): IdentifierCache {
+        const newCache = new IdentifierCache()
+        const basePath = splitNode.path + "/"
         entries(this.cache).forEach(([id, nodes]) => {
             let modified = false
             for (let i = nodes.length - 1; i >= 0; i--) {
-                if (nodes[i].path.indexOf(basePath) === 0) {
-                    res.addNodeToCache(nodes[i], false) // no need to update lastUpdated since it is a whole new cache
+                const node = nodes[i]
+                if (node === splitNode || node.path.indexOf(basePath) === 0) {
+                    newCache.addNodeToCache(node, false) // no need to update lastUpdated since it is a whole new cache
                     nodes.splice(i, 1)
+                    // remove empty sets from cache
+                    if (!nodes.length) {
+                        this.cache.delete(id)
+                    }
                     modified = true
                 }
             }
@@ -84,7 +89,7 @@ export class IdentifierCache {
                 this.updateLastCacheModificationPerId(id)
             }
         })
-        return res
+        return newCache
     }
 
     has(type: IAnyComplexType, identifier: string): boolean {


### PR DESCRIPTION
https://github.com/mobxjs/mobx-state-tree/issues/2053

When detach is used to remove nodes from the tree, splitCache is called to pull this node and its children out of the identifierCache of the original tree. The implementation of this splitting had a bug which would remove additional nodes that are not children of the detached node.

The issue was that it was using a string match of the path of the node being removed with all the other nodes in the indentifierCache. So if the node being removed had a path of `/items/1`, then this would match `/items/10`, or `items/199`. 

Additionally this PR removes empty sets in the indentifierCache when that is the result of splitCache. This matches the behavior of `notifiedDied`.