### PR TITLE
chore: remove immer open collective link

### DIFF
--- a/packages/mst-middlewares/package.json
+++ b/packages/mst-middlewares/package.json
@@ -25,10 +25,6 @@
     },
     "author": "",
     "license": "MIT",
-    "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-    },
     "repository": {
         "type": "git",
         "url": "https://github.com/mobxjs/mobx-state-tree.git",


### PR DESCRIPTION
## What does this PR do and why?

When I was publishing version `5.2.0`, I noticed we still have the open collective link for Immer on our npm page through the funding configuration. I don't think that's appropriate anymore, although I'd be happy to discuss reverting this change if it comes up. I can't imagine MST is funneling a ton of money that direction anyway.

I think we removed our connection to that org for the GitHub sponsors as well, so this seems to be consistent with that.