### PR TITLE
chore: remove unused, unnecessary custom Omit type

### DIFF
--- a/src/middlewares/createActionTrackingMiddleware2.ts
+++ b/src/middlewares/createActionTrackingMiddleware2.ts
@@ -1,7 +1,5 @@
 import { IMiddlewareEvent, IMiddlewareHandler, IActionContext } from "../internal"
 
-type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
-
 export interface IActionTrackingMiddleware2Call<TEnv> extends Readonly<IActionContext> {
   env: TEnv | undefined
   readonly parentCall?: IActionTrackingMiddleware2Call<TEnv>


### PR DESCRIPTION
## What does this PR do and why?

We had a custom `Omit` type in `src/middlewares/createActionTrackingMiddleware2.ts` that was:

1. Unused already
2. Unnecessary [since TypeScript 3.5](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys).

Now that we're on TS 5.3.3, we don't need it. Just a little cleanup.

## Steps to validate locally

Unused code, safe change. Tests should pass.