### PR TITLE
Fix wording and discuss a bad link in philosophy.md

### DIFF
--- a/docs/intro/philosophy.md
+++ b/docs/intro/philosophy.md
@@ -66,11 +66,11 @@ _Runtime type error_
 
 _Designtime type error_
 
-Because state trees are living, mutable models, actions are straight-forward to write; just modify local instance properties where appropriate. See `toggleTodo()` above or the examples below. It is not necessary to produce a new state tree yourself, MST's snapshot functionality will derive one for you automatically.
+Because state trees are living, mutable models, actions are straight-forward to write; just modify local instance properties where appropriate. See the `toggle()`-action in the Todo-store above or the examples below. It is not necessary to produce a new state tree yourself, MST's snapshot functionality will derive one for you automatically.
 
 Although mutable sounds scary to some, fear not, actions have many interesting properties.
 By default trees can only be modified by using an action that belongs to the same subtree.
-Furthermore, actions are replayable and can be used to distribute changes ([example](https://github.com/coolsoftwaretyler/mst-example-boxes/blob/main/src/stores/socket.js)).
+Furthermore, actions are replayable and can be used to distribute changes ([unclear example, where is the code to look at?](https://github.com/coolsoftwaretyler/mst-example-boxes/blob/main/src/stores/socket.js)).
 
 Moreover, because changes can be detected on a fine grained level, JSON patches are supported out of the box.
 Simply subscribing to the patch stream of a tree is another way to sync diffs with, for example, back-end servers or other clients ([example](https://github.com/coolsoftwaretyler/mst-example-boxes/blob/main/src/stores/socket.js)).

--- a/docs/intro/philosophy.md
+++ b/docs/intro/philosophy.md
@@ -70,7 +70,7 @@ Because state trees are living, mutable models, actions are straight-forward to 
 
 Although mutable sounds scary to some, fear not, actions have many interesting properties.
 By default trees can only be modified by using an action that belongs to the same subtree.
-Furthermore, actions are replayable and can be used to distribute changes ([unclear example, where is the code to look at?](https://github.com/coolsoftwaretyler/mst-example-boxes/blob/main/src/stores/socket.js)).
+Furthermore, actions are replayable and can be used to distribute changes ([example](https://github.com/coolsoftwaretyler/mst-example-boxes/blob/main/src/stores/time.js)).
 
 Moreover, because changes can be detected on a fine grained level, JSON patches are supported out of the box.
 Simply subscribing to the patch stream of a tree is another way to sync diffs with, for example, back-end servers or other clients ([example](https://github.com/coolsoftwaretyler/mst-example-boxes/blob/main/src/stores/socket.js)).


### PR DESCRIPTION
Not sure what to do with the duplicated link

## What does this PR do and why?
- rephrase a sentence that was referencing a previous method name `toggleTodo()` which has been renamed to `toggle()`.
- highlight a link that should be updated to a proper one by maintainers.
<!--
Try to complete the sentence: "If this pull request is approved, it will...",
and add some information telling us why you're requesting this change

List any relevant GitHub issues, GitHub discussions, or other references.
-->

## Steps to validate locally
[Read up on the philosophy of MobX-state-tree](https://mobx-state-tree.js.org/intro/philosophy) and follow the links. More specifically, the two paragraphs directly after Runtime and Designtime type error images.