### PR TITLE
Make ts-essentials a regular dependency

### DIFF
--- a/__tests__/core/api.test.ts
+++ b/__tests__/core/api.test.ts
@@ -1,6 +1,6 @@
-import * as mst from "../../src"
-import { readFileSync } from "fs"
 import { expect, test } from "bun:test"
+import { readFileSync } from "fs"
+import * as mst from "../../src"
 
 function stringToArray(s: string): string[] {
     return s.split(",").map(str => str.trim())
@@ -156,7 +156,7 @@ test("all methods mentioned in API docs", () => {
 })
 
 test("only accepted dependencies", () => {
-    const validDeps: string[] = []
+    const validDeps: string[] = ["ts-essentials"]
 
     const deps =
         JSON.parse(readFileSync(__dirname + "/../../package.json", "utf8")).dependencies || {}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "files": [
         "dist/"
     ],
+    "dependencies": {
+        "ts-essentials": "^9.4.1"
+    },
     "devDependencies": {
         "@size-limit/preset-big-lib": "^5.0.3",
         "@types/bun": "^1.0.6",
@@ -71,7 +74,6 @@
         "rollup-plugin-terser": "^6.1.0",
         "shx": "^0.3.2",
         "size-limit": "^5.0.3",
-        "ts-essentials": "^9.4.1",
         "ts-node": "^8.10.2",
         "tslib": "^2.0.0",
         "tslint": "^6.1.3",


### PR DESCRIPTION
## What does this PR do and why?

Resolves #2233

When I was working on improving type definitions, I brought in `ts-essentials` as a dev dependency. What I failed to realize was that this library still gets referenced in the generated type declaration files, so we can't have it as a dev dependency.

Also, doing the same thing locally without skipping the lib check (tsconfig.json), you get the following:

```
⠿ npm exec tsc
node_modules/mobx-state-tree/dist/core/type/type.d.ts(2,35): error TS2307: Cannot find module 'ts-essentials' or its corresponding type declarations.
```

This PR fixes that issue by making it a real dependency.

I've opted to follow up with testing that can catch this kind of user, to expedite getting this fix out to our users.

## Steps to validate locally

`npm pack`, and then using a `file:` dependency pointing at the tarball it created. Before this PR you get the above error, and after this error you get a happy `tsc`.