### PR TITLE
chore: target es6 in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "importHelpers": true,
     "stripInternal": true,
     "downlevelIteration": true,
-    "lib": ["ES2016"],
+    "lib": ["es6"],
     "useDefineForClassFields": true,
     "isolatedModules": true,
     "skipLibCheck": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "lib/",
-    "target": "es5",
+    "target": "es6",
     "sourceMap": false,
     "declaration": true,
     "module": "es2015",
@@ -18,7 +18,7 @@
     "importHelpers": true,
     "stripInternal": true,
     "downlevelIteration": true,
-    "lib": ["es6"],
+    "lib": ["ES2016"],
     "useDefineForClassFields": true,
     "isolatedModules": true,
     "skipLibCheck": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es6",
     "sourceMap": false,
     "declaration": true,
-    "module": "es2015",
+    "module": "es6",
     "removeComments": false,
     "moduleResolution": "node",
     "experimentalDecorators": true,


### PR DESCRIPTION
## What does this PR do and why?

Fixes https://github.com/mobxjs/mobx-state-tree/issues/1101 by upgrading our target to `es6`.

## Steps to validate locally

[Repro repo should work](https://github.com/andrey-ridge/mst-1101-demo/tree/master).