### PR TITLE
Bump typescript from 3.9.10 to 5.3.3

### DIFF
--- a/__tests__/core/jsonpatch.test.ts
+++ b/__tests__/core/jsonpatch.test.ts
@@ -16,7 +16,7 @@ import {
   joinJsonPath
 } from "../../src"
 
-function testPatches<C, S, T>(
+function testPatches<C, S, T extends object>(
   type: IType<C, S, T>,
   snapshot: C,
   fn: any,

--- a/__tests__/core/recordPatches.test.ts
+++ b/__tests__/core/recordPatches.test.ts
@@ -11,7 +11,7 @@ import {
   IMSTMap
 } from "../../src"
 
-function testPatches<C, S, T>(
+function testPatches<C, S, T extends object>(
   type: IType<C, S, T>,
   snapshot: C,
   fn: any,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:dev": "cross-env NODE_ENV=development JEST_JUNIT_OUTPUT=./test-results/dev.xml yarn jest",
     "test:prod": "cross-env NODE_ENV=production JEST_JUNIT_OUTPUT=./test-results/prod.xml yarn jest",
     "test:all": "yarn test && yarn test:dev && yarn test:prod && yarn size && yarn coverage",
+    "typecheck": "tsc --noEmit",
     "size": "size-limit",
     "coverage": "yarn jest --coverage",
     "tag-new-version": "yarn version && git push --tags",
@@ -77,7 +78,7 @@
     "rollup-plugin-terser": "^6.1.0",
     "shx": "^0.3.2",
     "size-limit": "^5.0.3",
-    "spec.ts": "^1.1.3",
+    "ts-essentials": "^9.4.1",
     "ts-jest": "^26.1.1",
     "ts-node": "^8.10.2",
     "tslib": "^2.0.0",
@@ -85,7 +86,7 @@
     "tslint-config-prettier": "^1.18.0",
     "typedoc": "0.15.8",
     "typedoc-plugin-markdown": "2.2.11",
-    "typescript": "^3.8.3",
+    "typescript": "^5.3.3",
     "yarn-deduplicate": "^3.1.0"
   },
   "peerDependencies": {

--- a/src/core/node/object-node.ts
+++ b/src/core/node/object-node.ts
@@ -216,7 +216,7 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
     const type = this.type
 
     try {
-      this.storedValue = type.createNewInstance(this._childNodes)
+      this.storedValue = type.createNewInstance(this._childNodes) as typeof this.storedValue
       this.preboot()
 
       this._isRunningAction = true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,6 @@
         "lib": ["es6"],
         "useDefineForClassFields": true
     },
-    "files": ["src/index.ts"]
+    "files": ["src/index.ts"],
+    "include": ["**/*.{js,ts}"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6518,11 +6518,6 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
-spec.ts@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/spec.ts/-/spec.ts-1.1.3.tgz"
-  integrity sha512-xDzHAwbHqe9OIHT1c+pnVpVuYSHNC5vk51aFKKoql2aH1RCzHplkd7MoSV7uLfzgm3GmlfpAfwLtfH2T3lQMmw==
-
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz"
@@ -7004,6 +6999,11 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+ts-essentials@^9.4.1:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-9.4.1.tgz#6a6b6f81c2138008a5eef216e9fa468d8d9e2ab4"
+  integrity sha512-oke0rI2EN9pzHsesdmrOrnqv1eQODmJpd/noJjwj2ZPC3Z4N2wbjrOEqnsEgmvlO2+4fBb0a794DCna2elEVIQ==
+
 ts-jest@^26.1.1:
   version "26.1.1"
   resolved "https://registry.npmjs.org/ts-jest/-/ts-jest-26.1.1.tgz"
@@ -7177,10 +7177,10 @@ typescript@3.7.x:
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.7.7.tgz"
   integrity sha512-MmQdgo/XenfZPvVLtKZOq9jQQvzaUAUpcKW8Z43x9B2fOm4S5g//tPtMweZUIP+SoBqrVPEIm+dJeQ9dfO0QdA==
 
-typescript@^3.8.3:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+typescript@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
+  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
 uglify-js@^3.1.4:
   version "3.6.2"


### PR DESCRIPTION
## What does this PR do and why?

Upgrade `mobx-state-tree` to the latest version of typescript (3.9 -> 5.3).

We were really far behind and missing out on all of the performance improvements and bug fixes, along with features that will allow writing better types for MST (e.g., [variadic tuple types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#variadic-tuple-types) for `types.union` to avoid an `IAnyType` when 10 or more types unioned).

## Steps to validate locally

<!--
Describe how you checked this in your local development environment,
and how a reviewer might check it for themselves.

Consider writing tests, providing code snippets or sandboxes, or at least
a step-by-step instruction that reviewers can use to validate the change and consider
any unexpected behavior
-->
Leaning on existing tests for build correctness, and other than that I've corrected a few failing typechecks.

The `include` config in `tsconfig.json` has also been updated to ensure typechecking in `__tests__` happens, and I've added a `typecheck` command to `package.json` to be able to run just a typecheck on the codebase. I iterated on those until everything passed.