### PR TITLE
Eliminate `NonEmptyObject`

### DIFF
--- a/__tests__/core/type-system.test.ts
+++ b/__tests__/core/type-system.test.ts
@@ -20,7 +20,6 @@ import {
   ModelPropertiesDeclaration,
   SnapshotOut
 } from "../../src"
-import { $nonEmptyObject } from "../../src/internal"
 
 type DifferingKeys<ActualT, ExpectedT> = {
   [K in keyof ActualT | keyof ExpectedT]: K extends keyof ActualT
@@ -1151,7 +1150,6 @@ test("maybe / optional type inference verification", () => {
   assertTypesEqual(
     _ as ITC,
     _ as {
-      [$nonEmptyObject]?: any
       a: string
       b?: string
       c?: string | undefined
@@ -1163,7 +1161,6 @@ test("maybe / optional type inference verification", () => {
   assertTypesEqual(
     _ as ITS,
     _ as {
-      [$nonEmptyObject]?: any
       a: string
       b: string
       c: string | undefined
@@ -1171,4 +1168,22 @@ test("maybe / optional type inference verification", () => {
       e: string
     }
   )
+})
+
+test("object creation with no props", () => {
+  const MyType = types.model().views((_self) => ({
+    get test() {
+      return 5
+    }
+  }))
+
+  MyType.create()
+  MyType.create({})
+  MyType.create({ [Symbol("test")]: 5 })
+
+  // @ts-expect-error
+  MyType.create({ test: 5 })
+
+  // @ts-expect-error
+  MyType.create({ another: 5 })
 })


### PR DESCRIPTION
## What does this PR do and why?

Resolves https://github.com/mobxjs/mobx-state-tree/issues/1524

`NonEmptyObject` was introduced in https://github.com/mobxjs/mobx-state-tree/pull/1269 to prevent passing in any object to a model type that had no props.

Although this works great, some people have found it harder to work with because now `keyof typeof MyModelType` now has this extra key they have to deal with. One could intersect that type with `string`, but it's unfortunate that users have to do this.

Instead, we use `Record<string, never>` which can only be represented by an empty object literal. Snapshot preprocessors also had to be tweaked because they can emit properties that aren't known to them in the case of composition with other types.

## Steps to validate locally

New test added to prove this works, and ran the existing test suite to ensure no breakages.
