### PR TITLE
 Type create/validate to accept an instance type 

### DIFF
--- a/__tests__/core/type-system.test.ts
+++ b/__tests__/core/type-system.test.ts
@@ -1210,6 +1210,9 @@ test("object creation with no props", () => {
   // Instances can be created with their own instance type
   MyType.create(MyType.create())
 
+  // Instances can be created with a snapshot of themselves
+  true || MyType.create(getSnapshot(MyType.create()))
+
   // TODO @ts-expect-error -- symbols aren't props (but may be one day)
   // This currently is allowed, because excess property checking doesn't happen against symbols.
   // See https://github.com/microsoft/TypeScript/issues/44794

--- a/src/core/type/type.ts
+++ b/src/core/type/type.ts
@@ -24,6 +24,7 @@ import {
   getStateTreeNodeSafe,
   assertArg
 } from "../../internal"
+import type { Writable, WritableKeys } from "ts-essentials"
 
 /**
  * @internal
@@ -70,6 +71,8 @@ export type STNValue<T, IT extends IAnyType> = T extends object ? T & IStateTree
 /** @hidden */
 const $type: unique symbol = Symbol("$type")
 
+type ExcludeReadonly<T> = T extends {} ? T[WritableKeys<T>] : T
+
 /**
  * A type, either complex or simple.
  */
@@ -93,7 +96,7 @@ export interface IType<C, S, T> {
    *
    * @returns An instance of that type.
    */
-  create(snapshot?: C, env?: any): this["Type"]
+  create(snapshot?: C | ExcludeReadonly<T>, env?: any): this["Type"]
 
   /**
    * Checks if a given snapshot / instance is of the given type.
@@ -110,7 +113,7 @@ export interface IType<C, S, T> {
    * @param context Validation context, an array of { subpaths, subtypes } that should be validated
    * @returns The validation result, an array with the list of validation errors.
    */
-  validate(thing: C, context: IValidationContext): IValidationResult
+  validate(thing: C | T, context: IValidationContext): IValidationResult
 
   /**
    * Gets the textual representation of the type as a string.

--- a/src/types/complex-types/model.ts
+++ b/src/types/complex-types/model.ts
@@ -125,7 +125,7 @@ type DefinablePropsNames<T> = { [K in keyof T]: IsOptionalValue<T[K], never, K> 
 
 /** @hidden */
 export type ExtractCFromProps<P extends ModelProperties> = MaybeEmpty<{
-  [k in keyof P]: P[k]["CreationType"]
+  [k in keyof P]: P[k]["CreationType"] | P[k]["TypeWithoutSTN"]
 }>
 
 /** @hidden */


### PR DESCRIPTION
## What does this PR do and why?

We've had issues with typings when instantiating references

![CleanShot 2024-07-20 at 11 42 42@2x](https://github.com/user-attachments/assets/afdd5e69-0a70-4b0f-acb8-f542cfa80c66)

https://github.com/mobxjs/mobx-state-tree/issues/1568 for example, and maybe even https://github.com/mobxjs/mobx-state-tree/issues/1764.

This PR resolves that by typing `create` to accept an instance type. I've added a "kitchen sink" test for create to test both snapshots and instances.

## Steps to validate locally

The test added in this PR will type issues (like in above the screenshot) if you revert 6176e94efbcf1094c846ef2c4f19fd0a08249d01.