### PR TITLE
Ensure actions/volatile state also throw when overriding props.

### DIFF
--- a/__tests__/core/model.test.ts
+++ b/__tests__/core/model.test.ts
@@ -208,8 +208,9 @@ describe("Model instantiation", () => {
     applySnapshot(model, { val: 1 })
     expect(onSnapshot).toHaveBeenLastCalledWith({ val: 1 })
   })
-  describe("When a model has duplicate key in actions or views", () => {
-    test("it should show friendly message", () => {
+
+  describe("Should show a friendly message when a model has a property overridden by", () => {
+    test("a view", () => {
       const UserModel = types
         .model("UserModel", {
           id: types.identifier,
@@ -226,9 +227,48 @@ describe("Model instantiation", () => {
           id: "chakri",
           name: "Subramanya Chakravarthy"
         })
-      ).toThrow("[mobx-state-tree] name property is declared twice")
+      ).toThrow("[mobx-state-tree] 'name' is a property and cannot be declared as a view")
+    })
+
+    test("an action", () => {
+      const StringSet = types
+        .model("StringSet", {
+          setName: types.string,
+          items: types.array(types.string)
+        })
+        .actions((self) => ({
+          setName(name: string) {
+            self.setName = name
+          }
+        }))
+
+      expect(() =>
+        StringSet.create({
+          setName: "Fruits",
+          items: ["banana", "apple"]
+        })
+      ).toThrow("[mobx-state-tree] 'setName' is a property and cannot be declared as an action")
+    })
+
+    test("a volatile", () => {
+      const UserModel = types
+        .model("UserModel", {
+          id: types.identifier,
+          name: types.string
+        })
+        .volatile((_self) => ({
+          name: "Subramanya Chakravarthy"
+        }))
+
+      expect(() =>
+        UserModel.create({
+          id: "chakri",
+          name: "Subramanya Chakravarthy"
+        })
+      ).toThrow("[mobx-state-tree] 'name' is a property and cannot be declared as volatile state")
     })
   })
+
   describe("with all of the property types", () => {
     const IdentifiedWithString = types.model({ id: types.identifier })
     const IdentifiedWithNumber = types.model({ id: types.identifierNumber })


### PR DESCRIPTION
## What does this PR do and why?

If we allow instantiation to proceed further, the instantiation will fail, but something about the snapshot reaction we set up leaks and causes future tests to fail. This is a follow-up to https://github.com/mobxjs/mobx-state-tree/pull/2204 where we made a similar change for views.

## Steps to validate locally

Revert the changes to `model.ts` and run `bun test` to observe various tests failing due to this "leak".