### PR TITLE
Add a test for debug name

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/late.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/late.test.ts
@@ -31,7 +31,7 @@ test("late should describe correctly circular references", () => {
     const Node = types.model("Node", {
         childs: types.array(types.late((): IAnyModelType => Node))
     })
-    expect(Node.describe()).toEqual("{ childs: Node[]? }")
+    expect(Node.describe()).toEqual("{ childs: late(() => Node)[]? }")
 })
 test("should typecheck", () => {
     const NodeObject = types.model("NodeObject", {

--- a/packages/mobx-state-tree/__tests__/core/name.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/name.test.ts
@@ -10,5 +10,5 @@ test("it should have a debug name", () => {
 
     expect(getDebugName(model)).toBe("Name")
     expect(getDebugName(array)).toBe("Name[]")
-    expect(getDebugName(map)).toBe("map<string, Name>")
+    expect(getDebugName(map)).toBe("Map<string, Name>")
 })

--- a/packages/mobx-state-tree/__tests__/core/name.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/name.test.ts
@@ -1,0 +1,14 @@
+import { types } from "../../src"
+import { getDebugName } from "mobx"
+
+test("it should have a debug name", () => {
+    const Model = types.model("Name")
+
+    const model = Model.create()
+    const array = types.array(Model).create()
+    const map = types.map(Model).create()
+
+    expect(getDebugName(model)).toBe("Name")
+    expect(getDebugName(array)).toBe("Array<Name>")
+    expect(getDebugName(map)).toBe("Map<string, Name>")
+})

--- a/packages/mobx-state-tree/__tests__/core/name.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/name.test.ts
@@ -9,6 +9,6 @@ test("it should have a debug name", () => {
     const map = types.map(Model).create()
 
     expect(getDebugName(model)).toBe("Name")
-    expect(getDebugName(array)).toBe("Array<Name>")
-    expect(getDebugName(map)).toBe("Map<string, Name>")
+    expect(getDebugName(array)).toBe("Name[]")
+    expect(getDebugName(map)).toBe("map<string, Name>")
 })

--- a/packages/mobx-state-tree/__tests__/core/object.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/object.test.ts
@@ -20,7 +20,7 @@ import {
     resolveIdentifier
 } from "../../src"
 
-import { autorun, reaction, observable, configure } from "mobx"
+import { autorun, reaction, observable, configure, getDebugName } from "mobx"
 
 const createTestFactories = () => {
     const Factory = types
@@ -323,79 +323,81 @@ test("it should throw if a replaced object is read or written to", () => {
 
     setLivelinessChecking("error")
 
-    function getError(objType: string, path: string, subpath: string, action: string) {
-        return `You are trying to read or write to an object that is no longer part of a state tree. (Object type: '${objType}', Path upon death: '${path}', Subpath: '${subpath}', Action: '${action}'). Either detach nodes first, or don't use objects after removing / replacing them in the tree.`
+    function getError(obj: any, path: string, subpath: string, action: string) {
+        return `You are trying to read or write to an object that is no longer part of a state tree. (Object type: '${getDebugName(
+            obj
+        )}', Path upon death: '${path}', Subpath: '${subpath}', Action: '${action}'). Either detach nodes first, or don't use objects after removing / replacing them in the tree.`
     }
 
     // dead todo
     expect(() => {
         deadTodo.fn()
-    }).toThrow(getError("Todo", "/todo", "", "/todo.fn()"))
+    }).toThrow(getError(deadTodo, "/todo", "", "/todo.fn()"))
     expect(() => {
         // tslint:disable-next-line:no-unused-expression
         deadTodo.title
-    }).toThrow(getError("Todo", "/todo", "title", ""))
+    }).toThrow(getError(deadTodo, "/todo", "title", ""))
     expect(() => {
         deadTodo.title = "5"
-    }).toThrow(getError("Todo", "/todo", "title", ""))
+    }).toThrow(getError(deadTodo, "/todo", "title", ""))
 
     expect(() => {
         // tslint:disable-next-line:no-unused-expression
         deadTodo.arr[0]
-    }).toThrow(getError("Todo", "/todo", "arr", ""))
+    }).toThrow(getError(deadTodo, "/todo", "arr", ""))
     expect(() => {
         deadTodo.arr.push("arr1")
-    }).toThrow(getError("Todo", "/todo", "arr", ""))
+    }).toThrow(getError(deadTodo, "/todo", "arr", ""))
 
     expect(() => {
         deadTodo.map.get("mapkey0")
-    }).toThrow(getError("Todo", "/todo", "map", ""))
+    }).toThrow(getError(deadTodo, "/todo", "map", ""))
     expect(() => {
         deadTodo.map.set("mapkey1", "val")
-    }).toThrow(getError("Todo", "/todo", "map", ""))
+    }).toThrow(getError(deadTodo, "/todo", "map", ""))
 
     expect(() => {
         deadTodo.sub.fn2()
-    }).toThrow(getError("Todo", "/todo", "sub", ""))
+    }).toThrow(getError(deadTodo, "/todo", "sub", ""))
     expect(() => {
         // tslint:disable-next-line:no-unused-expression
         deadTodo.sub.title
-    }).toThrow(getError("Todo", "/todo", "sub", ""))
+    }).toThrow(getError(deadTodo, "/todo", "sub", ""))
     expect(() => {
         deadTodo.sub.title = "hi"
-    }).toThrow(getError("Todo", "/todo", "sub", ""))
+    }).toThrow(getError(deadTodo, "/todo", "sub", ""))
 
     // dead array
     expect(() => {
         // tslint:disable-next-line:no-unused-expression
         deadArr[0]
-    }).toThrow(getError("string[]", "/todo/arr", "0", ""))
+    }).toThrow(getError(deadArr, "/todo/arr", "0", ""))
     expect(() => {
         deadArr[0] = "hi"
-    }).toThrow(getError("string[]", "/todo/arr", "0", ""))
+    }).toThrow(getError(deadArr, "/todo/arr", "0", ""))
     expect(() => {
         deadArr.push("hi")
-    }).toThrow(getError("string[]", "/todo/arr", "1", ""))
+    }).toThrow(getError(deadArr, "/todo/arr", "1", ""))
 
     // dead map
     expect(() => {
         deadMap.get("mapkey0")
-    }).toThrow(getError("map<string, string>", "/todo/map", "mapkey0", ""))
+    }).toThrow(getError(deadMap, "/todo/map", "mapkey0", ""))
     expect(() => {
         deadMap.set("mapkey0", "val")
-    }).toThrow(getError("map<string, string>", "/todo/map", "mapkey0", ""))
+    }).toThrow(getError(deadMap, "/todo/map", "mapkey0", ""))
 
     // dead subobj
     expect(() => {
         deadSub.fn2()
-    }).toThrow(getError("Sub", "/todo/sub", "", "/todo/sub.fn2()"))
+    }).toThrow(getError(deadSub, "/todo/sub", "", "/todo/sub.fn2()"))
     expect(() => {
         // tslint:disable-next-line:no-unused-expression
         deadSub.title
-    }).toThrow(getError("Sub", "/todo/sub", "title", ""))
+    }).toThrow(getError(deadSub, "/todo/sub", "title", ""))
     expect(() => {
         deadSub.title = "ho"
-    }).toThrow(getError("Sub", "/todo/sub", "title", ""))
+    }).toThrow(getError(deadSub, "/todo/sub", "title", ""))
 })
 
 test("it should warn if a replaced object is read or written to", () => {

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -122,7 +122,7 @@ export class ArrayType<IT extends IAnyType> extends ComplexType<
     }
 
     createNewInstance(childNodes: IChildNodesMap): this["T"] {
-        const options = { ...mobxShallow, name: this.describe() }
+        const options = { ...mobxShallow, name: this.name }
         return observable.array(convertChildNodesToArray(childNodes), options) as this["T"]
     }
 
@@ -336,8 +336,7 @@ ArrayType.prototype.applySnapshot = action(ArrayType.prototype.applySnapshot)
  */
 export function array<IT extends IAnyType>(subtype: IT): IArrayType<IT> {
     assertIsType(subtype, 1)
-
-    return new ArrayType<IT>(subtype.name + "[]", subtype)
+    return new ArrayType<IT>(`Array<${subtype.name}>`, subtype)
 }
 
 function reconcileArrayChildren<TT>(

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -336,7 +336,7 @@ ArrayType.prototype.applySnapshot = action(ArrayType.prototype.applySnapshot)
  */
 export function array<IT extends IAnyType>(subtype: IT): IArrayType<IT> {
     assertIsType(subtype, 1)
-    return new ArrayType<IT>(`Array<${subtype.name}>`, subtype)
+    return new ArrayType<IT>(`${subtype.name}[]`, subtype)
 }
 
 function reconcileArrayChildren<TT>(

--- a/packages/mobx-state-tree/src/types/complex-types/array.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/array.ts
@@ -148,7 +148,7 @@ export class ArrayType<IT extends IAnyType> extends ComplexType<
     }
 
     describe() {
-        return this._subType.describe() + "[]"
+        return this.name
     }
 
     getChildren(node: this["N"]): AnyNode[] {

--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -309,7 +309,7 @@ export class MapType<IT extends IAnyType> extends ComplexType<
     }
 
     describe() {
-        return "Map<string, " + this._subType.describe() + ">"
+        return this.name
     }
 
     getChildren(node: this["N"]): ReadonlyArray<AnyNode> {
@@ -508,7 +508,7 @@ MapType.prototype.applySnapshot = action(MapType.prototype.applySnapshot)
  * @returns
  */
 export function map<IT extends IAnyType>(subtype: IT): IMapType<IT> {
-    return new MapType<IT>(`map<string, ${subtype.name}>`, subtype)
+    return new MapType<IT>(`Map<string, ${subtype.name}>`, subtype)
 }
 
 /**

--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -508,7 +508,7 @@ MapType.prototype.applySnapshot = action(MapType.prototype.applySnapshot)
  * @returns
  */
 export function map<IT extends IAnyType>(subtype: IT): IMapType<IT> {
-    return new MapType<IT>(`Map<string, ${subtype.name}>`, subtype)
+    return new MapType<IT>(`map<string, ${subtype.name}>`, subtype)
 }
 
 /**

--- a/packages/mobx-state-tree/src/types/complex-types/map.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/map.ts
@@ -284,7 +284,7 @@ export class MapType<IT extends IAnyType> extends ComplexType<
     }
 
     createNewInstance(childNodes: IChildNodesMap): this["T"] {
-        return new MSTMap(childNodes, this.describe()) as any
+        return new MSTMap(childNodes, this.name) as any
     }
 
     finalizeNewInstance(node: this["N"], instance: ObservableMap<string, any>): void {
@@ -508,7 +508,7 @@ MapType.prototype.applySnapshot = action(MapType.prototype.applySnapshot)
  * @returns
  */
 export function map<IT extends IAnyType>(subtype: IT): IMapType<IT> {
-    return new MapType<IT>(`map<string, ${subtype.name}>`, subtype)
+    return new MapType<IT>(`Map<string, ${subtype.name}>`, subtype)
 }
 
 /**

--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -563,7 +563,7 @@ export class ModelType<
     }
 
     createNewInstance(childNodes: IChildNodesMap): this["T"] {
-        const options = { ...mobxShallow, name: this.describe() }
+        const options = { ...mobxShallow, name: this.name }
         return observable.object(childNodes, EMPTY_OBJECT, options) as any
     }
 

--- a/packages/mst-middlewares/__tests__/__snapshots__/redux.test.ts.snap
+++ b/packages/mst-middlewares/__tests__/__snapshots__/redux.test.ts.snap
@@ -1826,7 +1826,7 @@ Array [
   Array [
     Object {
       "args": Array [],
-      "targetTypePath": "SchoolYearConfigurationModel/map<string, late(() => ContentDefinitionModel)>/ContentDefinition",
+      "targetTypePath": "SchoolYearConfigurationModel/Map<string, late(() => ContentDefinitionModel)>/ContentDefinition",
       "type": "[root/contents/one] toggleState()",
     },
     Object {


### PR DESCRIPTION
## What does this PR do and why?

Adds a test to https://github.com/mobxjs/mobx-state-tree/pull/2049
Closes https://github.com/mobxjs/mobx-state-tree/issues/2055

Also modifies #2049 to use `this.name` instead of `this.describe`, since describe just iterates over children and their types and doesn't actually use name.

```ts
const Model = types.model("Name", { value: t.number });
const model = Model.create({ value: 5 });

const array = types.array(Model).create()
const map= types.map(Model).create()

// previous
console.log(getDebugName(model)) // { value: number }
console.log(getDebugName(array)) // { value: number }[]
console.log(getDebugName(map)) // map<string,{ value: number }>

// now
console.log(getDebugName(model)) // Name
console.log(getDebugName(array)) // Name[]
console.log(getDebugName(map)) // Map<string, Name>
```