### PR TITLE
Fix missing fail import

### DIFF
--- a/__tests__/core/snapshotProcessor.test.ts
+++ b/__tests__/core/snapshotProcessor.test.ts
@@ -843,4 +843,14 @@ describe("snapshotProcessor", () => {
     expect(() => store.setProp("b")).not.toThrow()
     expect(store.prop).toBe("b")
   })
+
+  test("it should fail if given incorrect processor", () => {
+    expect(() => {
+      types.model({
+        m: types.snapshotProcessor(types.number, {
+          postProcessor: {} as any
+        })
+      })
+    }).toThrowError("[mobx-state-tree] postSnapshotProcessor must be a function")
+  })
 })

--- a/__tests__/core/snapshotProcessor.test.ts
+++ b/__tests__/core/snapshotProcessor.test.ts
@@ -844,13 +844,15 @@ describe("snapshotProcessor", () => {
     expect(store.prop).toBe("b")
   })
 
-  test("it should fail if given incorrect processor", () => {
-    expect(() => {
-      types.model({
-        m: types.snapshotProcessor(types.number, {
-          postProcessor: {} as any
+  if (process.env.NODE_ENV !== "production") {
+    test("it should fail if given incorrect processor", () => {
+      expect(() => {
+        types.model({
+          m: types.snapshotProcessor(types.number, {
+            postProcessor: {} as any
+          })
         })
-      })
-    }).toThrowError("[mobx-state-tree] postSnapshotProcessor must be a function")
-  })
+      }).toThrowError("[mobx-state-tree] postSnapshotProcessor must be a function")
+    })
+  }
 })

--- a/src/types/utility-types/snapshotProcessor.ts
+++ b/src/types/utility-types/snapshotProcessor.ts
@@ -16,7 +16,8 @@ import {
   typeCheckFailure,
   isUnionType,
   Instance,
-  ObjectNode
+  ObjectNode,
+  fail
 } from "../../internal"
 
 /** @hidden */


### PR DESCRIPTION
## What does this PR do and why?

Fixes a missing import that would crash `types.snapshotProcessor` on usage.

The reason it wasn't caught by typescript is that it assumed `fail` was a built-in jest function.