### PR TITLE
test: add tests for boolean primitive

### DIFF
--- a/__tests__/core/boolean.test.ts
+++ b/__tests__/core/boolean.test.ts
@@ -1,31 +1,30 @@
 import { t } from "../../src"
 import { Hook, NodeLifeCycle } from "../../src/internal"
 
-describe("types.number", () => {
+describe("types.boolean", () => {
   describe("methods", () => {
     describe("create", () => {
       describe("with no arguments", () => {
         if (process.env.NODE_ENV !== "production") {
           it("should throw an error in development", () => {
             expect(() => {
-              t.number.create()
+              t.boolean.create()
             }).toThrow()
           })
         }
       })
-      describe("with a number argument", () => {
-        it("should return a number", () => {
-          const n = t.number.create(1)
-          expect(typeof n).toBe("number")
+      describe("with a boolean argument", () => {
+        it("should return a boolean", () => {
+          const n = t.boolean.create(true)
+          expect(typeof n).toBe("boolean")
         })
       })
       describe("with argument of different types", () => {
-        // Keep in mind, Infinity and NaN are treated as numbers in JavaScript, so we won't test for them here.
         const testCases = [
           null,
           undefined,
           "string",
-          true,
+          1,
           [],
           function () {},
           new Date(),
@@ -33,14 +32,16 @@ describe("types.number", () => {
           new Map(),
           new Set(),
           Symbol(),
-          new Error()
+          new Error(),
+          Infinity,
+          NaN
         ]
 
         if (process.env.NODE_ENV !== "production") {
           testCases.forEach((testCase) => {
             it(`should throw an error when passed ${JSON.stringify(testCase)}`, () => {
               expect(() => {
-                t.number.create(testCase as any)
+                t.boolean.create(testCase as any)
               }).toThrow()
             })
           })
@@ -48,21 +49,21 @@ describe("types.number", () => {
       })
     })
     describe("describe", () => {
-      it("should return the value 'number'", () => {
-        const description = t.number.describe()
-        expect(description).toBe("number")
+      it("should return the value 'boolean'", () => {
+        const description = t.boolean.describe()
+        expect(description).toBe("boolean")
       })
     })
     describe("getSnapshot", () => {
       it("should return the value passed in", () => {
-        const n = t.number.instantiate(null, "", {}, 1)
-        const snapshot = t.number.getSnapshot(n)
-        expect(snapshot).toBe(1)
+        const b = t.boolean.instantiate(null, "", {}, true)
+        const snapshot = t.boolean.getSnapshot(b)
+        expect(snapshot).toBe(true)
       })
     })
     describe("getSubtype", () => {
       it("should return null", () => {
-        const subtype = t.number.getSubTypes()
+        const subtype = t.boolean.getSubTypes()
         expect(subtype).toBe(null)
       })
     })
@@ -72,32 +73,31 @@ describe("types.number", () => {
           it("should not throw an error", () => {
             expect(() => {
               // @ts-ignore
-              t.number.instantiate()
+              t.boolean.instantiate()
             }).not.toThrow()
           })
         })
       }
-      describe("with a number argument", () => {
+      describe("with a boolean argument", () => {
         it("should return an object", () => {
-          const n = t.number.instantiate(null, "", {}, 1)
-          expect(typeof n).toBe("object")
+          const b = t.boolean.instantiate(null, "", {}, true)
+          expect(typeof b).toBe("object")
         })
       })
     })
     describe("is", () => {
-      describe("with a number argument", () => {
+      describe("with a boolean argument", () => {
         it("should return true", () => {
-          const result = t.number.is(1)
+          const result = t.boolean.is(true)
           expect(result).toBe(true)
         })
       })
       describe("with argument of different types", () => {
-        // Keep in mind, Infinity and NaN are treated as numbers in JavaScript, so we won't test for them here.
         const testCases = [
           null,
           undefined,
           "string",
-          true,
+          1,
           [],
           function () {},
           new Date(),
@@ -105,28 +105,30 @@ describe("types.number", () => {
           new Map(),
           new Set(),
           Symbol(),
-          new Error()
+          new Error(),
+          Infinity,
+          NaN
         ]
 
         testCases.forEach((testCase) => {
           it(`should return false when passed ${JSON.stringify(testCase)}`, () => {
-            const result = t.number.is(testCase as any)
+            const result = t.boolean.is(testCase as any)
             expect(result).toBe(false)
           })
         })
       })
     })
     describe("isAssignableFrom", () => {
-      describe("with a number argument", () => {
+      describe("with a boolean argument", () => {
         it("should return true", () => {
-          const result = t.number.isAssignableFrom(t.number)
+          const result = t.boolean.isAssignableFrom(t.boolean)
           expect(result).toBe(true)
         })
       })
       describe("with argument of different types", () => {
         const testCases = [
           t.Date,
-          t.boolean,
+          t.number,
           t.finite,
           t.float,
           t.identifier,
@@ -139,7 +141,7 @@ describe("types.number", () => {
 
         testCases.forEach((testCase) => {
           it(`should return false when passed ${JSON.stringify(testCase)}`, () => {
-            const result = t.number.isAssignableFrom(testCase as any)
+            const result = t.boolean.isAssignableFrom(testCase as any)
             expect(result).toBe(false)
           })
         })
@@ -148,19 +150,18 @@ describe("types.number", () => {
     // TODO: we need to test this, but to be honest I'm not sure what the expected behavior is on single string noden.
     describe.skip("reconcile", () => {})
     describe("validate", () => {
-      describe("with a number argument", () => {
+      describe("with a boolean argument", () => {
         it("should return with no validation errors", () => {
-          const result = t.number.validate(1, [])
+          const result = t.boolean.validate(true, [])
           expect(result).toEqual([])
         })
       })
       describe("with argument of different types", () => {
-        // Keep in mind, Infinity and NaN are treated as numbers in JavaScript, so we won't test for them here.
         const testCases = [
           null,
           undefined,
           "string",
-          true,
+          1,
           [],
           function () {},
           new Date(),
@@ -168,18 +169,20 @@ describe("types.number", () => {
           new Map(),
           new Set(),
           Symbol(),
-          new Error()
+          new Error(),
+          Infinity,
+          NaN
         ]
 
         testCases.forEach((testCase) => {
           it(`should return with a validation error when passed ${JSON.stringify(
             testCase
           )}`, () => {
-            const result = t.number.validate(testCase as any, [])
+            const result = t.boolean.validate(testCase as any, [])
             expect(result).toEqual([
               {
                 context: [],
-                message: "Value is not a number",
+                message: "Value is not a boolean",
                 value: testCase
               }
             ])
@@ -191,27 +194,27 @@ describe("types.number", () => {
   describe("properties", () => {
     describe("flags", () => {
       test("return the correct value", () => {
-        const flags = t.number.flags
-        expect(flags).toBe(2)
+        const flags = t.boolean.flags
+        expect(flags).toBe(4)
       })
     })
     describe("identifierAttribute", () => {
       // We don't have a way to set the identifierAttribute on a primitive type, so this should return undefined.
       test("returns undefined", () => {
-        const identifierAttribute = t.number.identifierAttribute
+        const identifierAttribute = t.boolean.identifierAttribute
         expect(identifierAttribute).toBe(undefined)
       })
     })
     describe("isType", () => {
       test("returns true", () => {
-        const isType = t.number.isType
+        const isType = t.boolean.isType
         expect(isType).toBe(true)
       })
     })
     describe("name", () => {
-      test('returns "number"', () => {
-        const name = t.number.name
-        expect(name).toBe("number")
+      test('returns "boolean"', () => {
+        const name = t.boolean.name
+        expect(name).toBe("boolean")
       })
     })
   })
@@ -219,64 +222,64 @@ describe("types.number", () => {
     describe("methods", () => {
       describe("aboutToDie", () => {
         it("calls the beforeDetach hook", () => {
-          const n = t.number.instantiate(null, "", {}, 1)
+          const b = t.boolean.instantiate(null, "", {}, true)
           let called = false
-          n.registerHook(Hook.beforeDestroy, () => {
+          b.registerHook(Hook.beforeDestroy, () => {
             called = true
           })
-          n.aboutToDie()
+          b.aboutToDie()
           expect(called).toBe(true)
         })
       })
       describe("die", () => {
         it("kills the node", () => {
-          const n = t.number.instantiate(null, "", {}, 1)
-          n.die()
-          expect(n.isAlive).toBe(false)
+          const b = t.boolean.instantiate(null, "", {}, true)
+          b.die()
+          expect(b.isAlive).toBe(false)
         })
         it("should mark the node as dead", () => {
-          const n = t.number.instantiate(null, "", {}, 1)
-          n.die()
-          expect(n.state).toBe(NodeLifeCycle.DEAD)
+          const b = t.boolean.instantiate(null, "", {}, true)
+          b.die()
+          expect(b.state).toBe(NodeLifeCycle.DEAD)
         })
       })
       describe("finalizeCreation", () => {
         it("should mark the node as finalized", () => {
-          const n = t.number.instantiate(null, "", {}, 1)
-          n.finalizeCreation()
-          expect(n.state).toBe(NodeLifeCycle.FINALIZED)
+          const b = t.boolean.instantiate(null, "", {}, true)
+          b.finalizeCreation()
+          expect(b.state).toBe(NodeLifeCycle.FINALIZED)
         })
       })
       describe("finalizeDeath", () => {
         it("should mark the node as dead", () => {
-          const n = t.number.instantiate(null, "", {}, 1)
-          n.finalizeDeath()
-          expect(n.state).toBe(NodeLifeCycle.DEAD)
+          const b = t.boolean.instantiate(null, "", {}, true)
+          b.finalizeDeath()
+          expect(b.state).toBe(NodeLifeCycle.DEAD)
         })
       })
       describe("getReconciliationType", () => {
         it("should return the correct type", () => {
-          const n = t.number.instantiate(null, "", {}, 1)
-          const type = n.getReconciliationType()
-          expect(type).toBe(t.number)
+          const b = t.boolean.instantiate(null, "", {}, true)
+          const type = b.getReconciliationType()
+          expect(type).toBe(t.boolean)
         })
       })
       describe("getSnapshot", () => {
         it("should return the value passed in", () => {
-          const n = t.number.instantiate(null, "", {}, 1)
-          const snapshot = n.getSnapshot()
-          expect(snapshot).toBe(1)
+          const b = t.boolean.instantiate(null, "", {}, true)
+          const snapshot = b.getSnapshot()
+          expect(snapshot).toBe(true)
         })
       })
       describe("registerHook", () => {
         it("should register a hook and call it", () => {
-          const n = t.number.instantiate(null, "", {}, 1)
+          const b = t.boolean.instantiate(null, "", {}, true)
           let called = false
-          n.registerHook(Hook.beforeDestroy, () => {
+          b.registerHook(Hook.beforeDestroy, () => {
             called = true
           })
 
-          n.die()
+          b.die()
 
           expect(called).toBe(true)
         })
@@ -285,25 +288,25 @@ describe("types.number", () => {
         if (process.env.NODE_ENV !== "production") {
           describe("with null", () => {
             it("should throw an error", () => {
-              const n = t.number.instantiate(null, "", {}, 1)
+              const b = t.boolean.instantiate(null, "", {}, true)
               expect(() => {
-                n.setParent(null, "foo")
+                b.setParent(null, "foo")
               }).toThrow()
             })
           })
           describe("with a parent object", () => {
             it("should throw an error", () => {
               const Parent = t.model({
-                child: t.number
+                child: t.boolean
               })
 
-              const parent = Parent.create({ child: 1 })
+              const parent = Parent.create({ child: true })
 
-              const n = t.number.instantiate(null, "", {}, 1)
+              const b = t.boolean.instantiate(null, "", {}, true)
 
               expect(() => {
                 // @ts-ignore
-                n.setParent(parent, "bar")
+                b.setParent(parent, "bar")
               }).toThrow(
                 "[mobx-state-tree] assertion failed: scalar nodes cannot change their parent"
               )


### PR DESCRIPTION
## What does this PR do and why?

Like #2123 and #2122 - adds tests for `t.boolean`, and cleans up a few typos from #2123.

## Steps to validate locally

`yarn test` should pass. I'm gonna merge this in once CI passes since it's just adding test coverage.