### PR TITLE
docs: fix broken link to /concepts/dependency-injection

### DIFF
--- a/src/core/mst-operations.ts
+++ b/src/core/mst-operations.ts
@@ -760,7 +760,7 @@ export function addDisposer(target: IAnyStateTreeNode, disposer: IDisposer): IDi
 
 /**
  * Returns the environment of the current state tree, or throws. For more info on environments,
- * see [Dependency injection](https://github.com/mobxjs/mobx-state-tree#dependency-injection)
+ * see [Dependency injection](/concepts/dependency-injection)
  *
  * Please note that in child nodes access to the root is only possible
  * once the `afterAttach` hook has fired


### PR DESCRIPTION
## What does this PR do and why?

This will fix a broken link at [`getEnv`](https://mobx-state-tree.js.org//API/#getenv) to "Dependency Injection" *once* the docs are being build again.

## Steps to validate locally
Execute following scripts:
```
bun install
bun run build-docs
bun start
```
Navigate to http://localhost:3000/API/#getenv and click on **Dependency injection**