### PR TITLE
bugfix: fix error judgement on splitCache

### DIFF
--- a/packages/mobx-state-tree/src/core/node/identifier-cache.ts
+++ b/packages/mobx-state-tree/src/core/node/identifier-cache.ts
@@ -71,10 +71,11 @@ export class IdentifierCache {
     splitCache(node: AnyObjectNode): IdentifierCache {
         const res = new IdentifierCache()
         const basePath = node.path
+        const branchPath = node.path+'/'
         entries(this.cache).forEach(([id, nodes]) => {
             let modified = false
             for (let i = nodes.length - 1; i >= 0; i--) {
-                if (nodes[i].path.indexOf(basePath) === 0) {
+                if (nodes[i].path.indexOf(branchPath) === 0||nodes[i].path===basePath) {
                     res.addNodeToCache(nodes[i], false) // no need to update lastUpdated since it is a whole new cache
                     nodes.splice(i, 1)
                     modified = true


### PR DESCRIPTION
## fix the bug of path judgement

inner function of splitCache has error when judging descendant node

```
node1.path='a/1'
node2.path='a/10'

nodes2.path.indexOf(node1) === 0 // true
// then it will assume node2 is the child of node1, which is not expected

```
## fix solution

add additional judgement of path that contains '/'