### PR TITLE
Allow readonly string arrays in types.enumeration

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/enum.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/enum.test.ts
@@ -46,3 +46,29 @@ test("should support optional enums inside a model", () => {
     const l = TrafficLight.create({})
     expect(l.color).toBe(ColorEnum.Orange)
 })
+test("should support plain string[] arrays", () => {
+    const colorOptions: string[] = ["Red", "Orange", "Green"]
+    const TrafficLight = types.model({ color: types.enumeration(colorOptions) })
+    const l = TrafficLight.create({ color: "Orange" })
+    unprotect(l)
+    l.color = "Red"
+    expect(TrafficLight.describe()).toBe('{ color: ("Red" | "Orange" | "Green") }')
+    if (process.env.NODE_ENV !== "production") {
+        expect(() => (l.color = "Blue" as any)).toThrowError(
+            /Error while converting `"Blue"` to `"Red" | "Orange" | "Green"`/
+        )
+    }
+})
+test("should support readonly enums as const", () => {
+    const colorOptions = ["Red", "Orange", "Green"] as const
+    const TrafficLight = types.model({ color: types.enumeration(colorOptions) })
+    const l = TrafficLight.create({ color: "Orange" })
+    unprotect(l)
+    l.color = "Red"
+    expect(TrafficLight.describe()).toBe('{ color: ("Red" | "Orange" | "Green") }')
+    if (process.env.NODE_ENV !== "production") {
+        expect(() => (l.color = "Blue" as any)).toThrowError(
+            /Error while converting `"Blue"` to `"Red" | "Orange" | "Green"`/
+        )
+    }
+})

--- a/packages/mobx-state-tree/src/types/utility-types/enumeration.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/enumeration.ts
@@ -1,18 +1,20 @@
 import { ISimpleType, union, literal, assertIsString, devMode } from "../../internal"
 
 /** @hidden */
-export type UnionStringArray<T extends string[]> = T[number]
+export type UnionStringArray<T extends readonly string[]> = T[number]
 
 // strongly typed enumeration forms for plain string arrays (when passed directly to the function)
 // with these overloads we also get correct typing for native TS string enums when we use Object.values(Enum) as Enum[] as options
 // also these overloads make types.enumeration<Enum>(Object.values(Enum)) possible
 // the only case where this doesn't work is when passing to the function an arrays variable, for these cases
 // it will just fallback and assume the type is a generic string
-export function enumeration<T extends string>(options: T[]): ISimpleType<UnionStringArray<T[]>>
-export function enumeration<T extends string>(
+export function enumeration<T extends readonly string[]>(
+    options: T
+): ISimpleType<UnionStringArray<T>>
+export function enumeration<T extends readonly string[]>(
     name: string,
-    options: T[]
-): ISimpleType<UnionStringArray<T[]>>
+    options: T
+): ISimpleType<UnionStringArray<T>>
 
 /**
  * `types.enumeration` - Can be used to create an string based enumeration.

--- a/packages/mobx-state-tree/src/types/utility-types/enumeration.ts
+++ b/packages/mobx-state-tree/src/types/utility-types/enumeration.ts
@@ -3,18 +3,18 @@ import { ISimpleType, union, literal, assertIsString, devMode } from "../../inte
 /** @hidden */
 export type UnionStringArray<T extends readonly string[]> = T[number]
 
-// strongly typed enumeration forms for plain string arrays (when passed directly to the function)
-// with these overloads we also get correct typing for native TS string enums when we use Object.values(Enum) as Enum[] as options
-// also these overloads make types.enumeration<Enum>(Object.values(Enum)) possible
-// the only case where this doesn't work is when passing to the function an arrays variable, for these cases
-// it will just fallback and assume the type is a generic string
+// strongly typed enumeration forms for plain and readonly string arrays (when passed directly to the function).
+// with these overloads, we get correct typing for native TS string enums when we use Object.values(Enum) as Enum[] as options.
+// these overloads also allow both mutable and immutable arrays, making types.enumeration<Enum>(Object.values(Enum)) possible.
+// the only case where this doesn't work is when passing to the function an array variable with a mutable type constraint;
+// for these cases, it will just fallback and assume the type is a generic string.
 export function enumeration<T extends readonly string[]>(
     options: T
 ): ISimpleType<UnionStringArray<T>>
-export function enumeration<T extends readonly string[]>(
+export function enumeration<T extends string>(
     name: string,
-    options: T
-): ISimpleType<UnionStringArray<T>>
+    options: T[]
+): ISimpleType<UnionStringArray<T[]>>
 
 /**
  * `types.enumeration` - Can be used to create an string based enumeration.


### PR DESCRIPTION
## Overview

This PR enhances the enumeration function types to accept both mutable (string[]) and immutable (readonly string[]) string arrays. This allows for better compatibility with `as const` syntax and provides a more flexible API for users.

Fixes #1314.

## Changes

* Updated the type signatures in the enumeration function to handle both `readonly string[]` and `string[]`.
* Added new test cases to verify support for `readonly string[]` as well as maintaining support for `string[]`.

## Impact

These changes enable developers to use as const syntax with the enumeration function without any type errors, providing a smoother development experience.

## Testing

New tests have been added to ensure that both readonly and plain string arrays are handled correctly. Note that tests don't seem to fail even when the typescript changes haven't been implemented, but there is a type error in the test in VS Code that goes away once this is implemented.

<img width="400" alt="CleanShot 2023-08-09 at 15 05 05@2x" src="https://github.com/mobxjs/mobx-state-tree/assets/1479215/23ec8cce-ba74-48bf-ad08-056da109e532">

