### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/concepts/references.md
+++ b/docs/concepts/references.md
@@ -72,7 +72,7 @@ References are looked up through the entire tree but per type, so identifiers ne
 
 The default implementation uses the `identifier` cache to resolve references (See [`resolveIdentifier`](/API#resolveIdentifier)).
 However, it is also possible to override the resolve logic and provide your own custom resolve logic.
-This also makes it possible to, for example, trigger a data fetch when trying to resolve the reference ([example](https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mobx-state-tree/__tests__/core/reference-custom.test.ts#L148)).
+This also makes it possible to, for example, trigger a data fetch when trying to resolve the reference ([example](https://github.com/mobxjs/mobx-state-tree/blob/master/__tests__/core/reference-custom.test.ts#L127)).
 
 Example:
 


### PR DESCRIPTION
## What does this PR do and why?

Fixes a broken link in the documentation

## Steps to validate locally

<!--
Describe how you checked this in your local development environment,
and how a reviewer might check it for themselves.

Consider writing tests, providing code snippets or sandboxes, or at least
a step-by-step instruction that reviewers can use to validate the change and consider
any unexpected behavior
-->

Notice that the old link is no longer valid:
https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mobx-state-tree/__tests__/core/reference-custom.test.ts#L148

Notice that the new link is valid:
https://github.com/mobxjs/mobx-state-tree/blob/master/__tests__/core/reference-custom.test.ts#L127


Please note that I've updated the line number. I didn't check the history of that file, but I do believe this line number is the best entry point to explore the file in the context of this documentation.

