### PR TITLE
Fixing a link to the API in references.md

### DIFF
--- a/docs/concepts/references.md
+++ b/docs/concepts/references.md
@@ -70,7 +70,7 @@ References are looked up through the entire tree but per type, so identifiers ne
 
 #### Customizable references
 
-The default implementation uses the `identifier` cache to resolve references (See [`resolveIdentifier`](/API#resolveIdentifier)).
+The default implementation uses the `identifier` cache to resolve references (See [`resolveIdentifier`](/API#resolveidentifier)).
 However, it is also possible to override the resolve logic and provide your own custom resolve logic.
 This also makes it possible to, for example, trigger a data fetch when trying to resolve the reference ([example](https://github.com/mobxjs/mobx-state-tree/blob/master/__tests__/core/reference-custom.test.ts#L127)).
 


### PR DESCRIPTION
Minor fix: making a link to resolveIdentifier lowercase