### PR TITLE
chore: 5.4.0-pre.1 release chores

### DIFF
--- a/docs/API/index.md
+++ b/docs/API/index.md
@@ -1,10 +1,10 @@
 ---
 id: "index"
-title: "mobx-state-tree - v5.3.alpha.1"
+title: "mobx-state-tree - v5.4.0-pre.1"
 sidebar_label: "Globals"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](index.md)
+[mobx-state-tree - v5.4.0-pre.1](index.md)
 
 ## Index
 
@@ -177,7 +177,7 @@ sidebar_label: "Globals"
 
 Ƭ **IDisposer**: *function*
 
-*Defined in [src/utils.ts:41](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/utils.ts#L41)*
+*Defined in [src/utils.ts:41](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/utils.ts#L41)*
 
 A generic disposer.
 
@@ -191,7 +191,7 @@ ___
 
 Ƭ **IHooksGetter**: *function*
 
-*Defined in [src/core/node/Hook.ts:19](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/node/Hook.ts#L19)*
+*Defined in [src/core/node/Hook.ts:19](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/node/Hook.ts#L19)*
 
 #### Type declaration:
 
@@ -209,7 +209,7 @@ ___
 
 Ƭ **IMiddlewareEventType**: *"action" | "flow_spawn" | "flow_resume" | "flow_resume_error" | "flow_return" | "flow_throw"*
 
-*Defined in [src/core/action.ts:16](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/action.ts#L16)*
+*Defined in [src/core/action.ts:16](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/action.ts#L16)*
 
 ___
 
@@ -217,7 +217,7 @@ ___
 
 Ƭ **IMiddlewareHandler**: *function*
 
-*Defined in [src/core/action.ts:54](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/action.ts#L54)*
+*Defined in [src/core/action.ts:54](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/action.ts#L54)*
 
 #### Type declaration:
 
@@ -254,7 +254,7 @@ ___
 
 Ƭ **ITypeDispatcher**: *function*
 
-*Defined in [src/types/utility-types/union.ts:27](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L27)*
+*Defined in [src/types/utility-types/union.ts:27](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L27)*
 
 #### Type declaration:
 
@@ -272,7 +272,7 @@ ___
 
 Ƭ **IValidationContext**: *[IValidationContextEntry](interfaces/ivalidationcontextentry.md)[]*
 
-*Defined in [src/core/type/type-checker.ts:23](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type-checker.ts#L23)*
+*Defined in [src/core/type/type-checker.ts:23](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type-checker.ts#L23)*
 
 Array of validation context entries
 
@@ -282,7 +282,7 @@ ___
 
 Ƭ **IValidationResult**: *[IValidationError](interfaces/ivalidationerror.md)[]*
 
-*Defined in [src/core/type/type-checker.ts:36](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type-checker.ts#L36)*
+*Defined in [src/core/type/type-checker.ts:36](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type-checker.ts#L36)*
 
 Type validation result, which is an array of type validation errors
 
@@ -292,7 +292,7 @@ ___
 
 Ƭ **Instance**: *T extends object ? T["Type"] : T*
 
-*Defined in [src/core/type/type.ts:230](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L230)*
+*Defined in [src/core/type/type.ts:230](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L230)*
 
 The instance representation of a given type.
 
@@ -302,7 +302,7 @@ ___
 
 Ƭ **LivelinessMode**: *"warn" | "error" | "ignore"*
 
-*Defined in [src/core/node/livelinessChecking.ts:7](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/node/livelinessChecking.ts#L7)*
+*Defined in [src/core/node/livelinessChecking.ts:7](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/node/livelinessChecking.ts#L7)*
 
 Defines what MST should do when running into reads / writes to objects that have died.
 - `"warn"`: Print a warning (default).
@@ -315,7 +315,7 @@ ___
 
 Ƭ **OnReferenceInvalidated**: *function*
 
-*Defined in [src/types/utility-types/reference.ts:43](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/reference.ts#L43)*
+*Defined in [src/types/utility-types/reference.ts:43](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/reference.ts#L43)*
 
 #### Type declaration:
 
@@ -333,7 +333,7 @@ ___
 
 Ƭ **OnReferenceInvalidatedEvent**: *object*
 
-*Defined in [src/types/utility-types/reference.ts:34](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/reference.ts#L34)*
+*Defined in [src/types/utility-types/reference.ts:34](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/reference.ts#L34)*
 
 #### Type declaration:
 
@@ -343,7 +343,7 @@ ___
 
 Ƭ **ReferenceIdentifier**: *string | number*
 
-*Defined in [src/types/utility-types/identifier.ts:142](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/identifier.ts#L142)*
+*Defined in [src/types/utility-types/identifier.ts:142](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/identifier.ts#L142)*
 
 Valid types for identifiers.
 
@@ -353,7 +353,7 @@ ___
 
 Ƭ **ReferenceOptions**: *[ReferenceOptionsGetSet](interfaces/referenceoptionsgetset.md)‹IT› | [ReferenceOptionsOnInvalidated](interfaces/referenceoptionsoninvalidated.md)‹IT› | [ReferenceOptionsGetSet](interfaces/referenceoptionsgetset.md)‹IT› & [ReferenceOptionsOnInvalidated](interfaces/referenceoptionsoninvalidated.md)‹IT›*
 
-*Defined in [src/types/utility-types/reference.ts:451](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/reference.ts#L451)*
+*Defined in [src/types/utility-types/reference.ts:451](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/reference.ts#L451)*
 
 ___
 
@@ -361,7 +361,7 @@ ___
 
 Ƭ **SnapshotIn**: *T extends object ? T["CreationType"] : T extends IStateTreeNode<infer IT> ? IT["CreationType"] : T*
 
-*Defined in [src/core/type/type.ts:235](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L235)*
+*Defined in [src/core/type/type.ts:235](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L235)*
 
 The input (creation) snapshot representation of a given type.
 
@@ -371,7 +371,7 @@ ___
 
 Ƭ **SnapshotOrInstance**: *[SnapshotIn](index.md#snapshotin)‹T› | [Instance](index.md#instance)‹T›*
 
-*Defined in [src/core/type/type.ts:276](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L276)*
+*Defined in [src/core/type/type.ts:276](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L276)*
 
 A type which is equivalent to the union of SnapshotIn and Instance types of a given typeof TYPE or typeof VARIABLE.
 For primitives it defaults to the primitive itself.
@@ -404,7 +404,7 @@ ___
 
 Ƭ **SnapshotOut**: *T extends object ? T["SnapshotType"] : T extends IStateTreeNode<infer IT> ? IT["SnapshotType"] : T*
 
-*Defined in [src/core/type/type.ts:244](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L244)*
+*Defined in [src/core/type/type.ts:244](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L244)*
 
 The output snapshot representation of a given type.
 
@@ -414,7 +414,7 @@ The output snapshot representation of a given type.
 
 • **DatePrimitive**: *[IType](interfaces/itype.md)‹number | Date, number, Date›* =  _DatePrimitive
 
-*Defined in [src/types/primitives.ts:215](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/primitives.ts#L215)*
+*Defined in [src/types/primitives.ts:215](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/primitives.ts#L215)*
 
 `types.Date` - Creates a type that can only contain a javascript Date value.
 
@@ -437,7 +437,7 @@ ___
   (v) => typeof v === "boolean"
 )
 
-*Defined in [src/types/primitives.ts:169](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/primitives.ts#L169)*
+*Defined in [src/types/primitives.ts:169](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/primitives.ts#L169)*
 
 `types.boolean` - Creates a type that can only contain a boolean value.
 This type is used for boolean values by default
@@ -460,7 +460,7 @@ ___
   (v) => isFinite(v)
 )
 
-*Defined in [src/types/primitives.ts:150](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/primitives.ts#L150)*
+*Defined in [src/types/primitives.ts:150](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/primitives.ts#L150)*
 
 `types.finite` - Creates a type that can only contain an finite value.
 
@@ -482,7 +482,7 @@ ___
   (v) => isFloat(v)
 )
 
-*Defined in [src/types/primitives.ts:132](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/primitives.ts#L132)*
+*Defined in [src/types/primitives.ts:132](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/primitives.ts#L132)*
 
 `types.float` - Creates a type that can only contain an float value.
 
@@ -500,7 +500,7 @@ ___
 
 • **identifier**: *[ISimpleType](interfaces/isimpletype.md)‹string›* =  new IdentifierType()
 
-*Defined in [src/types/utility-types/identifier.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/identifier.ts#L110)*
+*Defined in [src/types/utility-types/identifier.ts:110](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/identifier.ts#L110)*
 
 `types.identifier` - Identifiers are used to make references, lifecycle events and reconciling works.
 Inside a state tree, for each type can exist only one instance for each given identifier.
@@ -524,7 +524,7 @@ ___
 
 • **identifierNumber**: *[ISimpleType](interfaces/isimpletype.md)‹number›* =  new IdentifierNumberType()
 
-*Defined in [src/types/utility-types/identifier.ts:125](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/identifier.ts#L125)*
+*Defined in [src/types/utility-types/identifier.ts:125](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/identifier.ts#L125)*
 
 `types.identifierNumber` - Similar to `types.identifier`. This one will serialize from / to a number when applying snapshots
 
@@ -548,7 +548,7 @@ ___
   (v) => isInteger(v)
 )
 
-*Defined in [src/types/primitives.ts:114](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/primitives.ts#L114)*
+*Defined in [src/types/primitives.ts:114](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/primitives.ts#L114)*
 
 `types.integer` - Creates a type that can only contain an integer value.
 
@@ -570,7 +570,7 @@ ___
   (v) => v === null
 )
 
-*Defined in [src/types/primitives.ts:178](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/primitives.ts#L178)*
+*Defined in [src/types/primitives.ts:178](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/primitives.ts#L178)*
 
 `types.null` - The type of the value `null`
 
@@ -584,7 +584,7 @@ ___
   (v) => typeof v === "number"
 )
 
-*Defined in [src/types/primitives.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/primitives.ts#L96)*
+*Defined in [src/types/primitives.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/primitives.ts#L96)*
 
 `types.number` - Creates a type that can only contain a numeric value.
 This type is used for numeric values by default
@@ -607,7 +607,7 @@ ___
   (v) => typeof v === "string"
 )
 
-*Defined in [src/types/primitives.ts:77](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/primitives.ts#L77)*
+*Defined in [src/types/primitives.ts:77](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/primitives.ts#L77)*
 
 `types.string` - Creates a type that can only contain a string value.
 This type is used for string values by default
@@ -630,7 +630,7 @@ ___
   (v) => v === undefined
 )
 
-*Defined in [src/types/primitives.ts:187](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/primitives.ts#L187)*
+*Defined in [src/types/primitives.ts:187](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/primitives.ts#L187)*
 
 `types.undefined` - The type of the value `undefined`
 
@@ -640,7 +640,7 @@ ___
 
 ▸ **addDisposer**(`target`: IAnyStateTreeNode, `disposer`: [IDisposer](index.md#idisposer)): *[IDisposer](index.md#idisposer)*
 
-*Defined in [src/core/mst-operations.ts:752](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L752)*
+*Defined in [src/core/mst-operations.ts:752](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L752)*
 
 Use this utility to register a function that should be called whenever the
 targeted state tree node is destroyed. This is a useful alternative to managing
@@ -682,7 +682,7 @@ ___
 
 ▸ **addMiddleware**(`target`: IAnyStateTreeNode, `handler`: [IMiddlewareHandler](index.md#imiddlewarehandler), `includeHooks`: boolean): *[IDisposer](index.md#idisposer)*
 
-*Defined in [src/core/action.ts:161](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/action.ts#L161)*
+*Defined in [src/core/action.ts:161](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/action.ts#L161)*
 
 Middleware can be used to intercept any action is invoked on the subtree where it is attached.
 If a tree is protected (by default), this means that any mutation of the tree will pass through your middleware.
@@ -707,7 +707,7 @@ ___
 
 ▸ **applyAction**(`target`: IAnyStateTreeNode, `actions`: [ISerializedActionCall](interfaces/iserializedactioncall.md) | [ISerializedActionCall](interfaces/iserializedactioncall.md)[]): *void*
 
-*Defined in [src/middlewares/on-action.ts:88](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/on-action.ts#L88)*
+*Defined in [src/middlewares/on-action.ts:88](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/on-action.ts#L88)*
 
 Applies an action or a series of actions in a single MobX transaction.
 Does not return any value
@@ -728,7 +728,7 @@ ___
 
 ▸ **applyPatch**(`target`: IAnyStateTreeNode, `patch`: [IJsonPatch](interfaces/ijsonpatch.md) | ReadonlyArray‹[IJsonPatch](interfaces/ijsonpatch.md)›): *void*
 
-*Defined in [src/core/mst-operations.ts:125](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L125)*
+*Defined in [src/core/mst-operations.ts:125](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L125)*
 
 Applies a JSON-patch to the given model instance or bails out if the patch couldn't be applied
 See [patches](https://github.com/mobxjs/mobx-state-tree#patches) for more details.
@@ -750,7 +750,7 @@ ___
 
 ▸ **applySnapshot**<**C**>(`target`: IStateTreeNode‹[IType](interfaces/itype.md)‹C, any, any››, `snapshot`: C): *void*
 
-*Defined in [src/core/mst-operations.ts:322](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L322)*
+*Defined in [src/core/mst-operations.ts:322](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L322)*
 
 Applies a snapshot to a given model instances. Patch and snapshot listeners will be invoked as usual.
 
@@ -773,7 +773,7 @@ ___
 
 ▸ **array**<**IT**>(`subtype`: IT): *IArrayType‹IT›*
 
-*Defined in [src/types/complex-types/array.ts:333](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/array.ts#L333)*
+*Defined in [src/types/complex-types/array.ts:333](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/array.ts#L333)*
 
 `types.array` - Creates an index based collection type who's children are all of a uniform declared type.
 
@@ -813,7 +813,7 @@ ___
 
 ▸ **cast**<**O**>(`snapshotOrInstance`: O): *O*
 
-*Defined in [src/core/mst-operations.ts:881](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L881)*
+*Defined in [src/core/mst-operations.ts:881](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L881)*
 
 Casts a node snapshot or instance type to an instance type so it can be assigned to a type instance.
 Note that this is just a cast for the type system, this is, it won't actually convert a snapshot to an instance,
@@ -856,7 +856,7 @@ The same object cast as an instance
 
 ▸ **cast**<**O**>(`snapshotOrInstance`: TypeOfValue<O>["CreationType"] | TypeOfValue<O>["SnapshotType"] | TypeOfValue<O>["Type"]): *O*
 
-*Defined in [src/core/mst-operations.ts:884](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L884)*
+*Defined in [src/core/mst-operations.ts:884](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L884)*
 
 Casts a node snapshot or instance type to an instance type so it can be assigned to a type instance.
 Note that this is just a cast for the type system, this is, it won't actually convert a snapshot to an instance,
@@ -903,7 +903,7 @@ ___
 
 ▸ **castFlowReturn**<**T**>(`val`: T): *T*
 
-*Defined in [src/core/flow.ts:34](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/flow.ts#L34)*
+*Defined in [src/core/flow.ts:34](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/flow.ts#L34)*
 
 **`deprecated`** Not needed since TS3.6.
 Used for TypeScript to make flows that return a promise return the actual promise result.
@@ -926,7 +926,7 @@ ___
 
 ▸ **castToReferenceSnapshot**<**I**>(`instance`: I): *Extract<I, IAnyStateTreeNode> extends never ? I : ReferenceIdentifier*
 
-*Defined in [src/core/mst-operations.ts:984](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L984)*
+*Defined in [src/core/mst-operations.ts:984](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L984)*
 
 Casts a node instance type to a reference snapshot type so it can be assigned to a reference snapshot (e.g. to be used inside a create call).
 Note that this is just a cast for the type system, this is, it won't actually convert an instance to a reference snapshot,
@@ -972,7 +972,7 @@ ___
 
 ▸ **castToSnapshot**<**I**>(`snapshotOrInstance`: I): *Extract<I, IAnyStateTreeNode> extends never ? I : TypeOfValue<I>["CreationType"]*
 
-*Defined in [src/core/mst-operations.ts:950](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L950)*
+*Defined in [src/core/mst-operations.ts:950](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L950)*
 
 Casts a node instance type to a snapshot type so it can be assigned to a type snapshot (e.g. to be used inside a create call).
 Note that this is just a cast for the type system, this is, it won't actually convert an instance to a snapshot,
@@ -1017,7 +1017,7 @@ ___
 
 ▸ **clone**<**T**>(`source`: T, `keepEnvironment`: boolean | any): *T*
 
-*Defined in [src/core/mst-operations.ts:667](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L667)*
+*Defined in [src/core/mst-operations.ts:667](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L667)*
 
 Returns a deep copy of the given state tree node as new tree.
 Shorthand for `snapshot(x) = getType(x).create(getSnapshot(x))`
@@ -1043,7 +1043,7 @@ ___
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›): *[IModelType](interfaces/imodeltype.md)‹PA & PB, OA & OB, _CustomJoin‹FCA, FCB›, _CustomJoin‹FSA, FSB››*
 
-*Defined in [src/types/complex-types/model.ts:765](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L765)*
+*Defined in [src/types/complex-types/model.ts:765](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L765)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1081,7 +1081,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›): *[IModelType](interfaces/imodeltype.md)‹PA & PB, OA & OB, _CustomJoin‹FCA, FCB›, _CustomJoin‹FSA, FSB››*
 
-*Defined in [src/types/complex-types/model.ts:767](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L767)*
+*Defined in [src/types/complex-types/model.ts:767](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L767)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1118,7 +1118,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC, OA & OB & OC, _CustomJoin‹FCA, _CustomJoin‹FCB, FCC››, _CustomJoin‹FSA, _CustomJoin‹FSB, FSC›››*
 
-*Defined in [src/types/complex-types/model.ts:769](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L769)*
+*Defined in [src/types/complex-types/model.ts:769](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L769)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1165,7 +1165,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC, OA & OB & OC, _CustomJoin‹FCA, _CustomJoin‹FCB, FCC››, _CustomJoin‹FSA, _CustomJoin‹FSB, FSC›››*
 
-*Defined in [src/types/complex-types/model.ts:771](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L771)*
+*Defined in [src/types/complex-types/model.ts:771](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L771)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1211,7 +1211,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD, OA & OB & OC & OD, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, FCD›››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, FSD››››*
 
-*Defined in [src/types/complex-types/model.ts:773](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L773)*
+*Defined in [src/types/complex-types/model.ts:773](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L773)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1267,7 +1267,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD, OA & OB & OC & OD, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, FCD›››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, FSD››››*
 
-*Defined in [src/types/complex-types/model.ts:775](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L775)*
+*Defined in [src/types/complex-types/model.ts:775](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L775)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1322,7 +1322,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE, OA & OB & OC & OD & OE, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, FCE››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, FSE›››››*
 
-*Defined in [src/types/complex-types/model.ts:777](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L777)*
+*Defined in [src/types/complex-types/model.ts:777](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L777)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1387,7 +1387,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE, OA & OB & OC & OD & OE, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, FCE››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, FSE›››››*
 
-*Defined in [src/types/complex-types/model.ts:779](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L779)*
+*Defined in [src/types/complex-types/model.ts:779](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L779)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1451,7 +1451,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF, OA & OB & OC & OD & OE & OF, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, FCF›››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, FSF››››››*
 
-*Defined in [src/types/complex-types/model.ts:783](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L783)*
+*Defined in [src/types/complex-types/model.ts:783](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L783)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1525,7 +1525,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF, OA & OB & OC & OD & OE & OF, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, FCF›››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, FSF››››››*
 
-*Defined in [src/types/complex-types/model.ts:786](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L786)*
+*Defined in [src/types/complex-types/model.ts:786](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L786)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1598,7 +1598,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF & PG, OA & OB & OC & OD & OE & OF & OG, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, _CustomJoin‹FCF, FCG››››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, _CustomJoin‹FSF, FSG›››››››*
 
-*Defined in [src/types/complex-types/model.ts:789](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L789)*
+*Defined in [src/types/complex-types/model.ts:789](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L789)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1681,7 +1681,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF & PG, OA & OB & OC & OD & OE & OF & OG, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, _CustomJoin‹FCF, FCG››››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, _CustomJoin‹FSF, FSG›››››››*
 
-*Defined in [src/types/complex-types/model.ts:792](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L792)*
+*Defined in [src/types/complex-types/model.ts:792](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L792)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1763,7 +1763,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF & PG & PH, OA & OB & OC & OD & OE & OF & OG & OH, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, _CustomJoin‹FCF, _CustomJoin‹FCG, FCH›››››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, _CustomJoin‹FSF, _CustomJoin‹FSG, FSH››››››››*
 
-*Defined in [src/types/complex-types/model.ts:795](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L795)*
+*Defined in [src/types/complex-types/model.ts:795](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L795)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1855,7 +1855,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF & PG & PH, OA & OB & OC & OD & OE & OF & OG & OH, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, _CustomJoin‹FCF, _CustomJoin‹FCG, FCH›››››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, _CustomJoin‹FSF, _CustomJoin‹FSG, FSH››››››››*
 
-*Defined in [src/types/complex-types/model.ts:798](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L798)*
+*Defined in [src/types/complex-types/model.ts:798](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L798)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -1946,7 +1946,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**, **PI**, **OI**, **FCI**, **FSI**>(`name`: string, `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›, `I`: [IModelType](interfaces/imodeltype.md)‹PI, OI, FCI, FSI›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF & PG & PH & PI, OA & OB & OC & OD & OE & OF & OG & OH & OI, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, _CustomJoin‹FCF, _CustomJoin‹FCG, _CustomJoin‹FCH, FCI››››››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, _CustomJoin‹FSF, _CustomJoin‹FSG, _CustomJoin‹FSH, FSI›››››››››*
 
-*Defined in [src/types/complex-types/model.ts:801](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L801)*
+*Defined in [src/types/complex-types/model.ts:801](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L801)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -2047,7 +2047,7 @@ Name | Type |
 
 ▸ **compose**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**, **PI**, **OI**, **FCI**, **FSI**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›, `I`: [IModelType](interfaces/imodeltype.md)‹PI, OI, FCI, FSI›): *[IModelType](interfaces/imodeltype.md)‹PA & PB & PC & PD & PE & PF & PG & PH & PI, OA & OB & OC & OD & OE & OF & OG & OH & OI, _CustomJoin‹FCA, _CustomJoin‹FCB, _CustomJoin‹FCC, _CustomJoin‹FCD, _CustomJoin‹FCE, _CustomJoin‹FCF, _CustomJoin‹FCG, _CustomJoin‹FCH, FCI››››››››, _CustomJoin‹FSA, _CustomJoin‹FSB, _CustomJoin‹FSC, _CustomJoin‹FSD, _CustomJoin‹FSE, _CustomJoin‹FSF, _CustomJoin‹FSG, _CustomJoin‹FSH, FSI›››››››››*
 
-*Defined in [src/types/complex-types/model.ts:804](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L804)*
+*Defined in [src/types/complex-types/model.ts:804](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L804)*
 
 `types.compose` - Composes a new model from one or more existing model types.
 This method can be invoked in two forms:
@@ -2151,7 +2151,7 @@ ___
 
 ▸ **createActionTrackingMiddleware**<**T**>(`hooks`: [IActionTrackingMiddlewareHooks](interfaces/iactiontrackingmiddlewarehooks.md)‹T›): *[IMiddlewareHandler](index.md#imiddlewarehandler)*
 
-*Defined in [src/middlewares/create-action-tracking-middleware.ts:28](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/create-action-tracking-middleware.ts#L28)*
+*Defined in [src/middlewares/create-action-tracking-middleware.ts:28](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/create-action-tracking-middleware.ts#L28)*
 
 Note: Consider migrating to `createActionTrackingMiddleware2`, it is easier to use.
 
@@ -2181,7 +2181,7 @@ ___
 
 ▸ **createActionTrackingMiddleware2**<**TEnv**>(`middlewareHooks`: [IActionTrackingMiddleware2Hooks](interfaces/iactiontrackingmiddleware2hooks.md)‹TEnv›): *[IMiddlewareHandler](index.md#imiddlewarehandler)*
 
-*Defined in [src/middlewares/createActionTrackingMiddleware2.ts:74](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/createActionTrackingMiddleware2.ts#L74)*
+*Defined in [src/middlewares/createActionTrackingMiddleware2.ts:74](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/createActionTrackingMiddleware2.ts#L74)*
 
 Convenience utility to create action based middleware that supports async processes more easily.
 The flow is like this:
@@ -2220,7 +2220,7 @@ ___
 
 ▸ **custom**<**S**, **T**>(`options`: [CustomTypeOptions](interfaces/customtypeoptions.md)‹S, T›): *[IType](interfaces/itype.md)‹S | T, S, T›*
 
-*Defined in [src/types/utility-types/custom.ts:74](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/custom.ts#L74)*
+*Defined in [src/types/utility-types/custom.ts:74](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/custom.ts#L74)*
 
 `types.custom` - Creates a custom type. Custom types can be used for arbitrary immutable values, that have a serializable representation. For example, to create your own Date representation, Decimal type etc.
 
@@ -2284,7 +2284,7 @@ ___
 
 ▸ **decorate**<**T**>(`handler`: [IMiddlewareHandler](index.md#imiddlewarehandler), `fn`: T, `includeHooks`: boolean): *T*
 
-*Defined in [src/core/action.ts:200](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/action.ts#L200)*
+*Defined in [src/core/action.ts:200](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/action.ts#L200)*
 
 Binds middleware to a specific action.
 
@@ -2325,7 +2325,7 @@ ___
 
 ▸ **destroy**(`target`: IAnyStateTreeNode): *void*
 
-*Defined in [src/core/mst-operations.ts:699](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L699)*
+*Defined in [src/core/mst-operations.ts:699](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L699)*
 
 Removes a model element from the state tree, and mark it as end-of-life; the element should not be used anymore
 
@@ -2343,7 +2343,7 @@ ___
 
 ▸ **detach**<**T**>(`target`: T): *T*
 
-*Defined in [src/core/mst-operations.ts:688](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L688)*
+*Defined in [src/core/mst-operations.ts:688](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L688)*
 
 Removes a model element from the state tree, and let it live on as a new state tree
 
@@ -2365,7 +2365,7 @@ ___
 
 ▸ **enumeration**<**T**>(`options`: T): *[ISimpleType](interfaces/isimpletype.md)‹UnionStringArray‹T››*
 
-*Defined in [src/types/utility-types/enumeration.ts:11](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/enumeration.ts#L11)*
+*Defined in [src/types/utility-types/enumeration.ts:11](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/enumeration.ts#L11)*
 
 `types.enumeration` - Can be used to create an string based enumeration.
 (note: this methods is just sugar for a union of string literals)
@@ -2391,7 +2391,7 @@ Name | Type | Description |
 
 ▸ **enumeration**<**T**>(`name`: string, `options`: T[]): *[ISimpleType](interfaces/isimpletype.md)‹UnionStringArray‹T[]››*
 
-*Defined in [src/types/utility-types/enumeration.ts:14](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/enumeration.ts#L14)*
+*Defined in [src/types/utility-types/enumeration.ts:14](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/enumeration.ts#L14)*
 
 `types.enumeration` - Can be used to create an string based enumeration.
 (note: this methods is just sugar for a union of string literals)
@@ -2422,7 +2422,7 @@ ___
 
 ▸ **escapeJsonPath**(`path`: string): *string*
 
-*Defined in [src/core/json-patch.ts:77](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/json-patch.ts#L77)*
+*Defined in [src/core/json-patch.ts:77](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/json-patch.ts#L77)*
 
 Escape slashes and backslashes.
 
@@ -2442,7 +2442,7 @@ ___
 
 ▸ **flow**<**R**, **Args**>(`generator`: function): *function*
 
-*Defined in [src/core/flow.ts:21](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/flow.ts#L21)*
+*Defined in [src/core/flow.ts:21](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/flow.ts#L21)*
 
 See [asynchronous actions](concepts/async-actions.md).
 
@@ -2482,7 +2482,7 @@ ___
 
 ▸ **frozen**<**C**>(`subType`: [IType](interfaces/itype.md)‹C, any, any›): *[IType](interfaces/itype.md)‹C, C, C›*
 
-*Defined in [src/types/utility-types/frozen.ts:54](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/frozen.ts#L54)*
+*Defined in [src/types/utility-types/frozen.ts:54](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/frozen.ts#L54)*
 
 `types.frozen` - Frozen can be used to store any value that is serializable in itself (that is valid JSON).
 Frozen values need to be immutable or treated as if immutable. They need be serializable as well.
@@ -2534,7 +2534,7 @@ Name | Type |
 
 ▸ **frozen**<**T**>(`defaultValue`: T): *[IType](interfaces/itype.md)‹T | undefined | null, T, T›*
 
-*Defined in [src/types/utility-types/frozen.ts:55](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/frozen.ts#L55)*
+*Defined in [src/types/utility-types/frozen.ts:55](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/frozen.ts#L55)*
 
 `types.frozen` - Frozen can be used to store any value that is serializable in itself (that is valid JSON).
 Frozen values need to be immutable or treated as if immutable. They need be serializable as well.
@@ -2586,7 +2586,7 @@ Name | Type |
 
 ▸ **frozen**<**T**>(): *[IType](interfaces/itype.md)‹T, T, T›*
 
-*Defined in [src/types/utility-types/frozen.ts:56](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/frozen.ts#L56)*
+*Defined in [src/types/utility-types/frozen.ts:56](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/frozen.ts#L56)*
 
 `types.frozen` - Frozen can be used to store any value that is serializable in itself (that is valid JSON).
 Frozen values need to be immutable or treated as if immutable. They need be serializable as well.
@@ -2636,7 +2636,7 @@ ___
 
 ▸ **getChildType**(`object`: IAnyStateTreeNode, `propertyName?`: undefined | string): *[IAnyType](interfaces/ianytype.md)*
 
-*Defined in [src/core/mst-operations.ts:69](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L69)*
+*Defined in [src/core/mst-operations.ts:69](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L69)*
 
 Returns the _declared_ type of the given sub property of an object, array or map.
 In the case of arrays and maps the property name is optional and will be ignored.
@@ -2664,7 +2664,7 @@ ___
 
 ▸ **getEnv**<**T**>(`target`: IAnyStateTreeNode): *T*
 
-*Defined in [src/core/mst-operations.ts:774](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L774)*
+*Defined in [src/core/mst-operations.ts:774](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L774)*
 
 Returns the environment of the current state tree. For more info on environments,
 see [Dependency injection](https://github.com/mobxjs/mobx-state-tree#dependency-injection)
@@ -2692,7 +2692,7 @@ ___
 
 ▸ **getIdentifier**(`target`: IAnyStateTreeNode): *string | null*
 
-*Defined in [src/core/mst-operations.ts:550](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L550)*
+*Defined in [src/core/mst-operations.ts:550](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L550)*
 
 Returns the identifier of the target node.
 This is the *string normalized* identifier, which might not match the type of the identifier attribute
@@ -2711,7 +2711,7 @@ ___
 
 ▸ **getLivelinessChecking**(): *[LivelinessMode](index.md#livelinessmode)*
 
-*Defined in [src/core/node/livelinessChecking.ts:27](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/node/livelinessChecking.ts#L27)*
+*Defined in [src/core/node/livelinessChecking.ts:27](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/node/livelinessChecking.ts#L27)*
 
 Returns the current liveliness checking mode.
 
@@ -2725,7 +2725,7 @@ ___
 
 ▸ **getMembers**(`target`: IAnyStateTreeNode): *[IModelReflectionData](interfaces/imodelreflectiondata.md)*
 
-*Defined in [src/core/mst-operations.ts:853](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L853)*
+*Defined in [src/core/mst-operations.ts:853](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L853)*
 
 Returns a reflection of the model node, including name, properties, views, volatile state,
 and actions. `flowActions` is also provided as a separate array of names for any action that
@@ -2750,7 +2750,7 @@ ___
 
 ▸ **getNodeId**(`target`: IAnyStateTreeNode): *number*
 
-*Defined in [src/core/mst-operations.ts:999](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L999)*
+*Defined in [src/core/mst-operations.ts:999](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L999)*
 
 Returns the unique node id (not to be confused with the instance identifier) for a
 given instance.
@@ -2772,7 +2772,7 @@ ___
 
 ▸ **getParent**<**IT**>(`target`: IAnyStateTreeNode, `depth`: number): *TypeOrStateTreeNodeToStateTreeNode‹IT›*
 
-*Defined in [src/core/mst-operations.ts:383](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L383)*
+*Defined in [src/core/mst-operations.ts:383](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L383)*
 
 Returns the immediate parent of this object, or throws.
 
@@ -2801,7 +2801,7 @@ ___
 
 ▸ **getParentOfType**<**IT**>(`target`: IAnyStateTreeNode, `type`: IT): *IT["Type"]*
 
-*Defined in [src/core/mst-operations.ts:427](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L427)*
+*Defined in [src/core/mst-operations.ts:427](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L427)*
 
 Returns the target's parent of a given type, or throws.
 
@@ -2824,7 +2824,7 @@ ___
 
 ▸ **getPath**(`target`: IAnyStateTreeNode): *string*
 
-*Defined in [src/core/mst-operations.ts:467](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L467)*
+*Defined in [src/core/mst-operations.ts:467](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L467)*
 
 Returns the path of the given object in the model tree
 
@@ -2842,7 +2842,7 @@ ___
 
 ▸ **getPathParts**(`target`: IAnyStateTreeNode): *string[]*
 
-*Defined in [src/core/mst-operations.ts:480](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L480)*
+*Defined in [src/core/mst-operations.ts:480](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L480)*
 
 Returns the path of the given object as unescaped string array.
 
@@ -2860,7 +2860,7 @@ ___
 
 ▸ **getPropertyMembers**(`typeOrNode`: [IAnyModelType](interfaces/ianymodeltype.md) | IAnyStateTreeNode): *[IModelReflectionPropertiesData](interfaces/imodelreflectionpropertiesdata.md)*
 
-*Defined in [src/core/mst-operations.ts:814](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L814)*
+*Defined in [src/core/mst-operations.ts:814](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L814)*
 
 Returns a reflection of the model type properties and name for either a model type or model node.
 
@@ -2878,7 +2878,7 @@ ___
 
 ▸ **getRelativePath**(`base`: IAnyStateTreeNode, `target`: IAnyStateTreeNode): *string*
 
-*Defined in [src/core/mst-operations.ts:649](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L649)*
+*Defined in [src/core/mst-operations.ts:649](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L649)*
 
 Given two state tree nodes that are part of the same tree,
 returns the shortest jsonpath needed to navigate from the one to the other
@@ -2898,7 +2898,7 @@ ___
 
 ▸ **getRoot**<**IT**>(`target`: IAnyStateTreeNode): *TypeOrStateTreeNodeToStateTreeNode‹IT›*
 
-*Defined in [src/core/mst-operations.ts:452](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L452)*
+*Defined in [src/core/mst-operations.ts:452](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L452)*
 
 Given an object in a model tree, returns the root object of that tree.
 
@@ -2923,7 +2923,7 @@ ___
 
 ▸ **getRunningActionContext**(): *[IActionContext](interfaces/iactioncontext.md) | undefined*
 
-*Defined in [src/core/actionContext.ts:26](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L26)*
+*Defined in [src/core/actionContext.ts:26](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L26)*
 
 Returns the currently executing MST action context, or undefined if none.
 
@@ -2935,7 +2935,7 @@ ___
 
 ▸ **getSnapshot**<**S**>(`target`: IStateTreeNode‹[IType](interfaces/itype.md)‹any, S, any››, `applyPostProcess`: boolean): *S*
 
-*Defined in [src/core/mst-operations.ts:337](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L337)*
+*Defined in [src/core/mst-operations.ts:337](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L337)*
 
 Calculates a snapshot from the given model instance. The snapshot will always reflect the latest state but use
 structural sharing where possible. Doesn't require MobX transactions to be completed.
@@ -2959,7 +2959,7 @@ ___
 
 ▸ **getType**(`object`: IAnyStateTreeNode): *[IAnyComplexType](interfaces/ianycomplextype.md)*
 
-*Defined in [src/core/mst-operations.ts:47](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L47)*
+*Defined in [src/core/mst-operations.ts:47](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L47)*
 
 Returns the _actual_ type of the given tree node. (Or throws)
 
@@ -2977,7 +2977,7 @@ ___
 
 ▸ **hasParent**(`target`: IAnyStateTreeNode, `depth`: number): *boolean*
 
-*Defined in [src/core/mst-operations.ts:357](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L357)*
+*Defined in [src/core/mst-operations.ts:357](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L357)*
 
 Given a model instance, returns `true` if the object has a parent, that is, is part of another object, map or array.
 
@@ -2996,7 +2996,7 @@ ___
 
 ▸ **hasParentOfType**(`target`: IAnyStateTreeNode, `type`: [IAnyComplexType](interfaces/ianycomplextype.md)): *boolean*
 
-*Defined in [src/core/mst-operations.ts:407](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L407)*
+*Defined in [src/core/mst-operations.ts:407](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L407)*
 
 Given a model instance, returns `true` if the object has a parent of given type, that is, is part of another object, map or array
 
@@ -3015,7 +3015,7 @@ ___
 
 ▸ **isActionContextChildOf**(`actionContext`: [IActionContext](interfaces/iactioncontext.md), `parent`: number | [IActionContext](interfaces/iactioncontext.md) | [IMiddlewareEvent](interfaces/imiddlewareevent.md)): *boolean*
 
-*Defined in [src/core/actionContext.ts:56](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L56)*
+*Defined in [src/core/actionContext.ts:56](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L56)*
 
 Returns if the given action context is a parent of this action context.
 
@@ -3034,7 +3034,7 @@ ___
 
 ▸ **isActionContextThisOrChildOf**(`actionContext`: [IActionContext](interfaces/iactioncontext.md), `parentOrThis`: number | [IActionContext](interfaces/iactioncontext.md) | [IMiddlewareEvent](interfaces/imiddlewareevent.md)): *boolean*
 
-*Defined in [src/core/actionContext.ts:66](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L66)*
+*Defined in [src/core/actionContext.ts:66](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L66)*
 
 Returns if the given action context is this or a parent of this action context.
 
@@ -3053,7 +3053,7 @@ ___
 
 ▸ **isAlive**(`target`: IAnyStateTreeNode): *boolean*
 
-*Defined in [src/core/mst-operations.ts:717](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L717)*
+*Defined in [src/core/mst-operations.ts:717](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L717)*
 
 Returns true if the given state tree node is not killed yet.
 This means that the node is still a part of a tree, and that `destroy`
@@ -3074,7 +3074,7 @@ ___
 
 ▸ **isArrayType**<**Items**>(`type`: [IAnyType](interfaces/ianytype.md)): *type is IArrayType<Items>*
 
-*Defined in [src/types/complex-types/array.ts:497](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/array.ts#L497)*
+*Defined in [src/types/complex-types/array.ts:497](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/array.ts#L497)*
 
 Returns if a given value represents an array type.
 
@@ -3098,7 +3098,7 @@ ___
 
 ▸ **isFrozenType**<**IT**, **T**>(`type`: IT): *type is IT*
 
-*Defined in [src/types/utility-types/frozen.ts:109](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/frozen.ts#L109)*
+*Defined in [src/types/utility-types/frozen.ts:109](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/frozen.ts#L109)*
 
 Returns if a given value represents a frozen type.
 
@@ -3122,7 +3122,7 @@ ___
 
 ▸ **isIdentifierType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [src/types/utility-types/identifier.ts:133](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/identifier.ts#L133)*
+*Defined in [src/types/utility-types/identifier.ts:133](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/identifier.ts#L133)*
 
 Returns if a given value represents an identifier type.
 
@@ -3144,7 +3144,7 @@ ___
 
 ▸ **isLateType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [src/types/utility-types/late.ts:137](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/late.ts#L137)*
+*Defined in [src/types/utility-types/late.ts:137](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/late.ts#L137)*
 
 Returns if a given value represents a late type.
 
@@ -3166,7 +3166,7 @@ ___
 
 ▸ **isLiteralType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [src/types/utility-types/literal.ts:82](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/literal.ts#L82)*
+*Defined in [src/types/utility-types/literal.ts:82](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/literal.ts#L82)*
 
 Returns if a given value represents a literal type.
 
@@ -3188,7 +3188,7 @@ ___
 
 ▸ **isMapType**<**Items**>(`type`: [IAnyType](interfaces/ianytype.md)): *type is IMapType<Items>*
 
-*Defined in [src/types/complex-types/map.ts:512](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/map.ts#L512)*
+*Defined in [src/types/complex-types/map.ts:512](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/map.ts#L512)*
 
 Returns if a given value represents a map type.
 
@@ -3212,7 +3212,7 @@ ___
 
 ▸ **isModelType**<**IT**>(`type`: [IAnyType](interfaces/ianytype.md)): *type is IT*
 
-*Defined in [src/types/complex-types/model.ts:850](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L850)*
+*Defined in [src/types/complex-types/model.ts:850](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L850)*
 
 Returns if a given value represents a model type.
 
@@ -3234,7 +3234,7 @@ ___
 
 ▸ **isOptionalType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [src/types/utility-types/optional.ts:229](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/optional.ts#L229)*
+*Defined in [src/types/utility-types/optional.ts:229](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/optional.ts#L229)*
 
 Returns if a value represents an optional type.
 
@@ -3258,7 +3258,7 @@ ___
 
 ▸ **isPrimitiveType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [src/types/primitives.ts:241](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/primitives.ts#L241)*
+*Defined in [src/types/primitives.ts:241](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/primitives.ts#L241)*
 
 Returns if a given value represents a primitive type.
 
@@ -3280,7 +3280,7 @@ ___
 
 ▸ **isProtected**(`target`: IAnyStateTreeNode): *boolean*
 
-*Defined in [src/core/mst-operations.ts:311](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L311)*
+*Defined in [src/core/mst-operations.ts:311](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L311)*
 
 Returns true if the object is in protected mode, @see protect
 
@@ -3298,7 +3298,7 @@ ___
 
 ▸ **isReferenceType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [src/types/utility-types/reference.ts:509](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/reference.ts#L509)*
+*Defined in [src/types/utility-types/reference.ts:509](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/reference.ts#L509)*
 
 Returns if a given value represents a reference type.
 
@@ -3320,7 +3320,7 @@ ___
 
 ▸ **isRefinementType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [src/types/utility-types/refinement.ts:124](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/refinement.ts#L124)*
+*Defined in [src/types/utility-types/refinement.ts:124](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/refinement.ts#L124)*
 
 Returns if a given value is a refinement type.
 
@@ -3342,7 +3342,7 @@ ___
 
 ▸ **isRoot**(`target`: IAnyStateTreeNode): *boolean*
 
-*Defined in [src/core/mst-operations.ts:493](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L493)*
+*Defined in [src/core/mst-operations.ts:493](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L493)*
 
 Returns true if the given object is the root of a model tree.
 
@@ -3360,7 +3360,7 @@ ___
 
 ▸ **isStateTreeNode**<**IT**>(`value`: any): *value is STNValue<Instance<IT>, IT>*
 
-*Defined in [src/core/node/node-utils.ts:68](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/node/node-utils.ts#L68)*
+*Defined in [src/core/node/node-utils.ts:68](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/node/node-utils.ts#L68)*
 
 Returns true if the given value is a node in a state tree.
 More precisely, that is, if the value is an instance of a
@@ -3386,7 +3386,7 @@ ___
 
 ▸ **isType**(`value`: any): *value is IAnyType*
 
-*Defined in [src/core/type/type.ts:538](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L538)*
+*Defined in [src/core/type/type.ts:538](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L538)*
 
 Returns if a given value represents a type.
 
@@ -3406,7 +3406,7 @@ ___
 
 ▸ **isUnionType**<**IT**>(`type`: IT): *type is IT*
 
-*Defined in [src/types/utility-types/union.ts:280](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L280)*
+*Defined in [src/types/utility-types/union.ts:280](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L280)*
 
 Returns if a given value represents a union type.
 
@@ -3428,7 +3428,7 @@ ___
 
 ▸ **isValidReference**<**N**>(`getter`: function, `checkIfAlive`: boolean): *boolean*
 
-*Defined in [src/core/mst-operations.ts:597](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L597)*
+*Defined in [src/core/mst-operations.ts:597](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L597)*
 
 Tests if a reference is valid (pointing to an existing node and optionally if alive) and returns if the check passes or not.
 
@@ -3456,7 +3456,7 @@ ___
 
 ▸ **joinJsonPath**(`path`: string[]): *string*
 
-*Defined in [src/core/json-patch.ts:98](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/json-patch.ts#L98)*
+*Defined in [src/core/json-patch.ts:98](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/json-patch.ts#L98)*
 
 Generates a json-path compliant json path from path parts.
 
@@ -3474,7 +3474,7 @@ ___
 
 ▸ **late**<**T**>(`type`: function): *T*
 
-*Defined in [src/types/utility-types/late.ts:99](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/late.ts#L99)*
+*Defined in [src/types/utility-types/late.ts:99](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/late.ts#L99)*
 
 `types.late` - Defines a type that gets implemented later. This is useful when you have to deal with circular dependencies.
 Please notice that when defining circular dependencies TypeScript isn't smart enough to inference them.
@@ -3503,7 +3503,7 @@ A function that returns the type that will be defined.
 
 ▸ **late**<**T**>(`name`: string, `type`: function): *T*
 
-*Defined in [src/types/utility-types/late.ts:100](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/late.ts#L100)*
+*Defined in [src/types/utility-types/late.ts:100](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/late.ts#L100)*
 
 `types.late` - Defines a type that gets implemented later. This is useful when you have to deal with circular dependencies.
 Please notice that when defining circular dependencies TypeScript isn't smart enough to inference them.
@@ -3540,7 +3540,7 @@ ___
 
 ▸ **lazy**<**T**, **U**>(`name`: string, `options`: LazyOptions‹T, U›): *T*
 
-*Defined in [src/types/utility-types/lazy.ts:22](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/lazy.ts#L22)*
+*Defined in [src/types/utility-types/lazy.ts:22](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/lazy.ts#L22)*
 
 **Type parameters:**
 
@@ -3563,7 +3563,7 @@ ___
 
 ▸ **literal**<**S**>(`value`: S): *[ISimpleType](interfaces/isimpletype.md)‹S›*
 
-*Defined in [src/types/utility-types/literal.ts:69](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/literal.ts#L69)*
+*Defined in [src/types/utility-types/literal.ts:69](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/literal.ts#L69)*
 
 `types.literal` - The literal type will return a type that will match only the exact given type.
 The given value must be a primitive, in order to be serialized to a snapshot correctly.
@@ -3595,7 +3595,7 @@ ___
 
 ▸ **map**<**IT**>(`subtype`: IT): *IMapType‹IT›*
 
-*Defined in [src/types/complex-types/map.ts:502](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/map.ts#L502)*
+*Defined in [src/types/complex-types/map.ts:502](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/map.ts#L502)*
 
 `types.map` - Creates a key based collection type who's children are all of a uniform declared type.
 If the type stored in a map has an identifier, it is mandatory to store the child under that identifier in the map.
@@ -3638,7 +3638,7 @@ ___
 
 ▸ **maybe**<**IT**>(`type`: IT): *IMaybe‹IT›*
 
-*Defined in [src/types/utility-types/maybe.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/maybe.ts#L31)*
+*Defined in [src/types/utility-types/maybe.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/maybe.ts#L31)*
 
 `types.maybe` - Maybe will make a type nullable, and also optional.
 The value `undefined` will be used to represent nullability.
@@ -3661,7 +3661,7 @@ ___
 
 ▸ **maybeNull**<**IT**>(`type`: IT): *IMaybeNull‹IT›*
 
-*Defined in [src/types/utility-types/maybe.ts:44](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/maybe.ts#L44)*
+*Defined in [src/types/utility-types/maybe.ts:44](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/maybe.ts#L44)*
 
 `types.maybeNull` - Maybe will make a type nullable, and also optional.
 The value `null` will be used to represent no value.
@@ -3684,7 +3684,7 @@ ___
 
 ▸ **model**<**P**>(`name`: string, `properties?`: [P](undefined)): *[IModelType](interfaces/imodeltype.md)‹ModelPropertiesDeclarationToProperties‹P›, __type›*
 
-*Defined in [src/types/complex-types/model.ts:734](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L734)*
+*Defined in [src/types/complex-types/model.ts:734](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L734)*
 
 `types.model` - Creates a new model type by providing a name, properties, volatile state and actions.
 
@@ -3705,7 +3705,7 @@ Name | Type |
 
 ▸ **model**<**P**>(`properties?`: [P](undefined)): *[IModelType](interfaces/imodeltype.md)‹ModelPropertiesDeclarationToProperties‹P›, __type›*
 
-*Defined in [src/types/complex-types/model.ts:738](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L738)*
+*Defined in [src/types/complex-types/model.ts:738](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L738)*
 
 `types.model` - Creates a new model type by providing a name, properties, volatile state and actions.
 
@@ -3729,7 +3729,7 @@ ___
 
 ▸ **onAction**(`target`: IAnyStateTreeNode, `listener`: function, `attachAfter`: boolean): *[IDisposer](index.md#idisposer)*
 
-*Defined in [src/middlewares/on-action.ts:225](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/on-action.ts#L225)*
+*Defined in [src/middlewares/on-action.ts:225](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/on-action.ts#L225)*
 
 Registers a function that will be invoked for each action that is called on the provided model instance, or to any of its children.
 See [actions](https://github.com/mobxjs/mobx-state-tree#actions) for more details. onAction events are emitted only for the outermost called action in the stack.
@@ -3789,7 +3789,7 @@ ___
 
 ▸ **onPatch**(`target`: IAnyStateTreeNode, `callback`: function): *[IDisposer](index.md#idisposer)*
 
-*Defined in [src/core/mst-operations.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L84)*
+*Defined in [src/core/mst-operations.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L84)*
 
 Registers a function that will be invoked for each mutation that is applied to the provided model instance, or to any of its children.
 See [patches](https://github.com/mobxjs/mobx-state-tree#patches) for more details. onPatch events are emitted immediately and will not await the end of a transaction.
@@ -3824,7 +3824,7 @@ ___
 
 ▸ **onSnapshot**<**S**>(`target`: IStateTreeNode‹[IType](interfaces/itype.md)‹any, S, any››, `callback`: function): *[IDisposer](index.md#idisposer)*
 
-*Defined in [src/core/mst-operations.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L104)*
+*Defined in [src/core/mst-operations.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L104)*
 
 Registers a function that is invoked whenever a new snapshot for the given model instance is available.
 The listener will only be fire at the end of the current MobX (trans)action.
@@ -3856,7 +3856,7 @@ ___
 
 ▸ **optional**<**IT**>(`type`: IT, `defaultValueOrFunction`: OptionalDefaultValueOrFunction‹IT›): *IOptionalIType‹IT, [undefined]›*
 
-*Defined in [src/types/utility-types/optional.ts:155](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/optional.ts#L155)*
+*Defined in [src/types/utility-types/optional.ts:155](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/optional.ts#L155)*
 
 `types.optional` - Can be used to create a property with a default value.
 
@@ -3908,7 +3908,7 @@ Name | Type |
 
 ▸ **optional**<**IT**, **OptionalVals**>(`type`: IT, `defaultValueOrFunction`: OptionalDefaultValueOrFunction‹IT›, `optionalValues`: OptionalVals): *IOptionalIType‹IT, OptionalVals›*
 
-*Defined in [src/types/utility-types/optional.ts:159](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/optional.ts#L159)*
+*Defined in [src/types/utility-types/optional.ts:159](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/optional.ts#L159)*
 
 `types.optional` - Can be used to create a property with a default value.
 
@@ -3967,7 +3967,7 @@ ___
 
 ▸ **protect**(`target`: IAnyStateTreeNode): *void*
 
-*Defined in [src/core/mst-operations.ts:266](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L266)*
+*Defined in [src/core/mst-operations.ts:266](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L266)*
 
 The inverse of `unprotect`.
 
@@ -3985,7 +3985,7 @@ ___
 
 ▸ **recordActions**(`subject`: IAnyStateTreeNode, `filter?`: undefined | function): *[IActionRecorder](interfaces/iactionrecorder.md)*
 
-*Defined in [src/middlewares/on-action.ts:147](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/on-action.ts#L147)*
+*Defined in [src/middlewares/on-action.ts:147](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/on-action.ts#L147)*
 
 Small abstraction around `onAction` and `applyAction`, attaches an action listener to a tree and records all the actions emitted.
 Returns an recorder object with the following signature:
@@ -4023,7 +4023,7 @@ ___
 
 ▸ **recordPatches**(`subject`: IAnyStateTreeNode, `filter?`: undefined | function): *[IPatchRecorder](interfaces/ipatchrecorder.md)*
 
-*Defined in [src/core/mst-operations.ts:178](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L178)*
+*Defined in [src/core/mst-operations.ts:178](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L178)*
 
 Small abstraction around `onPatch` and `applyPatch`, attaches a patch listener to a tree and records all the patches.
 Returns a recorder object with the following signature:
@@ -4066,7 +4066,7 @@ ___
 
 ▸ **reference**<**IT**>(`subType`: IT, `options?`: [ReferenceOptions](index.md#referenceoptions)‹IT›): *IReferenceType‹IT›*
 
-*Defined in [src/types/utility-types/reference.ts:464](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/reference.ts#L464)*
+*Defined in [src/types/utility-types/reference.ts:464](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/reference.ts#L464)*
 
 `types.reference` - Creates a reference to another type, which should have defined an identifier.
 See also the [reference and identifiers](https://github.com/mobxjs/mobx-state-tree#references-and-identifiers) section.
@@ -4090,7 +4090,7 @@ ___
 
 ▸ **refinement**<**IT**>(`name`: string, `type`: IT, `predicate`: function, `message?`: string | function): *IT*
 
-*Defined in [src/types/utility-types/refinement.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/refinement.ts#L84)*
+*Defined in [src/types/utility-types/refinement.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/refinement.ts#L84)*
 
 `types.refinement` - Creates a type that is more specific than the base type, e.g. `types.refinement(types.string, value => value.length > 5)` to create a type of strings that can only be longer then 5.
 
@@ -4120,7 +4120,7 @@ Name | Type |
 
 ▸ **refinement**<**IT**>(`type`: IT, `predicate`: function, `message?`: string | function): *IT*
 
-*Defined in [src/types/utility-types/refinement.ts:90](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/refinement.ts#L90)*
+*Defined in [src/types/utility-types/refinement.ts:90](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/refinement.ts#L90)*
 
 `types.refinement` - Creates a type that is more specific than the base type, e.g. `types.refinement(types.string, value => value.length > 5)` to create a type of strings that can only be longer then 5.
 
@@ -4152,7 +4152,7 @@ ___
 
 ▸ **resolveIdentifier**<**IT**>(`type`: IT, `target`: IAnyStateTreeNode, `identifier`: [ReferenceIdentifier](index.md#referenceidentifier)): *IT["Type"] | undefined*
 
-*Defined in [src/core/mst-operations.ts:526](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L526)*
+*Defined in [src/core/mst-operations.ts:526](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L526)*
 
 Resolves a model instance given a root target, the type and the identifier you are searching for.
 Returns undefined if no value can be found.
@@ -4177,7 +4177,7 @@ ___
 
 ▸ **resolvePath**(`target`: IAnyStateTreeNode, `path`: string): *any*
 
-*Defined in [src/core/mst-operations.ts:508](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L508)*
+*Defined in [src/core/mst-operations.ts:508](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L508)*
 
 Resolves a path relatively to a given object.
 Returns undefined if no value can be found.
@@ -4197,7 +4197,7 @@ ___
 
 ▸ **safeReference**<**IT**>(`subType`: IT, `options`: __type | [ReferenceOptionsGetSet](interfaces/referenceoptionsgetset.md)‹IT› & object): *IReferenceType‹IT›*
 
-*Defined in [src/types/utility-types/reference.ts:513](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/reference.ts#L513)*
+*Defined in [src/types/utility-types/reference.ts:513](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/reference.ts#L513)*
 
 `types.safeReference` - A safe reference is like a standard reference, except that it accepts the undefined value by default
 and automatically sets itself to undefined (when the parent is a model) / removes itself from arrays and maps
@@ -4227,7 +4227,7 @@ Name | Type |
 
 ▸ **safeReference**<**IT**>(`subType`: IT, `options?`: __type | [ReferenceOptionsGetSet](interfaces/referenceoptionsgetset.md)‹IT› & object): *IMaybe‹IReferenceType‹IT››*
 
-*Defined in [src/types/utility-types/reference.ts:520](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/reference.ts#L520)*
+*Defined in [src/types/utility-types/reference.ts:520](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/reference.ts#L520)*
 
 `types.safeReference` - A safe reference is like a standard reference, except that it accepts the undefined value by default
 and automatically sets itself to undefined (when the parent is a model) / removes itself from arrays and maps
@@ -4261,7 +4261,7 @@ ___
 
 ▸ **setLivelinessChecking**(`mode`: [LivelinessMode](index.md#livelinessmode)): *void*
 
-*Defined in [src/core/node/livelinessChecking.ts:18](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/node/livelinessChecking.ts#L18)*
+*Defined in [src/core/node/livelinessChecking.ts:18](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/node/livelinessChecking.ts#L18)*
 
 Defines what MST should do when running into reads / writes to objects that have died.
 By default it will print a warning.
@@ -4281,7 +4281,7 @@ ___
 
 ▸ **snapshotProcessor**<**IT**, **CustomC**, **CustomS**>(`type`: IT, `processors`: [ISnapshotProcessors](interfaces/isnapshotprocessors.md)‹IT["CreationType"], CustomC, IT["SnapshotType"], CustomS›, `name?`: undefined | string): *[ISnapshotProcessor](interfaces/isnapshotprocessor.md)‹IT, CustomC, CustomS›*
 
-*Defined in [src/types/utility-types/snapshotProcessor.ts:246](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/snapshotProcessor.ts#L246)*
+*Defined in [src/types/utility-types/snapshotProcessor.ts:246](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/snapshotProcessor.ts#L246)*
 
 `types.snapshotProcessor` - Runs a pre/post snapshot processor before/after serializing a given type.
 
@@ -4332,7 +4332,7 @@ ___
 
 ▸ **splitJsonPath**(`path`: string): *string[]*
 
-*Defined in [src/core/json-patch.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/json-patch.ts#L118)*
+*Defined in [src/core/json-patch.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/json-patch.ts#L118)*
 
 Splits and decodes a json path into several parts.
 
@@ -4350,7 +4350,7 @@ ___
 
 ▸ **toGenerator**<**R**>(`p`: Promise‹R›): *Generator‹Promise‹R›, R, R›*
 
-*Defined in [src/core/flow.ts:87](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/flow.ts#L87)*
+*Defined in [src/core/flow.ts:87](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/flow.ts#L87)*
 
 **`experimental`** 
 experimental api - might change on minor/patch releases
@@ -4390,7 +4390,7 @@ ___
 
 ▸ **toGeneratorFunction**<**R**, **Args**>(`p`: function): *(Anonymous function)*
 
-*Defined in [src/core/flow.ts:60](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/flow.ts#L60)*
+*Defined in [src/core/flow.ts:60](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/flow.ts#L60)*
 
 **`experimental`** 
 experimental api - might change on minor/patch releases
@@ -4439,7 +4439,7 @@ ___
 
 ▸ **tryReference**<**N**>(`getter`: function, `checkIfAlive`: boolean): *N | undefined*
 
-*Defined in [src/core/mst-operations.ts:565](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L565)*
+*Defined in [src/core/mst-operations.ts:565](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L565)*
 
 Tests if a reference is valid (pointing to an existing node and optionally if alive) and returns such reference if the check passes,
 else it returns undefined.
@@ -4468,7 +4468,7 @@ ___
 
 ▸ **tryResolve**(`target`: IAnyStateTreeNode, `path`: string): *any*
 
-*Defined in [src/core/mst-operations.ts:625](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L625)*
+*Defined in [src/core/mst-operations.ts:625](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L625)*
 
 Try to resolve a given path relative to a given node.
 
@@ -4487,7 +4487,7 @@ ___
 
 ▸ **typecheck**<**IT**>(`type`: IT, `value`: ExtractCSTWithSTN‹IT›): *void*
 
-*Defined in [src/core/type/type-checker.ts:164](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type-checker.ts#L164)*
+*Defined in [src/core/type/type-checker.ts:164](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type-checker.ts#L164)*
 
 Run's the typechecker for the given type on the given value, which can be a snapshot or an instance.
 Throws if the given value is not according the provided type specification.
@@ -4512,7 +4512,7 @@ ___
 
 ▸ **unescapeJsonPath**(`path`: string): *string*
 
-*Defined in [src/core/json-patch.ts:88](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/json-patch.ts#L88)*
+*Defined in [src/core/json-patch.ts:88](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/json-patch.ts#L88)*
 
 Unescape slashes and backslashes.
 
@@ -4530,7 +4530,7 @@ ___
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB››*
 
-*Defined in [src/types/utility-types/union.ts:157](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L157)*
+*Defined in [src/types/utility-types/union.ts:157](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L157)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4563,7 +4563,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB››*
 
-*Defined in [src/types/utility-types/union.ts:159](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L159)*
+*Defined in [src/types/utility-types/union.ts:159](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L159)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4597,7 +4597,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC››*
 
-*Defined in [src/types/utility-types/union.ts:162](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L162)*
+*Defined in [src/types/utility-types/union.ts:162](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L162)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4639,7 +4639,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC››*
 
-*Defined in [src/types/utility-types/union.ts:164](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L164)*
+*Defined in [src/types/utility-types/union.ts:164](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L164)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4682,7 +4682,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD››*
 
-*Defined in [src/types/utility-types/union.ts:166](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L166)*
+*Defined in [src/types/utility-types/union.ts:166](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L166)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4733,7 +4733,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD››*
 
-*Defined in [src/types/utility-types/union.ts:169](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L169)*
+*Defined in [src/types/utility-types/union.ts:169](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L169)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4785,7 +4785,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE››*
 
-*Defined in [src/types/utility-types/union.ts:172](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L172)*
+*Defined in [src/types/utility-types/union.ts:172](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L172)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4845,7 +4845,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE››*
 
-*Defined in [src/types/utility-types/union.ts:175](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L175)*
+*Defined in [src/types/utility-types/union.ts:175](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L175)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4906,7 +4906,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF››*
 
-*Defined in [src/types/utility-types/union.ts:178](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L178)*
+*Defined in [src/types/utility-types/union.ts:178](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L178)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -4975,7 +4975,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF››*
 
-*Defined in [src/types/utility-types/union.ts:181](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L181)*
+*Defined in [src/types/utility-types/union.ts:181](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L181)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5045,7 +5045,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF› | ModelCreationType2‹PG, FCG›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF› | ModelSnapshotType2‹PG, FSG›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF› | ModelInstanceType‹PG, OG››*
 
-*Defined in [src/types/utility-types/union.ts:184](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L184)*
+*Defined in [src/types/utility-types/union.ts:184](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L184)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5123,7 +5123,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF› | ModelCreationType2‹PG, FCG›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF› | ModelSnapshotType2‹PG, FSG›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF› | ModelInstanceType‹PG, OG››*
 
-*Defined in [src/types/utility-types/union.ts:187](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L187)*
+*Defined in [src/types/utility-types/union.ts:187](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L187)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5202,7 +5202,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF› | ModelCreationType2‹PG, FCG› | ModelCreationType2‹PH, FCH›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF› | ModelSnapshotType2‹PG, FSG› | ModelSnapshotType2‹PH, FSH›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF› | ModelInstanceType‹PG, OG› | ModelInstanceType‹PH, OH››*
 
-*Defined in [src/types/utility-types/union.ts:191](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L191)*
+*Defined in [src/types/utility-types/union.ts:191](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L191)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5289,7 +5289,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF› | ModelCreationType2‹PG, FCG› | ModelCreationType2‹PH, FCH›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF› | ModelSnapshotType2‹PG, FSG› | ModelSnapshotType2‹PH, FSH›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF› | ModelInstanceType‹PG, OG› | ModelInstanceType‹PH, OH››*
 
-*Defined in [src/types/utility-types/union.ts:194](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L194)*
+*Defined in [src/types/utility-types/union.ts:194](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L194)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5377,7 +5377,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**, **PI**, **OI**, **FCI**, **FSI**>(`A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›, `I`: [IModelType](interfaces/imodeltype.md)‹PI, OI, FCI, FSI›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF› | ModelCreationType2‹PG, FCG› | ModelCreationType2‹PH, FCH› | ModelCreationType2‹PI, FCI›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF› | ModelSnapshotType2‹PG, FSG› | ModelSnapshotType2‹PH, FSH› | ModelSnapshotType2‹PI, FSI›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF› | ModelInstanceType‹PG, OG› | ModelInstanceType‹PH, OH› | ModelInstanceType‹PI, OI››*
 
-*Defined in [src/types/utility-types/union.ts:198](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L198)*
+*Defined in [src/types/utility-types/union.ts:198](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L198)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5473,7 +5473,7 @@ Name | Type |
 
 ▸ **union**<**PA**, **OA**, **FCA**, **FSA**, **PB**, **OB**, **FCB**, **FSB**, **PC**, **OC**, **FCC**, **FSC**, **PD**, **OD**, **FCD**, **FSD**, **PE**, **OE**, **FCE**, **FSE**, **PF**, **OF**, **FCF**, **FSF**, **PG**, **OG**, **FCG**, **FSG**, **PH**, **OH**, **FCH**, **FSH**, **PI**, **OI**, **FCI**, **FSI**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IModelType](interfaces/imodeltype.md)‹PA, OA, FCA, FSA›, `B`: [IModelType](interfaces/imodeltype.md)‹PB, OB, FCB, FSB›, `C`: [IModelType](interfaces/imodeltype.md)‹PC, OC, FCC, FSC›, `D`: [IModelType](interfaces/imodeltype.md)‹PD, OD, FCD, FSD›, `E`: [IModelType](interfaces/imodeltype.md)‹PE, OE, FCE, FSE›, `F`: [IModelType](interfaces/imodeltype.md)‹PF, OF, FCF, FSF›, `G`: [IModelType](interfaces/imodeltype.md)‹PG, OG, FCG, FSG›, `H`: [IModelType](interfaces/imodeltype.md)‹PH, OH, FCH, FSH›, `I`: [IModelType](interfaces/imodeltype.md)‹PI, OI, FCI, FSI›): *ITypeUnion‹ModelCreationType2‹PA, FCA› | ModelCreationType2‹PB, FCB› | ModelCreationType2‹PC, FCC› | ModelCreationType2‹PD, FCD› | ModelCreationType2‹PE, FCE› | ModelCreationType2‹PF, FCF› | ModelCreationType2‹PG, FCG› | ModelCreationType2‹PH, FCH› | ModelCreationType2‹PI, FCI›, ModelSnapshotType2‹PA, FSA› | ModelSnapshotType2‹PB, FSB› | ModelSnapshotType2‹PC, FSC› | ModelSnapshotType2‹PD, FSD› | ModelSnapshotType2‹PE, FSE› | ModelSnapshotType2‹PF, FSF› | ModelSnapshotType2‹PG, FSG› | ModelSnapshotType2‹PH, FSH› | ModelSnapshotType2‹PI, FSI›, ModelInstanceType‹PA, OA› | ModelInstanceType‹PB, OB› | ModelInstanceType‹PC, OC› | ModelInstanceType‹PD, OD› | ModelInstanceType‹PE, OE› | ModelInstanceType‹PF, OF› | ModelInstanceType‹PG, OG› | ModelInstanceType‹PH, OH› | ModelInstanceType‹PI, OI››*
 
-*Defined in [src/types/utility-types/union.ts:201](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L201)*
+*Defined in [src/types/utility-types/union.ts:201](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L201)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5570,7 +5570,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›): *ITypeUnion‹CA | CB, SA | SB, TA | TB›*
 
-*Defined in [src/types/utility-types/union.ts:205](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L205)*
+*Defined in [src/types/utility-types/union.ts:205](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L205)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5599,7 +5599,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›): *ITypeUnion‹CA | CB, SA | SB, TA | TB›*
 
-*Defined in [src/types/utility-types/union.ts:207](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L207)*
+*Defined in [src/types/utility-types/union.ts:207](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L207)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5629,7 +5629,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›): *ITypeUnion‹CA | CB | CC, SA | SB | SC, TA | TB | TC›*
 
-*Defined in [src/types/utility-types/union.ts:209](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L209)*
+*Defined in [src/types/utility-types/union.ts:209](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L209)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5665,7 +5665,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›): *ITypeUnion‹CA | CB | CC, SA | SB | SC, TA | TB | TC›*
 
-*Defined in [src/types/utility-types/union.ts:211](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L211)*
+*Defined in [src/types/utility-types/union.ts:211](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L211)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5702,7 +5702,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›): *ITypeUnion‹CA | CB | CC | CD, SA | SB | SC | SD, TA | TB | TC | TD›*
 
-*Defined in [src/types/utility-types/union.ts:213](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L213)*
+*Defined in [src/types/utility-types/union.ts:213](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L213)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5745,7 +5745,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›): *ITypeUnion‹CA | CB | CC | CD, SA | SB | SC | SD, TA | TB | TC | TD›*
 
-*Defined in [src/types/utility-types/union.ts:216](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L216)*
+*Defined in [src/types/utility-types/union.ts:216](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L216)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5789,7 +5789,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›): *ITypeUnion‹CA | CB | CC | CD | CE, SA | SB | SC | SD | SE, TA | TB | TC | TD | TE›*
 
-*Defined in [src/types/utility-types/union.ts:218](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L218)*
+*Defined in [src/types/utility-types/union.ts:218](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L218)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5839,7 +5839,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›): *ITypeUnion‹CA | CB | CC | CD | CE, SA | SB | SC | SD | SE, TA | TB | TC | TD | TE›*
 
-*Defined in [src/types/utility-types/union.ts:220](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L220)*
+*Defined in [src/types/utility-types/union.ts:220](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L220)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5890,7 +5890,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›): *ITypeUnion‹CA | CB | CC | CD | CE | CF, SA | SB | SC | SD | SE | SF, TA | TB | TC | TD | TE | TF›*
 
-*Defined in [src/types/utility-types/union.ts:222](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L222)*
+*Defined in [src/types/utility-types/union.ts:222](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L222)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -5947,7 +5947,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›): *ITypeUnion‹CA | CB | CC | CD | CE | CF, SA | SB | SC | SD | SE | SF, TA | TB | TC | TD | TE | TF›*
 
-*Defined in [src/types/utility-types/union.ts:224](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L224)*
+*Defined in [src/types/utility-types/union.ts:224](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L224)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6005,7 +6005,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**, **CG**, **SG**, **TG**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›, `G`: [IType](interfaces/itype.md)‹CG, SG, TG›): *ITypeUnion‹CA | CB | CC | CD | CE | CF | CG, SA | SB | SC | SD | SE | SF | SG, TA | TB | TC | TD | TE | TF | TG›*
 
-*Defined in [src/types/utility-types/union.ts:226](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L226)*
+*Defined in [src/types/utility-types/union.ts:226](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L226)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6069,7 +6069,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**, **CG**, **SG**, **TG**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›, `G`: [IType](interfaces/itype.md)‹CG, SG, TG›): *ITypeUnion‹CA | CB | CC | CD | CE | CF | CG, SA | SB | SC | SD | SE | SF | SG, TA | TB | TC | TD | TE | TF | TG›*
 
-*Defined in [src/types/utility-types/union.ts:229](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L229)*
+*Defined in [src/types/utility-types/union.ts:229](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L229)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6134,7 +6134,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**, **CG**, **SG**, **TG**, **CH**, **SH**, **TH**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›, `G`: [IType](interfaces/itype.md)‹CG, SG, TG›, `H`: [IType](interfaces/itype.md)‹CH, SH, TH›): *ITypeUnion‹CA | CB | CC | CD | CE | CF | CG | CH, SA | SB | SC | SD | SE | SF | SG | SH, TA | TB | TC | TD | TE | TF | TG | TH›*
 
-*Defined in [src/types/utility-types/union.ts:231](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L231)*
+*Defined in [src/types/utility-types/union.ts:231](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L231)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6205,7 +6205,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**, **CG**, **SG**, **TG**, **CH**, **SH**, **TH**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›, `G`: [IType](interfaces/itype.md)‹CG, SG, TG›, `H`: [IType](interfaces/itype.md)‹CH, SH, TH›): *ITypeUnion‹CA | CB | CC | CD | CE | CF | CG | CH, SA | SB | SC | SD | SE | SF | SG | SH, TA | TB | TC | TD | TE | TF | TG | TH›*
 
-*Defined in [src/types/utility-types/union.ts:234](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L234)*
+*Defined in [src/types/utility-types/union.ts:234](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L234)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6277,7 +6277,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**, **CG**, **SG**, **TG**, **CH**, **SH**, **TH**, **CI**, **SI**, **TI**>(`A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›, `G`: [IType](interfaces/itype.md)‹CG, SG, TG›, `H`: [IType](interfaces/itype.md)‹CH, SH, TH›, `I`: [IType](interfaces/itype.md)‹CI, SI, TI›): *ITypeUnion‹CA | CB | CC | CD | CE | CF | CG | CH | CI, SA | SB | SC | SD | SE | SF | SG | SH | SI, TA | TB | TC | TD | TE | TF | TG | TH | TI›*
 
-*Defined in [src/types/utility-types/union.ts:237](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L237)*
+*Defined in [src/types/utility-types/union.ts:237](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L237)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6355,7 +6355,7 @@ Name | Type |
 
 ▸ **union**<**CA**, **SA**, **TA**, **CB**, **SB**, **TB**, **CC**, **SC**, **TC**, **CD**, **SD**, **TD**, **CE**, **SE**, **TE**, **CF**, **SF**, **TF**, **CG**, **SG**, **TG**, **CH**, **SH**, **TH**, **CI**, **SI**, **TI**>(`options`: [UnionOptions](interfaces/unionoptions.md), `A`: [IType](interfaces/itype.md)‹CA, SA, TA›, `B`: [IType](interfaces/itype.md)‹CB, SB, TB›, `C`: [IType](interfaces/itype.md)‹CC, SC, TC›, `D`: [IType](interfaces/itype.md)‹CD, SD, TD›, `E`: [IType](interfaces/itype.md)‹CE, SE, TE›, `F`: [IType](interfaces/itype.md)‹CF, SF, TF›, `G`: [IType](interfaces/itype.md)‹CG, SG, TG›, `H`: [IType](interfaces/itype.md)‹CH, SH, TH›, `I`: [IType](interfaces/itype.md)‹CI, SI, TI›): *ITypeUnion‹CA | CB | CC | CD | CE | CF | CG | CH | CI, SA | SB | SC | SD | SE | SF | SG | SH | SI, TA | TB | TC | TD | TE | TF | TG | TH | TI›*
 
-*Defined in [src/types/utility-types/union.ts:240](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L240)*
+*Defined in [src/types/utility-types/union.ts:240](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L240)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6434,7 +6434,7 @@ Name | Type |
 
 ▸ **union**(...`types`: [IAnyType](interfaces/ianytype.md)[]): *[IAnyType](interfaces/ianytype.md)*
 
-*Defined in [src/types/utility-types/union.ts:243](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L243)*
+*Defined in [src/types/utility-types/union.ts:243](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L243)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6448,7 +6448,7 @@ Name | Type |
 
 ▸ **union**(`dispatchOrType`: [UnionOptions](interfaces/unionoptions.md) | [IAnyType](interfaces/ianytype.md), ...`otherTypes`: [IAnyType](interfaces/ianytype.md)[]): *[IAnyType](interfaces/ianytype.md)*
 
-*Defined in [src/types/utility-types/union.ts:244](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L244)*
+*Defined in [src/types/utility-types/union.ts:244](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L244)*
 
 `types.union` - Create a union of multiple types. If the correct type cannot be inferred unambiguously from a snapshot, provide a dispatcher function of the form `(snapshot) => Type`.
 
@@ -6467,7 +6467,7 @@ ___
 
 ▸ **unprotect**(`target`: IAnyStateTreeNode): *void*
 
-*Defined in [src/core/mst-operations.ts:299](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L299)*
+*Defined in [src/core/mst-operations.ts:299](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L299)*
 
 By default it is not allowed to directly modify a model. Models can only be modified through actions.
 However, in some cases you don't care about the advantages (like replayability, traceability, etc) this yields.
@@ -6506,7 +6506,7 @@ ___
 
 ▸ **walk**(`target`: IAnyStateTreeNode, `processor`: function): *void*
 
-*Defined in [src/core/mst-operations.ts:787](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L787)*
+*Defined in [src/core/mst-operations.ts:787](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L787)*
 
 Performs a depth first walk through a tree.
 
@@ -6532,178 +6532,178 @@ Name | Type |
 
 ### ▪ **types**: *object*
 
-*Defined in [src/types/index.ts:34](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L34)*
+*Defined in [src/types/index.ts:34](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L34)*
 
 ###  Date
 
 • **Date**: *[IType](interfaces/itype.md)‹number | Date, number, Date›* =  DatePrimitive
 
-*Defined in [src/types/index.ts:53](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L53)*
+*Defined in [src/types/index.ts:53](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L53)*
 
 ###  array
 
 • **array**: *[array](index.md#array)*
 
-*Defined in [src/types/index.ts:55](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L55)*
+*Defined in [src/types/index.ts:55](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L55)*
 
 ###  boolean
 
 • **boolean**: *[ISimpleType](interfaces/isimpletype.md)‹boolean›*
 
-*Defined in [src/types/index.ts:48](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L48)*
+*Defined in [src/types/index.ts:48](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L48)*
 
 ###  compose
 
 • **compose**: *[compose](index.md#compose)*
 
-*Defined in [src/types/index.ts:37](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L37)*
+*Defined in [src/types/index.ts:37](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L37)*
 
 ###  custom
 
 • **custom**: *[custom](index.md#custom)*
 
-*Defined in [src/types/index.ts:38](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L38)*
+*Defined in [src/types/index.ts:38](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L38)*
 
 ###  enumeration
 
 • **enumeration**: *[enumeration](index.md#enumeration)*
 
-*Defined in [src/types/index.ts:35](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L35)*
+*Defined in [src/types/index.ts:35](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L35)*
 
 ###  finite
 
 • **finite**: *[ISimpleType](interfaces/isimpletype.md)‹number›*
 
-*Defined in [src/types/index.ts:52](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L52)*
+*Defined in [src/types/index.ts:52](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L52)*
 
 ###  float
 
 • **float**: *[ISimpleType](interfaces/isimpletype.md)‹number›*
 
-*Defined in [src/types/index.ts:51](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L51)*
+*Defined in [src/types/index.ts:51](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L51)*
 
 ###  frozen
 
 • **frozen**: *[frozen](index.md#frozen)*
 
-*Defined in [src/types/index.ts:56](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L56)*
+*Defined in [src/types/index.ts:56](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L56)*
 
 ###  identifier
 
 • **identifier**: *[ISimpleType](interfaces/isimpletype.md)‹string›*
 
-*Defined in [src/types/index.ts:57](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L57)*
+*Defined in [src/types/index.ts:57](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L57)*
 
 ###  identifierNumber
 
 • **identifierNumber**: *[ISimpleType](interfaces/isimpletype.md)‹number›*
 
-*Defined in [src/types/index.ts:58](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L58)*
+*Defined in [src/types/index.ts:58](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L58)*
 
 ###  integer
 
 • **integer**: *[ISimpleType](interfaces/isimpletype.md)‹number›*
 
-*Defined in [src/types/index.ts:50](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L50)*
+*Defined in [src/types/index.ts:50](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L50)*
 
 ###  late
 
 • **late**: *[late](index.md#late)*
 
-*Defined in [src/types/index.ts:59](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L59)*
+*Defined in [src/types/index.ts:59](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L59)*
 
 ###  lazy
 
 • **lazy**: *[lazy](index.md#lazy)*
 
-*Defined in [src/types/index.ts:60](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L60)*
+*Defined in [src/types/index.ts:60](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L60)*
 
 ###  literal
 
 • **literal**: *[literal](index.md#literal)*
 
-*Defined in [src/types/index.ts:43](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L43)*
+*Defined in [src/types/index.ts:43](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L43)*
 
 ###  map
 
 • **map**: *[map](index.md#map)*
 
-*Defined in [src/types/index.ts:54](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L54)*
+*Defined in [src/types/index.ts:54](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L54)*
 
 ###  maybe
 
 • **maybe**: *[maybe](index.md#maybe)*
 
-*Defined in [src/types/index.ts:44](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L44)*
+*Defined in [src/types/index.ts:44](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L44)*
 
 ###  maybeNull
 
 • **maybeNull**: *[maybeNull](index.md#maybenull)*
 
-*Defined in [src/types/index.ts:45](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L45)*
+*Defined in [src/types/index.ts:45](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L45)*
 
 ###  model
 
 • **model**: *[model](index.md#model)*
 
-*Defined in [src/types/index.ts:36](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L36)*
+*Defined in [src/types/index.ts:36](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L36)*
 
 ###  null
 
 • **null**: *[ISimpleType](interfaces/isimpletype.md)‹null›* =  nullType
 
-*Defined in [src/types/index.ts:62](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L62)*
+*Defined in [src/types/index.ts:62](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L62)*
 
 ###  number
 
 • **number**: *[ISimpleType](interfaces/isimpletype.md)‹number›*
 
-*Defined in [src/types/index.ts:49](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L49)*
+*Defined in [src/types/index.ts:49](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L49)*
 
 ###  optional
 
 • **optional**: *[optional](index.md#optional)*
 
-*Defined in [src/types/index.ts:42](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L42)*
+*Defined in [src/types/index.ts:42](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L42)*
 
 ###  reference
 
 • **reference**: *[reference](index.md#reference)*
 
-*Defined in [src/types/index.ts:39](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L39)*
+*Defined in [src/types/index.ts:39](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L39)*
 
 ###  refinement
 
 • **refinement**: *[refinement](index.md#refinement)*
 
-*Defined in [src/types/index.ts:46](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L46)*
+*Defined in [src/types/index.ts:46](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L46)*
 
 ###  safeReference
 
 • **safeReference**: *[safeReference](index.md#safereference)*
 
-*Defined in [src/types/index.ts:40](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L40)*
+*Defined in [src/types/index.ts:40](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L40)*
 
 ###  snapshotProcessor
 
 • **snapshotProcessor**: *[snapshotProcessor](index.md#snapshotprocessor)*
 
-*Defined in [src/types/index.ts:63](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L63)*
+*Defined in [src/types/index.ts:63](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L63)*
 
 ###  string
 
 • **string**: *[ISimpleType](interfaces/isimpletype.md)‹string›*
 
-*Defined in [src/types/index.ts:47](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L47)*
+*Defined in [src/types/index.ts:47](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L47)*
 
 ###  undefined
 
 • **undefined**: *[ISimpleType](interfaces/isimpletype.md)‹undefined›* =  undefinedType
 
-*Defined in [src/types/index.ts:61](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L61)*
+*Defined in [src/types/index.ts:61](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L61)*
 
 ###  union
 
 • **union**: *[union](index.md#union)*
 
-*Defined in [src/types/index.ts:41](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/index.ts#L41)*
+*Defined in [src/types/index.ts:41](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/index.ts#L41)*

--- a/docs/API/interfaces/customtypeoptions.md
+++ b/docs/API/interfaces/customtypeoptions.md
@@ -4,7 +4,7 @@ title: "CustomTypeOptions"
 sidebar_label: "CustomTypeOptions"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [CustomTypeOptions](customtypeoptions.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [CustomTypeOptions](customtypeoptions.md)
 
 ## Type parameters
 
@@ -35,7 +35,7 @@ sidebar_label: "CustomTypeOptions"
 
 • **name**: *string*
 
-*Defined in [src/types/utility-types/custom.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/custom.ts#L15)*
+*Defined in [src/types/utility-types/custom.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/custom.ts#L15)*
 
 Friendly name
 
@@ -45,7 +45,7 @@ Friendly name
 
 ▸ **fromSnapshot**(`snapshot`: S, `env?`: any): *T*
 
-*Defined in [src/types/utility-types/custom.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/custom.ts#L17)*
+*Defined in [src/types/utility-types/custom.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/custom.ts#L17)*
 
 given a serialized value and environment, how to turn it into the target type
 
@@ -64,7 +64,7 @@ ___
 
 ▸ **getValidationMessage**(`snapshot`: S): *string*
 
-*Defined in [src/types/utility-types/custom.ts:23](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/custom.ts#L23)*
+*Defined in [src/types/utility-types/custom.ts:23](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/custom.ts#L23)*
 
 a non empty string is assumed to be a validation error
 
@@ -82,7 +82,7 @@ ___
 
 ▸ **isTargetType**(`value`: T | S): *boolean*
 
-*Defined in [src/types/utility-types/custom.ts:21](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/custom.ts#L21)*
+*Defined in [src/types/utility-types/custom.ts:21](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/custom.ts#L21)*
 
 if true, this is a converted value, if false, it's a snapshot
 
@@ -100,7 +100,7 @@ ___
 
 ▸ **toSnapshot**(`value`: T): *S*
 
-*Defined in [src/types/utility-types/custom.ts:19](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/custom.ts#L19)*
+*Defined in [src/types/utility-types/custom.ts:19](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/custom.ts#L19)*
 
 return the serialization of the current value
 

--- a/docs/API/interfaces/functionwithflag.md
+++ b/docs/API/interfaces/functionwithflag.md
@@ -4,7 +4,7 @@ title: "FunctionWithFlag"
 sidebar_label: "FunctionWithFlag"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [FunctionWithFlag](functionwithflag.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [FunctionWithFlag](functionwithflag.md)
 
 ## Hierarchy
 
@@ -47,7 +47,7 @@ ___
 
 • **_isFlowAction**? : *undefined | false | true*
 
-*Defined in [src/core/action.ts:42](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/action.ts#L42)*
+*Defined in [src/core/action.ts:42](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/action.ts#L42)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 • **_isMSTAction**? : *undefined | false | true*
 
-*Defined in [src/core/action.ts:41](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/action.ts#L41)*
+*Defined in [src/core/action.ts:41](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/action.ts#L41)*
 
 ___
 

--- a/docs/API/interfaces/iactioncontext.md
+++ b/docs/API/interfaces/iactioncontext.md
@@ -4,7 +4,7 @@ title: "IActionContext"
 sidebar_label: "IActionContext"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IActionContext](iactioncontext.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IActionContext](iactioncontext.md)
 
 ## Hierarchy
 
@@ -29,7 +29,7 @@ sidebar_label: "IActionContext"
 
 • **args**: *any[]*
 
-*Defined in [src/core/actionContext.ts:20](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L20)*
+*Defined in [src/core/actionContext.ts:20](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L20)*
 
 Event arguments in an array (action arguments for actions)
 
@@ -39,7 +39,7 @@ ___
 
 • **context**: *IAnyStateTreeNode*
 
-*Defined in [src/core/actionContext.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L15)*
+*Defined in [src/core/actionContext.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L15)*
 
 Event context (node where the action was invoked)
 
@@ -49,7 +49,7 @@ ___
 
 • **id**: *number*
 
-*Defined in [src/core/actionContext.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L9)*
+*Defined in [src/core/actionContext.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L9)*
 
 Event unique id
 
@@ -59,7 +59,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/core/actionContext.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L6)*
+*Defined in [src/core/actionContext.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L6)*
 
 Event name (action name for actions)
 
@@ -69,7 +69,7 @@ ___
 
 • **parentActionEvent**: *[IMiddlewareEvent](imiddlewareevent.md) | undefined*
 
-*Defined in [src/core/actionContext.ts:12](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L12)*
+*Defined in [src/core/actionContext.ts:12](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L12)*
 
 Parent action event object
 
@@ -79,6 +79,6 @@ ___
 
 • **tree**: *IAnyStateTreeNode*
 
-*Defined in [src/core/actionContext.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L17)*
+*Defined in [src/core/actionContext.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L17)*
 
 Event tree (root node of the node where the action was invoked)

--- a/docs/API/interfaces/iactionrecorder.md
+++ b/docs/API/interfaces/iactionrecorder.md
@@ -4,7 +4,7 @@ title: "IActionRecorder"
 sidebar_label: "IActionRecorder"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IActionRecorder](iactionrecorder.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IActionRecorder](iactionrecorder.md)
 
 ## Hierarchy
 
@@ -29,7 +29,7 @@ sidebar_label: "IActionRecorder"
 
 • **actions**: *ReadonlyArray‹[ISerializedActionCall](iserializedactioncall.md)›*
 
-*Defined in [src/middlewares/on-action.ts:37](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/on-action.ts#L37)*
+*Defined in [src/middlewares/on-action.ts:37](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/on-action.ts#L37)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **recording**: *boolean*
 
-*Defined in [src/middlewares/on-action.ts:38](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/on-action.ts#L38)*
+*Defined in [src/middlewares/on-action.ts:38](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/on-action.ts#L38)*
 
 ## Methods
 
@@ -45,7 +45,7 @@ ___
 
 ▸ **replay**(`target`: IAnyStateTreeNode): *void*
 
-*Defined in [src/middlewares/on-action.ts:41](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/on-action.ts#L41)*
+*Defined in [src/middlewares/on-action.ts:41](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/on-action.ts#L41)*
 
 **Parameters:**
 
@@ -61,7 +61,7 @@ ___
 
 ▸ **resume**(): *void*
 
-*Defined in [src/middlewares/on-action.ts:40](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/on-action.ts#L40)*
+*Defined in [src/middlewares/on-action.ts:40](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/on-action.ts#L40)*
 
 **Returns:** *void*
 
@@ -71,6 +71,6 @@ ___
 
 ▸ **stop**(): *void*
 
-*Defined in [src/middlewares/on-action.ts:39](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/on-action.ts#L39)*
+*Defined in [src/middlewares/on-action.ts:39](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/on-action.ts#L39)*
 
 **Returns:** *void*

--- a/docs/API/interfaces/iactiontrackingmiddleware2call.md
+++ b/docs/API/interfaces/iactiontrackingmiddleware2call.md
@@ -4,7 +4,7 @@ title: "IActionTrackingMiddleware2Call"
 sidebar_label: "IActionTrackingMiddleware2Call"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IActionTrackingMiddleware2Call](iactiontrackingmiddleware2call.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IActionTrackingMiddleware2Call](iactiontrackingmiddleware2call.md)
 
 ## Type parameters
 
@@ -29,7 +29,7 @@ sidebar_label: "IActionTrackingMiddleware2Call"
 
 • **env**: *TEnv | undefined*
 
-*Defined in [src/middlewares/createActionTrackingMiddleware2.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/createActionTrackingMiddleware2.ts#L6)*
+*Defined in [src/middlewares/createActionTrackingMiddleware2.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/createActionTrackingMiddleware2.ts#L6)*
 
 ___
 
@@ -37,4 +37,4 @@ ___
 
 • **parentCall**? : *[IActionTrackingMiddleware2Call](iactiontrackingmiddleware2call.md)‹TEnv›*
 
-*Defined in [src/middlewares/createActionTrackingMiddleware2.ts:7](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/createActionTrackingMiddleware2.ts#L7)*
+*Defined in [src/middlewares/createActionTrackingMiddleware2.ts:7](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/createActionTrackingMiddleware2.ts#L7)*

--- a/docs/API/interfaces/iactiontrackingmiddleware2hooks.md
+++ b/docs/API/interfaces/iactiontrackingmiddleware2hooks.md
@@ -4,7 +4,7 @@ title: "IActionTrackingMiddleware2Hooks"
 sidebar_label: "IActionTrackingMiddleware2Hooks"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IActionTrackingMiddleware2Hooks](iactiontrackingmiddleware2hooks.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IActionTrackingMiddleware2Hooks](iactiontrackingmiddleware2hooks.md)
 
 ## Type parameters
 
@@ -28,7 +28,7 @@ sidebar_label: "IActionTrackingMiddleware2Hooks"
 
 • **filter**? : *undefined | function*
 
-*Defined in [src/middlewares/createActionTrackingMiddleware2.ts:11](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/createActionTrackingMiddleware2.ts#L11)*
+*Defined in [src/middlewares/createActionTrackingMiddleware2.ts:11](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/createActionTrackingMiddleware2.ts#L11)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 • **onFinish**: *function*
 
-*Defined in [src/middlewares/createActionTrackingMiddleware2.ts:13](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/createActionTrackingMiddleware2.ts#L13)*
+*Defined in [src/middlewares/createActionTrackingMiddleware2.ts:13](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/createActionTrackingMiddleware2.ts#L13)*
 
 #### Type declaration:
 
@@ -55,7 +55,7 @@ ___
 
 • **onStart**: *function*
 
-*Defined in [src/middlewares/createActionTrackingMiddleware2.ts:12](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/createActionTrackingMiddleware2.ts#L12)*
+*Defined in [src/middlewares/createActionTrackingMiddleware2.ts:12](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/createActionTrackingMiddleware2.ts#L12)*
 
 #### Type declaration:
 

--- a/docs/API/interfaces/iactiontrackingmiddlewarehooks.md
+++ b/docs/API/interfaces/iactiontrackingmiddlewarehooks.md
@@ -4,7 +4,7 @@ title: "IActionTrackingMiddlewareHooks"
 sidebar_label: "IActionTrackingMiddlewareHooks"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IActionTrackingMiddlewareHooks](iactiontrackingmiddlewarehooks.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IActionTrackingMiddlewareHooks](iactiontrackingmiddlewarehooks.md)
 
 ## Type parameters
 
@@ -31,7 +31,7 @@ sidebar_label: "IActionTrackingMiddlewareHooks"
 
 • **filter**? : *undefined | function*
 
-*Defined in [src/middlewares/create-action-tracking-middleware.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/create-action-tracking-middleware.ts#L6)*
+*Defined in [src/middlewares/create-action-tracking-middleware.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/create-action-tracking-middleware.ts#L6)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • **onFail**: *function*
 
-*Defined in [src/middlewares/create-action-tracking-middleware.ts:11](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/create-action-tracking-middleware.ts#L11)*
+*Defined in [src/middlewares/create-action-tracking-middleware.ts:11](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/create-action-tracking-middleware.ts#L11)*
 
 #### Type declaration:
 
@@ -59,7 +59,7 @@ ___
 
 • **onResume**: *function*
 
-*Defined in [src/middlewares/create-action-tracking-middleware.ts:8](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/create-action-tracking-middleware.ts#L8)*
+*Defined in [src/middlewares/create-action-tracking-middleware.ts:8](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/create-action-tracking-middleware.ts#L8)*
 
 #### Type declaration:
 
@@ -78,7 +78,7 @@ ___
 
 • **onStart**: *function*
 
-*Defined in [src/middlewares/create-action-tracking-middleware.ts:7](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/create-action-tracking-middleware.ts#L7)*
+*Defined in [src/middlewares/create-action-tracking-middleware.ts:7](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/create-action-tracking-middleware.ts#L7)*
 
 #### Type declaration:
 
@@ -96,7 +96,7 @@ ___
 
 • **onSuccess**: *function*
 
-*Defined in [src/middlewares/create-action-tracking-middleware.ts:10](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/create-action-tracking-middleware.ts#L10)*
+*Defined in [src/middlewares/create-action-tracking-middleware.ts:10](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/create-action-tracking-middleware.ts#L10)*
 
 #### Type declaration:
 
@@ -116,7 +116,7 @@ ___
 
 • **onSuspend**: *function*
 
-*Defined in [src/middlewares/create-action-tracking-middleware.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/create-action-tracking-middleware.ts#L9)*
+*Defined in [src/middlewares/create-action-tracking-middleware.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/create-action-tracking-middleware.ts#L9)*
 
 #### Type declaration:
 

--- a/docs/API/interfaces/ianycomplextype.md
+++ b/docs/API/interfaces/ianycomplextype.md
@@ -4,7 +4,7 @@ title: "IAnyComplexType"
 sidebar_label: "IAnyComplexType"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IAnyComplexType](ianycomplextype.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IAnyComplexType](ianycomplextype.md)
 
 Any kind of complex type.
 
@@ -36,7 +36,7 @@ Any kind of complex type.
 
 *Inherited from [IType](itype.md).[identifierAttribute](itype.md#optional-identifierattribute)*
 
-*Defined in [src/core/type/type.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L89)*
+*Defined in [src/core/type/type.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L89)*
 
 Name of the identifier attribute or null if none.
 
@@ -48,7 +48,7 @@ ___
 
 *Inherited from [IType](itype.md).[name](itype.md#name)*
 
-*Defined in [src/core/type/type.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L84)*
+*Defined in [src/core/type/type.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L84)*
 
 Friendly type name.
 
@@ -60,7 +60,7 @@ Friendly type name.
 
 *Inherited from [IType](itype.md).[create](itype.md#create)*
 
-*Defined in [src/core/type/type.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L96)*
+*Defined in [src/core/type/type.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L96)*
 
 Creates an instance for the type given an snapshot input.
 
@@ -83,7 +83,7 @@ ___
 
 *Inherited from [IType](itype.md).[describe](itype.md#describe)*
 
-*Defined in [src/core/type/type.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L118)*
+*Defined in [src/core/type/type.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L118)*
 
 Gets the textual representation of the type as a string.
 
@@ -97,7 +97,7 @@ ___
 
 *Inherited from [IType](itype.md).[is](itype.md#is)*
 
-*Defined in [src/core/type/type.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L104)*
+*Defined in [src/core/type/type.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L104)*
 
 Checks if a given snapshot / instance is of the given type.
 
@@ -119,7 +119,7 @@ ___
 
 *Inherited from [IType](itype.md).[validate](itype.md#validate)*
 
-*Defined in [src/core/type/type.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L113)*
+*Defined in [src/core/type/type.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L113)*
 
 Run's the type's typechecker on the given value with the given validation context.
 

--- a/docs/API/interfaces/ianymodeltype.md
+++ b/docs/API/interfaces/ianymodeltype.md
@@ -4,7 +4,7 @@ title: "IAnyModelType"
 sidebar_label: "IAnyModelType"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IAnyModelType](ianymodeltype.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IAnyModelType](ianymodeltype.md)
 
 Any model type.
 
@@ -45,7 +45,7 @@ Any model type.
 
 *Inherited from [IType](itype.md).[identifierAttribute](itype.md#optional-identifierattribute)*
 
-*Defined in [src/core/type/type.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L89)*
+*Defined in [src/core/type/type.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L89)*
 
 Name of the identifier attribute or null if none.
 
@@ -57,7 +57,7 @@ ___
 
 *Inherited from [IType](itype.md).[name](itype.md#name)*
 
-*Defined in [src/core/type/type.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L84)*
+*Defined in [src/core/type/type.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L84)*
 
 Friendly type name.
 
@@ -69,7 +69,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[properties](imodeltype.md#properties)*
 
-*Defined in [src/types/complex-types/model.ts:187](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L187)*
+*Defined in [src/types/complex-types/model.ts:187](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L187)*
 
 ## Methods
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[actions](imodeltype.md#actions)*
 
-*Defined in [src/types/complex-types/model.ts:201](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L201)*
+*Defined in [src/types/complex-types/model.ts:201](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L201)*
 
 **Type parameters:**
 
@@ -107,7 +107,7 @@ ___
 
 *Inherited from [IType](itype.md).[create](itype.md#create)*
 
-*Defined in [src/core/type/type.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L96)*
+*Defined in [src/core/type/type.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L96)*
 
 Creates an instance for the type given an snapshot input.
 
@@ -130,7 +130,7 @@ ___
 
 *Inherited from [IType](itype.md).[describe](itype.md#describe)*
 
-*Defined in [src/core/type/type.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L118)*
+*Defined in [src/core/type/type.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L118)*
 
 Gets the textual representation of the type as a string.
 
@@ -144,7 +144,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[extend](imodeltype.md#extend)*
 
-*Defined in [src/types/complex-types/model.ts:209](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L209)*
+*Defined in [src/types/complex-types/model.ts:209](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L209)*
 
 **Type parameters:**
 
@@ -176,7 +176,7 @@ ___
 
 *Inherited from [IType](itype.md).[is](itype.md#is)*
 
-*Defined in [src/core/type/type.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L104)*
+*Defined in [src/core/type/type.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L104)*
 
 Checks if a given snapshot / instance is of the given type.
 
@@ -198,7 +198,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[named](imodeltype.md#named)*
 
-*Defined in [src/types/complex-types/model.ts:189](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L189)*
+*Defined in [src/types/complex-types/model.ts:189](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L189)*
 
 **Parameters:**
 
@@ -216,7 +216,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[postProcessSnapshot](imodeltype.md#postprocesssnapshot)*
 
-*Defined in [src/types/complex-types/model.ts:217](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L217)*
+*Defined in [src/types/complex-types/model.ts:217](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L217)*
 
 **Type parameters:**
 
@@ -244,7 +244,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[preProcessSnapshot](imodeltype.md#preprocesssnapshot)*
 
-*Defined in [src/types/complex-types/model.ts:213](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L213)*
+*Defined in [src/types/complex-types/model.ts:213](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L213)*
 
 **Type parameters:**
 
@@ -272,7 +272,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[props](imodeltype.md#props)*
 
-*Defined in [src/types/complex-types/model.ts:193](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L193)*
+*Defined in [src/types/complex-types/model.ts:193](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L193)*
 
 **Type parameters:**
 
@@ -294,7 +294,7 @@ ___
 
 *Inherited from [IType](itype.md).[validate](itype.md#validate)*
 
-*Defined in [src/core/type/type.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L113)*
+*Defined in [src/core/type/type.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L113)*
 
 Run's the type's typechecker on the given value with the given validation context.
 
@@ -317,7 +317,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[views](imodeltype.md#views)*
 
-*Defined in [src/types/complex-types/model.ts:197](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L197)*
+*Defined in [src/types/complex-types/model.ts:197](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L197)*
 
 **Type parameters:**
 
@@ -345,7 +345,7 @@ ___
 
 *Inherited from [IModelType](imodeltype.md).[volatile](imodeltype.md#volatile)*
 
-*Defined in [src/types/complex-types/model.ts:205](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L205)*
+*Defined in [src/types/complex-types/model.ts:205](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L205)*
 
 **Type parameters:**
 

--- a/docs/API/interfaces/ianytype.md
+++ b/docs/API/interfaces/ianytype.md
@@ -4,7 +4,7 @@ title: "IAnyType"
 sidebar_label: "IAnyType"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IAnyType](ianytype.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IAnyType](ianytype.md)
 
 Any kind of type.
 
@@ -36,7 +36,7 @@ Any kind of type.
 
 *Inherited from [IType](itype.md).[identifierAttribute](itype.md#optional-identifierattribute)*
 
-*Defined in [src/core/type/type.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L89)*
+*Defined in [src/core/type/type.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L89)*
 
 Name of the identifier attribute or null if none.
 
@@ -48,7 +48,7 @@ ___
 
 *Inherited from [IType](itype.md).[name](itype.md#name)*
 
-*Defined in [src/core/type/type.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L84)*
+*Defined in [src/core/type/type.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L84)*
 
 Friendly type name.
 
@@ -60,7 +60,7 @@ Friendly type name.
 
 *Inherited from [IType](itype.md).[create](itype.md#create)*
 
-*Defined in [src/core/type/type.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L96)*
+*Defined in [src/core/type/type.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L96)*
 
 Creates an instance for the type given an snapshot input.
 
@@ -83,7 +83,7 @@ ___
 
 *Inherited from [IType](itype.md).[describe](itype.md#describe)*
 
-*Defined in [src/core/type/type.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L118)*
+*Defined in [src/core/type/type.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L118)*
 
 Gets the textual representation of the type as a string.
 
@@ -97,7 +97,7 @@ ___
 
 *Inherited from [IType](itype.md).[is](itype.md#is)*
 
-*Defined in [src/core/type/type.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L104)*
+*Defined in [src/core/type/type.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L104)*
 
 Checks if a given snapshot / instance is of the given type.
 
@@ -119,7 +119,7 @@ ___
 
 *Inherited from [IType](itype.md).[validate](itype.md#validate)*
 
-*Defined in [src/core/type/type.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L113)*
+*Defined in [src/core/type/type.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L113)*
 
 Run's the type's typechecker on the given value with the given validation context.
 

--- a/docs/API/interfaces/ihooks.md
+++ b/docs/API/interfaces/ihooks.md
@@ -4,7 +4,7 @@ title: "IHooks"
 sidebar_label: "IHooks"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IHooks](ihooks.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IHooks](ihooks.md)
 
 ## Hierarchy
 
@@ -25,7 +25,7 @@ sidebar_label: "IHooks"
 
 • **[Hook.afterAttach]**? : *undefined | function*
 
-*Defined in [src/core/node/Hook.ts:14](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/node/Hook.ts#L14)*
+*Defined in [src/core/node/Hook.ts:14](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/node/Hook.ts#L14)*
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 • **[Hook.afterCreate]**? : *undefined | function*
 
-*Defined in [src/core/node/Hook.ts:13](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/node/Hook.ts#L13)*
+*Defined in [src/core/node/Hook.ts:13](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/node/Hook.ts#L13)*
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 • **[Hook.beforeDestroy]**? : *undefined | function*
 
-*Defined in [src/core/node/Hook.ts:16](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/node/Hook.ts#L16)*
+*Defined in [src/core/node/Hook.ts:16](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/node/Hook.ts#L16)*
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 • **[Hook.beforeDetach]**? : *undefined | function*
 
-*Defined in [src/core/node/Hook.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/node/Hook.ts#L15)*
+*Defined in [src/core/node/Hook.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/node/Hook.ts#L15)*

--- a/docs/API/interfaces/ijsonpatch.md
+++ b/docs/API/interfaces/ijsonpatch.md
@@ -4,7 +4,7 @@ title: "IJsonPatch"
 sidebar_label: "IJsonPatch"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IJsonPatch](ijsonpatch.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IJsonPatch](ijsonpatch.md)
 
 https://tools.ietf.org/html/rfc6902
 http://jsonpatch.com/
@@ -29,7 +29,7 @@ http://jsonpatch.com/
 
 • **op**: *"replace" | "add" | "remove"*
 
-*Defined in [src/core/json-patch.ts:8](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/json-patch.ts#L8)*
+*Defined in [src/core/json-patch.ts:8](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/json-patch.ts#L8)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **path**: *string*
 
-*Defined in [src/core/json-patch.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/json-patch.ts#L9)*
+*Defined in [src/core/json-patch.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/json-patch.ts#L9)*
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 • **value**? : *any*
 
-*Defined in [src/core/json-patch.ts:10](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/json-patch.ts#L10)*
+*Defined in [src/core/json-patch.ts:10](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/json-patch.ts#L10)*

--- a/docs/API/interfaces/imiddlewareevent.md
+++ b/docs/API/interfaces/imiddlewareevent.md
@@ -4,7 +4,7 @@ title: "IMiddlewareEvent"
 sidebar_label: "IMiddlewareEvent"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IMiddlewareEvent](imiddlewareevent.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IMiddlewareEvent](imiddlewareevent.md)
 
 ## Hierarchy
 
@@ -34,7 +34,7 @@ sidebar_label: "IMiddlewareEvent"
 
 • **allParentIds**: *number[]*
 
-*Defined in [src/core/action.ts:37](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/action.ts#L37)*
+*Defined in [src/core/action.ts:37](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/action.ts#L37)*
 
 Id of all events, from root until current (excluding current)
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [IActionContext](iactioncontext.md).[args](iactioncontext.md#args)*
 
-*Defined in [src/core/actionContext.ts:20](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L20)*
+*Defined in [src/core/actionContext.ts:20](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L20)*
 
 Event arguments in an array (action arguments for actions)
 
@@ -58,7 +58,7 @@ ___
 
 *Inherited from [IActionContext](iactioncontext.md).[context](iactioncontext.md#context)*
 
-*Defined in [src/core/actionContext.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L15)*
+*Defined in [src/core/actionContext.ts:15](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L15)*
 
 Event context (node where the action was invoked)
 
@@ -70,7 +70,7 @@ ___
 
 *Inherited from [IActionContext](iactioncontext.md).[id](iactioncontext.md#id)*
 
-*Defined in [src/core/actionContext.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L9)*
+*Defined in [src/core/actionContext.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L9)*
 
 Event unique id
 
@@ -82,7 +82,7 @@ ___
 
 *Inherited from [IActionContext](iactioncontext.md).[name](iactioncontext.md#name)*
 
-*Defined in [src/core/actionContext.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L6)*
+*Defined in [src/core/actionContext.ts:6](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L6)*
 
 Event name (action name for actions)
 
@@ -94,7 +94,7 @@ ___
 
 *Inherited from [IActionContext](iactioncontext.md).[parentActionEvent](iactioncontext.md#parentactionevent)*
 
-*Defined in [src/core/actionContext.ts:12](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L12)*
+*Defined in [src/core/actionContext.ts:12](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L12)*
 
 Parent action event object
 
@@ -104,7 +104,7 @@ ___
 
 • **parentEvent**: *[IMiddlewareEvent](imiddlewareevent.md) | undefined*
 
-*Defined in [src/core/action.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/action.ts#L32)*
+*Defined in [src/core/action.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/action.ts#L32)*
 
 Parent event object
 
@@ -114,7 +114,7 @@ ___
 
 • **parentId**: *number*
 
-*Defined in [src/core/action.ts:30](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/action.ts#L30)*
+*Defined in [src/core/action.ts:30](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/action.ts#L30)*
 
 Parent event unique id
 
@@ -124,7 +124,7 @@ ___
 
 • **rootId**: *number*
 
-*Defined in [src/core/action.ts:35](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/action.ts#L35)*
+*Defined in [src/core/action.ts:35](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/action.ts#L35)*
 
 Root event unique id
 
@@ -136,7 +136,7 @@ ___
 
 *Inherited from [IActionContext](iactioncontext.md).[tree](iactioncontext.md#tree)*
 
-*Defined in [src/core/actionContext.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/actionContext.ts#L17)*
+*Defined in [src/core/actionContext.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/actionContext.ts#L17)*
 
 Event tree (root node of the node where the action was invoked)
 
@@ -146,6 +146,6 @@ ___
 
 • **type**: *[IMiddlewareEventType](../index.md#imiddlewareeventtype)*
 
-*Defined in [src/core/action.ts:27](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/action.ts#L27)*
+*Defined in [src/core/action.ts:27](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/action.ts#L27)*
 
 Event type

--- a/docs/API/interfaces/imodelreflectiondata.md
+++ b/docs/API/interfaces/imodelreflectiondata.md
@@ -4,7 +4,7 @@ title: "IModelReflectionData"
 sidebar_label: "IModelReflectionData"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IModelReflectionData](imodelreflectiondata.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IModelReflectionData](imodelreflectiondata.md)
 
 ## Hierarchy
 
@@ -29,7 +29,7 @@ sidebar_label: "IModelReflectionData"
 
 • **actions**: *string[]*
 
-*Defined in [src/core/mst-operations.ts:834](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L834)*
+*Defined in [src/core/mst-operations.ts:834](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L834)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **flowActions**: *string[]*
 
-*Defined in [src/core/mst-operations.ts:837](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L837)*
+*Defined in [src/core/mst-operations.ts:837](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L837)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 *Inherited from [IModelReflectionPropertiesData](imodelreflectionpropertiesdata.md).[name](imodelreflectionpropertiesdata.md#name)*
 
-*Defined in [src/core/mst-operations.ts:804](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L804)*
+*Defined in [src/core/mst-operations.ts:804](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L804)*
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 *Inherited from [IModelReflectionPropertiesData](imodelreflectionpropertiesdata.md).[properties](imodelreflectionpropertiesdata.md#properties)*
 
-*Defined in [src/core/mst-operations.ts:805](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L805)*
+*Defined in [src/core/mst-operations.ts:805](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L805)*
 
 #### Type declaration:
 
@@ -69,7 +69,7 @@ ___
 
 • **views**: *string[]*
 
-*Defined in [src/core/mst-operations.ts:835](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L835)*
+*Defined in [src/core/mst-operations.ts:835](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L835)*
 
 ___
 
@@ -77,4 +77,4 @@ ___
 
 • **volatile**: *string[]*
 
-*Defined in [src/core/mst-operations.ts:836](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L836)*
+*Defined in [src/core/mst-operations.ts:836](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L836)*

--- a/docs/API/interfaces/imodelreflectionpropertiesdata.md
+++ b/docs/API/interfaces/imodelreflectionpropertiesdata.md
@@ -4,7 +4,7 @@ title: "IModelReflectionPropertiesData"
 sidebar_label: "IModelReflectionPropertiesData"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IModelReflectionPropertiesData](imodelreflectionpropertiesdata.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IModelReflectionPropertiesData](imodelreflectionpropertiesdata.md)
 
 ## Hierarchy
 
@@ -25,7 +25,7 @@ sidebar_label: "IModelReflectionPropertiesData"
 
 • **name**: *string*
 
-*Defined in [src/core/mst-operations.ts:804](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L804)*
+*Defined in [src/core/mst-operations.ts:804](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L804)*
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 • **properties**: *object*
 
-*Defined in [src/core/mst-operations.ts:805](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L805)*
+*Defined in [src/core/mst-operations.ts:805](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L805)*
 
 #### Type declaration:
 

--- a/docs/API/interfaces/imodeltype.md
+++ b/docs/API/interfaces/imodeltype.md
@@ -4,7 +4,7 @@ title: "IModelType"
 sidebar_label: "IModelType"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IModelType](imodeltype.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IModelType](imodeltype.md)
 
 ## Type parameters
 
@@ -55,7 +55,7 @@ sidebar_label: "IModelType"
 
 *Inherited from [IType](itype.md).[identifierAttribute](itype.md#optional-identifierattribute)*
 
-*Defined in [src/core/type/type.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L89)*
+*Defined in [src/core/type/type.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L89)*
 
 Name of the identifier attribute or null if none.
 
@@ -67,7 +67,7 @@ ___
 
 *Inherited from [IType](itype.md).[name](itype.md#name)*
 
-*Defined in [src/core/type/type.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L84)*
+*Defined in [src/core/type/type.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L84)*
 
 Friendly type name.
 
@@ -77,7 +77,7 @@ ___
 
 • **properties**: *PROPS*
 
-*Defined in [src/types/complex-types/model.ts:187](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L187)*
+*Defined in [src/types/complex-types/model.ts:187](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L187)*
 
 ## Methods
 
@@ -85,7 +85,7 @@ ___
 
 ▸ **actions**<**A**>(`fn`: function): *[IModelType](imodeltype.md)‹PROPS, OTHERS & A, CustomC, CustomS›*
 
-*Defined in [src/types/complex-types/model.ts:201](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L201)*
+*Defined in [src/types/complex-types/model.ts:201](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L201)*
 
 **Type parameters:**
 
@@ -113,7 +113,7 @@ ___
 
 *Inherited from [IType](itype.md).[create](itype.md#create)*
 
-*Defined in [src/core/type/type.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L96)*
+*Defined in [src/core/type/type.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L96)*
 
 Creates an instance for the type given an snapshot input.
 
@@ -136,7 +136,7 @@ ___
 
 *Inherited from [IType](itype.md).[describe](itype.md#describe)*
 
-*Defined in [src/core/type/type.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L118)*
+*Defined in [src/core/type/type.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L118)*
 
 Gets the textual representation of the type as a string.
 
@@ -148,7 +148,7 @@ ___
 
 ▸ **extend**<**A**, **V**, **VS**>(`fn`: function): *[IModelType](imodeltype.md)‹PROPS, OTHERS & A & V & VS, CustomC, CustomS›*
 
-*Defined in [src/types/complex-types/model.ts:209](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L209)*
+*Defined in [src/types/complex-types/model.ts:209](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L209)*
 
 **Type parameters:**
 
@@ -180,7 +180,7 @@ ___
 
 *Inherited from [IType](itype.md).[is](itype.md#is)*
 
-*Defined in [src/core/type/type.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L104)*
+*Defined in [src/core/type/type.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L104)*
 
 Checks if a given snapshot / instance is of the given type.
 
@@ -200,7 +200,7 @@ ___
 
 ▸ **named**(`newName`: string): *[IModelType](imodeltype.md)‹PROPS, OTHERS, CustomC, CustomS›*
 
-*Defined in [src/types/complex-types/model.ts:189](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L189)*
+*Defined in [src/types/complex-types/model.ts:189](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L189)*
 
 **Parameters:**
 
@@ -216,7 +216,7 @@ ___
 
 ▸ **postProcessSnapshot**<**NewS**>(`fn`: function): *[IModelType](imodeltype.md)‹PROPS, OTHERS, CustomC, NewS›*
 
-*Defined in [src/types/complex-types/model.ts:217](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L217)*
+*Defined in [src/types/complex-types/model.ts:217](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L217)*
 
 **Type parameters:**
 
@@ -242,7 +242,7 @@ ___
 
 ▸ **preProcessSnapshot**<**NewC**>(`fn`: function): *[IModelType](imodeltype.md)‹PROPS, OTHERS, NewC, CustomS›*
 
-*Defined in [src/types/complex-types/model.ts:213](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L213)*
+*Defined in [src/types/complex-types/model.ts:213](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L213)*
 
 **Type parameters:**
 
@@ -268,7 +268,7 @@ ___
 
 ▸ **props**<**PROPS2**>(`props`: PROPS2): *[IModelType](imodeltype.md)‹PROPS & ModelPropertiesDeclarationToProperties‹PROPS2›, OTHERS, CustomC, CustomS›*
 
-*Defined in [src/types/complex-types/model.ts:193](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L193)*
+*Defined in [src/types/complex-types/model.ts:193](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L193)*
 
 **Type parameters:**
 
@@ -290,7 +290,7 @@ ___
 
 *Inherited from [IType](itype.md).[validate](itype.md#validate)*
 
-*Defined in [src/core/type/type.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L113)*
+*Defined in [src/core/type/type.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L113)*
 
 Run's the type's typechecker on the given value with the given validation context.
 
@@ -311,7 +311,7 @@ ___
 
 ▸ **views**<**V**>(`fn`: function): *[IModelType](imodeltype.md)‹PROPS, OTHERS & V, CustomC, CustomS›*
 
-*Defined in [src/types/complex-types/model.ts:197](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L197)*
+*Defined in [src/types/complex-types/model.ts:197](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L197)*
 
 **Type parameters:**
 
@@ -337,7 +337,7 @@ ___
 
 ▸ **volatile**<**TP**>(`fn`: function): *[IModelType](imodeltype.md)‹PROPS, OTHERS & TP, CustomC, CustomS›*
 
-*Defined in [src/types/complex-types/model.ts:205](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/complex-types/model.ts#L205)*
+*Defined in [src/types/complex-types/model.ts:205](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/complex-types/model.ts#L205)*
 
 **Type parameters:**
 

--- a/docs/API/interfaces/ipatchrecorder.md
+++ b/docs/API/interfaces/ipatchrecorder.md
@@ -4,7 +4,7 @@ title: "IPatchRecorder"
 sidebar_label: "IPatchRecorder"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IPatchRecorder](ipatchrecorder.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IPatchRecorder](ipatchrecorder.md)
 
 ## Hierarchy
 
@@ -32,7 +32,7 @@ sidebar_label: "IPatchRecorder"
 
 • **inversePatches**: *ReadonlyArray‹[IJsonPatch](ijsonpatch.md)›*
 
-*Defined in [src/core/mst-operations.ts:138](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L138)*
+*Defined in [src/core/mst-operations.ts:138](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L138)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **patches**: *ReadonlyArray‹[IJsonPatch](ijsonpatch.md)›*
 
-*Defined in [src/core/mst-operations.ts:137](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L137)*
+*Defined in [src/core/mst-operations.ts:137](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L137)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **recording**: *boolean*
 
-*Defined in [src/core/mst-operations.ts:140](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L140)*
+*Defined in [src/core/mst-operations.ts:140](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L140)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • **reversedInversePatches**: *ReadonlyArray‹[IJsonPatch](ijsonpatch.md)›*
 
-*Defined in [src/core/mst-operations.ts:139](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L139)*
+*Defined in [src/core/mst-operations.ts:139](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L139)*
 
 ## Methods
 
@@ -64,7 +64,7 @@ ___
 
 ▸ **replay**(`target?`: IAnyStateTreeNode): *void*
 
-*Defined in [src/core/mst-operations.ts:143](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L143)*
+*Defined in [src/core/mst-operations.ts:143](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L143)*
 
 **Parameters:**
 
@@ -80,7 +80,7 @@ ___
 
 ▸ **resume**(): *void*
 
-*Defined in [src/core/mst-operations.ts:142](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L142)*
+*Defined in [src/core/mst-operations.ts:142](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L142)*
 
 **Returns:** *void*
 
@@ -90,7 +90,7 @@ ___
 
 ▸ **stop**(): *void*
 
-*Defined in [src/core/mst-operations.ts:141](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L141)*
+*Defined in [src/core/mst-operations.ts:141](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L141)*
 
 **Returns:** *void*
 
@@ -100,7 +100,7 @@ ___
 
 ▸ **undo**(`target?`: IAnyStateTreeNode): *void*
 
-*Defined in [src/core/mst-operations.ts:144](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/mst-operations.ts#L144)*
+*Defined in [src/core/mst-operations.ts:144](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/mst-operations.ts#L144)*
 
 **Parameters:**
 

--- a/docs/API/interfaces/ireversiblejsonpatch.md
+++ b/docs/API/interfaces/ireversiblejsonpatch.md
@@ -4,7 +4,7 @@ title: "IReversibleJsonPatch"
 sidebar_label: "IReversibleJsonPatch"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IReversibleJsonPatch](ireversiblejsonpatch.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IReversibleJsonPatch](ireversiblejsonpatch.md)
 
 ## Hierarchy
 
@@ -27,7 +27,7 @@ sidebar_label: "IReversibleJsonPatch"
 
 • **oldValue**: *any*
 
-*Defined in [src/core/json-patch.ts:14](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/json-patch.ts#L14)*
+*Defined in [src/core/json-patch.ts:14](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/json-patch.ts#L14)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 *Inherited from [IJsonPatch](ijsonpatch.md).[op](ijsonpatch.md#op)*
 
-*Defined in [src/core/json-patch.ts:8](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/json-patch.ts#L8)*
+*Defined in [src/core/json-patch.ts:8](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/json-patch.ts#L8)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 *Inherited from [IJsonPatch](ijsonpatch.md).[path](ijsonpatch.md#path)*
 
-*Defined in [src/core/json-patch.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/json-patch.ts#L9)*
+*Defined in [src/core/json-patch.ts:9](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/json-patch.ts#L9)*
 
 ___
 
@@ -57,4 +57,4 @@ ___
 
 *Inherited from [IJsonPatch](ijsonpatch.md).[value](ijsonpatch.md#optional-value)*
 
-*Defined in [src/core/json-patch.ts:10](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/json-patch.ts#L10)*
+*Defined in [src/core/json-patch.ts:10](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/json-patch.ts#L10)*

--- a/docs/API/interfaces/iserializedactioncall.md
+++ b/docs/API/interfaces/iserializedactioncall.md
@@ -4,7 +4,7 @@ title: "ISerializedActionCall"
 sidebar_label: "ISerializedActionCall"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [ISerializedActionCall](iserializedactioncall.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [ISerializedActionCall](iserializedactioncall.md)
 
 ## Hierarchy
 
@@ -24,7 +24,7 @@ sidebar_label: "ISerializedActionCall"
 
 • **args**? : *any[]*
 
-*Defined in [src/middlewares/on-action.ts:33](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/on-action.ts#L33)*
+*Defined in [src/middlewares/on-action.ts:33](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/on-action.ts#L33)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/middlewares/on-action.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/on-action.ts#L31)*
+*Defined in [src/middlewares/on-action.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/on-action.ts#L31)*
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 • **path**? : *undefined | string*
 
-*Defined in [src/middlewares/on-action.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/middlewares/on-action.ts#L32)*
+*Defined in [src/middlewares/on-action.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/middlewares/on-action.ts#L32)*

--- a/docs/API/interfaces/isimpletype.md
+++ b/docs/API/interfaces/isimpletype.md
@@ -4,7 +4,7 @@ title: "ISimpleType"
 sidebar_label: "ISimpleType"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [ISimpleType](isimpletype.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [ISimpleType](isimpletype.md)
 
 A simple type, this is, a type where the instance and the snapshot representation are the same.
 
@@ -40,7 +40,7 @@ A simple type, this is, a type where the instance and the snapshot representatio
 
 *Inherited from [IType](itype.md).[identifierAttribute](itype.md#optional-identifierattribute)*
 
-*Defined in [src/core/type/type.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L89)*
+*Defined in [src/core/type/type.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L89)*
 
 Name of the identifier attribute or null if none.
 
@@ -52,7 +52,7 @@ ___
 
 *Inherited from [IType](itype.md).[name](itype.md#name)*
 
-*Defined in [src/core/type/type.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L84)*
+*Defined in [src/core/type/type.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L84)*
 
 Friendly type name.
 
@@ -64,7 +64,7 @@ Friendly type name.
 
 *Inherited from [IType](itype.md).[create](itype.md#create)*
 
-*Defined in [src/core/type/type.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L96)*
+*Defined in [src/core/type/type.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L96)*
 
 Creates an instance for the type given an snapshot input.
 
@@ -87,7 +87,7 @@ ___
 
 *Inherited from [IType](itype.md).[describe](itype.md#describe)*
 
-*Defined in [src/core/type/type.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L118)*
+*Defined in [src/core/type/type.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L118)*
 
 Gets the textual representation of the type as a string.
 
@@ -101,7 +101,7 @@ ___
 
 *Inherited from [IType](itype.md).[is](itype.md#is)*
 
-*Defined in [src/core/type/type.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L104)*
+*Defined in [src/core/type/type.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L104)*
 
 Checks if a given snapshot / instance is of the given type.
 
@@ -123,7 +123,7 @@ ___
 
 *Inherited from [IType](itype.md).[validate](itype.md#validate)*
 
-*Defined in [src/core/type/type.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L113)*
+*Defined in [src/core/type/type.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L113)*
 
 Run's the type's typechecker on the given value with the given validation context.
 

--- a/docs/API/interfaces/isnapshotprocessor.md
+++ b/docs/API/interfaces/isnapshotprocessor.md
@@ -4,7 +4,7 @@ title: "ISnapshotProcessor"
 sidebar_label: "ISnapshotProcessor"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [ISnapshotProcessor](isnapshotprocessor.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [ISnapshotProcessor](isnapshotprocessor.md)
 
 A type that has its snapshots processed.
 
@@ -44,7 +44,7 @@ A type that has its snapshots processed.
 
 *Inherited from [IType](itype.md).[identifierAttribute](itype.md#optional-identifierattribute)*
 
-*Defined in [src/core/type/type.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L89)*
+*Defined in [src/core/type/type.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L89)*
 
 Name of the identifier attribute or null if none.
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [IType](itype.md).[name](itype.md#name)*
 
-*Defined in [src/core/type/type.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L84)*
+*Defined in [src/core/type/type.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L84)*
 
 Friendly type name.
 
@@ -68,7 +68,7 @@ Friendly type name.
 
 *Inherited from [IType](itype.md).[create](itype.md#create)*
 
-*Defined in [src/core/type/type.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L96)*
+*Defined in [src/core/type/type.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L96)*
 
 Creates an instance for the type given an snapshot input.
 
@@ -91,7 +91,7 @@ ___
 
 *Inherited from [IType](itype.md).[describe](itype.md#describe)*
 
-*Defined in [src/core/type/type.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L118)*
+*Defined in [src/core/type/type.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L118)*
 
 Gets the textual representation of the type as a string.
 
@@ -105,7 +105,7 @@ ___
 
 *Inherited from [IType](itype.md).[is](itype.md#is)*
 
-*Defined in [src/core/type/type.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L104)*
+*Defined in [src/core/type/type.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L104)*
 
 Checks if a given snapshot / instance is of the given type.
 
@@ -127,7 +127,7 @@ ___
 
 *Inherited from [IType](itype.md).[validate](itype.md#validate)*
 
-*Defined in [src/core/type/type.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L113)*
+*Defined in [src/core/type/type.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L113)*
 
 Run's the type's typechecker on the given value with the given validation context.
 

--- a/docs/API/interfaces/isnapshotprocessors.md
+++ b/docs/API/interfaces/isnapshotprocessors.md
@@ -4,7 +4,7 @@ title: "ISnapshotProcessors"
 sidebar_label: "ISnapshotProcessors"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [ISnapshotProcessors](isnapshotprocessors.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [ISnapshotProcessors](isnapshotprocessors.md)
 
 Snapshot processors.
 
@@ -35,7 +35,7 @@ Snapshot processors.
 
 ▸ **postProcessor**(`snapshot`: S): *CustomS*
 
-*Defined in [src/types/utility-types/snapshotProcessor.ts:212](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/snapshotProcessor.ts#L212)*
+*Defined in [src/types/utility-types/snapshotProcessor.ts:212](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/snapshotProcessor.ts#L212)*
 
 Function that transforms an output snapshot.
 
@@ -53,7 +53,7 @@ ___
 
 ▸ **preProcessor**(`snapshot`: CustomC): *C*
 
-*Defined in [src/types/utility-types/snapshotProcessor.ts:207](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/snapshotProcessor.ts#L207)*
+*Defined in [src/types/utility-types/snapshotProcessor.ts:207](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/snapshotProcessor.ts#L207)*
 
 Function that transforms an input snapshot.
 

--- a/docs/API/interfaces/itype.md
+++ b/docs/API/interfaces/itype.md
@@ -4,7 +4,7 @@ title: "IType"
 sidebar_label: "IType"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IType](itype.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IType](itype.md)
 
 A type, either complex or simple.
 
@@ -50,7 +50,7 @@ A type, either complex or simple.
 
 • **identifierAttribute**? : *undefined | string*
 
-*Defined in [src/core/type/type.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L89)*
+*Defined in [src/core/type/type.ts:89](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L89)*
 
 Name of the identifier attribute or null if none.
 
@@ -60,7 +60,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/core/type/type.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L84)*
+*Defined in [src/core/type/type.ts:84](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L84)*
 
 Friendly type name.
 
@@ -70,7 +70,7 @@ Friendly type name.
 
 ▸ **create**(`snapshot?`: [C](undefined), `env?`: any): *this["Type"]*
 
-*Defined in [src/core/type/type.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L96)*
+*Defined in [src/core/type/type.ts:96](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L96)*
 
 Creates an instance for the type given an snapshot input.
 
@@ -91,7 +91,7 @@ ___
 
 ▸ **describe**(): *string*
 
-*Defined in [src/core/type/type.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L118)*
+*Defined in [src/core/type/type.ts:118](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L118)*
 
 Gets the textual representation of the type as a string.
 
@@ -103,7 +103,7 @@ ___
 
 ▸ **is**(`thing`: any): *thing is C | this["Type"]*
 
-*Defined in [src/core/type/type.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L104)*
+*Defined in [src/core/type/type.ts:104](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L104)*
 
 Checks if a given snapshot / instance is of the given type.
 
@@ -123,7 +123,7 @@ ___
 
 ▸ **validate**(`thing`: C, `context`: [IValidationContext](../index.md#ivalidationcontext)): *[IValidationResult](../index.md#ivalidationresult)*
 
-*Defined in [src/core/type/type.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type.ts#L113)*
+*Defined in [src/core/type/type.ts:113](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type.ts#L113)*
 
 Run's the type's typechecker on the given value with the given validation context.
 

--- a/docs/API/interfaces/ivalidationcontextentry.md
+++ b/docs/API/interfaces/ivalidationcontextentry.md
@@ -4,7 +4,7 @@ title: "IValidationContextEntry"
 sidebar_label: "IValidationContextEntry"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IValidationContextEntry](ivalidationcontextentry.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IValidationContextEntry](ivalidationcontextentry.md)
 
 Validation context entry, this is, where the validation should run against which type
 
@@ -25,7 +25,7 @@ Validation context entry, this is, where the validation should run against which
 
 • **path**: *string*
 
-*Defined in [src/core/type/type-checker.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type-checker.ts#L17)*
+*Defined in [src/core/type/type-checker.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type-checker.ts#L17)*
 
 Subpath where the validation should be run, or an empty string to validate it all
 
@@ -35,6 +35,6 @@ ___
 
 • **type**: *[IAnyType](ianytype.md)*
 
-*Defined in [src/core/type/type-checker.ts:19](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type-checker.ts#L19)*
+*Defined in [src/core/type/type-checker.ts:19](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type-checker.ts#L19)*
 
 Type to validate the subpath against

--- a/docs/API/interfaces/ivalidationerror.md
+++ b/docs/API/interfaces/ivalidationerror.md
@@ -4,7 +4,7 @@ title: "IValidationError"
 sidebar_label: "IValidationError"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [IValidationError](ivalidationerror.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [IValidationError](ivalidationerror.md)
 
 Type validation error
 
@@ -26,7 +26,7 @@ Type validation error
 
 • **context**: *[IValidationContext](../index.md#ivalidationcontext)*
 
-*Defined in [src/core/type/type-checker.ts:28](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type-checker.ts#L28)*
+*Defined in [src/core/type/type-checker.ts:28](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type-checker.ts#L28)*
 
 Validation context
 
@@ -36,7 +36,7 @@ ___
 
 • **message**? : *undefined | string*
 
-*Defined in [src/core/type/type-checker.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type-checker.ts#L32)*
+*Defined in [src/core/type/type-checker.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type-checker.ts#L32)*
 
 Error message
 
@@ -46,6 +46,6 @@ ___
 
 • **value**: *any*
 
-*Defined in [src/core/type/type-checker.ts:30](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/core/type/type-checker.ts#L30)*
+*Defined in [src/core/type/type-checker.ts:30](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/core/type/type-checker.ts#L30)*
 
 Value that was being validated, either a snapshot or an instance

--- a/docs/API/interfaces/referenceoptionsgetset.md
+++ b/docs/API/interfaces/referenceoptionsgetset.md
@@ -4,7 +4,7 @@ title: "ReferenceOptionsGetSet"
 sidebar_label: "ReferenceOptionsGetSet"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [ReferenceOptionsGetSet](referenceoptionsgetset.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [ReferenceOptionsGetSet](referenceoptionsgetset.md)
 
 ## Type parameters
 
@@ -27,7 +27,7 @@ sidebar_label: "ReferenceOptionsGetSet"
 
 ▸ **get**(`identifier`: [ReferenceIdentifier](../index.md#referenceidentifier), `parent`: IAnyStateTreeNode | null): *ReferenceT‹IT›*
 
-*Defined in [src/types/utility-types/reference.ts:442](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/reference.ts#L442)*
+*Defined in [src/types/utility-types/reference.ts:442](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/reference.ts#L442)*
 
 **Parameters:**
 
@@ -44,7 +44,7 @@ ___
 
 ▸ **set**(`value`: ReferenceT‹IT›, `parent`: IAnyStateTreeNode | null): *[ReferenceIdentifier](../index.md#referenceidentifier)*
 
-*Defined in [src/types/utility-types/reference.ts:443](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/reference.ts#L443)*
+*Defined in [src/types/utility-types/reference.ts:443](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/reference.ts#L443)*
 
 **Parameters:**
 

--- a/docs/API/interfaces/referenceoptionsoninvalidated.md
+++ b/docs/API/interfaces/referenceoptionsoninvalidated.md
@@ -4,7 +4,7 @@ title: "ReferenceOptionsOnInvalidated"
 sidebar_label: "ReferenceOptionsOnInvalidated"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [ReferenceOptionsOnInvalidated](referenceoptionsoninvalidated.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [ReferenceOptionsOnInvalidated](referenceoptionsoninvalidated.md)
 
 ## Type parameters
 
@@ -26,4 +26,4 @@ sidebar_label: "ReferenceOptionsOnInvalidated"
 
 • **onInvalidated**: *[OnReferenceInvalidated](../index.md#onreferenceinvalidated)‹ReferenceT‹IT››*
 
-*Defined in [src/types/utility-types/reference.ts:448](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/reference.ts#L448)*
+*Defined in [src/types/utility-types/reference.ts:448](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/reference.ts#L448)*

--- a/docs/API/interfaces/unionoptions.md
+++ b/docs/API/interfaces/unionoptions.md
@@ -4,7 +4,7 @@ title: "UnionOptions"
 sidebar_label: "UnionOptions"
 ---
 
-[mobx-state-tree - v5.3.alpha.1](../index.md) › [UnionOptions](unionoptions.md)
+[mobx-state-tree - v5.4.0-pre.1](../index.md) › [UnionOptions](unionoptions.md)
 
 ## Hierarchy
 
@@ -23,7 +23,7 @@ sidebar_label: "UnionOptions"
 
 • **dispatcher**? : *[ITypeDispatcher](../index.md#itypedispatcher)*
 
-*Defined in [src/types/utility-types/union.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L31)*
+*Defined in [src/types/utility-types/union.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L31)*
 
 ___
 
@@ -31,4 +31,4 @@ ___
 
 • **eager**? : *undefined | false | true*
 
-*Defined in [src/types/utility-types/union.ts:30](https://github.com/mobxjs/mobx-state-tree/blob/a411fc10/src/types/utility-types/union.ts#L30)*
+*Defined in [src/types/utility-types/union.ts:30](https://github.com/mobxjs/mobx-state-tree/blob/0694a96a/src/types/utility-types/union.ts#L30)*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-state-tree",
-  "version": "5.3.alpha.1",
+  "version": "5.4.0-pre.1",
   "description": "Opinionated, transactional, MobX powered state container",
   "main": "dist/mobx-state-tree.js",
   "umd:main": "dist/mobx-state-tree.umd.js",


### PR DESCRIPTION
## What does this PR do and why?

Bumps version to `5.4.0-pre.1` and builds docs.

## Steps to validate locally

Nothing to validate here, we'll be pushing a pre-release.