### PR TITLE
fix: invalidate safe references after snapshot reconciliation

### DIFF
--- a/__tests__/core/reference-onInvalidated.test.ts
+++ b/__tests__/core/reference-onInvalidated.test.ts
@@ -299,6 +299,80 @@ describe("safeReference", () => {
         expect(store.single).toBeUndefined()
     })
 
+    test("invalid references applied to an existing tree should be removed", () => {
+        const events: Array<[string, string | number]> = []
+        const onInvalidated: OnReferenceInvalidated<Instance<typeof Todo>> = ev => {
+            events.push([ev.cause, ev.invalidId])
+        }
+        const SafeRef = types.safeReference(Todo, { onInvalidated })
+
+        const Store = types.model({
+            todos: types.array(Todo),
+            single: SafeRef,
+            arr: types.array(SafeRef),
+            map: types.map(SafeRef)
+        })
+
+        const store = Store.create({
+            todos: [{ id: "1" }, { id: "2" }],
+            single: "1",
+            arr: ["1"],
+            map: { a: "1" }
+        })
+        unprotect(store)
+
+        applySnapshot(store, {
+            todos: [{ id: "1" }, { id: "2" }],
+            single: "100",
+            arr: ["100", "2"],
+            map: { a: "100", b: "2" }
+        })
+
+        expect(events).toEqual([
+            ["invalidSnapshotReference", "100"],
+            ["invalidSnapshotReference", "100"],
+            ["invalidSnapshotReference", "100"]
+        ])
+        expect(store.single).toBeUndefined()
+        expect(store.arr.length).toBe(1)
+        expect(store.arr[0]!.id).toBe("2")
+        expect(store.map.size).toBe(1)
+        expect(store.map.get("b")!.id).toBe("2")
+    })
+
+    test("references applied before their target appears later in the same snapshot should stay valid", () => {
+        const events: Array<[string, string | number]> = []
+        const Item = types.model({
+            id: types.identifierNumber,
+            title: types.string
+        })
+        const SafeRef = types.safeReference(Item, {
+            onInvalidated(ev) {
+                events.push([ev.cause, ev.invalidId])
+            }
+        })
+        const Store = types.model({
+            selected: SafeRef,
+            items: types.array(Item)
+        })
+
+        const store = Store.create({
+            selected: 1,
+            items: [{ id: 1, title: "one" }]
+        })
+
+        applySnapshot(store, {
+            selected: 2,
+            items: [
+                { id: 1, title: "one" },
+                { id: 2, title: "two" }
+            ]
+        })
+
+        expect(events).toEqual([])
+        expect(store.selected).toBe(store.items[1])
+    })
+
     test("setting it to an invalid id and then accessing it should still result in an error", () => {
         const store = createStore({})
         store.single = "100" as any

--- a/__tests__/core/reference-onInvalidated.test.ts
+++ b/__tests__/core/reference-onInvalidated.test.ts
@@ -9,7 +9,9 @@ import {
     getSnapshot,
     applySnapshot,
     clone,
-    destroy
+    destroy,
+    flow,
+    addMiddleware
 } from "../../src"
 import { describe, expect, it, test } from "bun:test"
 
@@ -371,6 +373,86 @@ describe("safeReference", () => {
 
         expect(events).toEqual([])
         expect(store.selected).toBe(store.items[1])
+    })
+
+    test("invalid references applied in a resumed flow step should be removed before the flow resolves", async () => {
+        const events: Array<[string, string | number]> = []
+        const Item = types.model({
+            id: types.identifier
+        })
+        const SafeRef = types.safeReference(Item, {
+            onInvalidated(ev) {
+                events.push([ev.cause, ev.invalidId])
+            }
+        })
+        const Store = types
+            .model({
+                selected: SafeRef,
+                items: types.array(Item)
+            })
+            .actions(self => ({
+                update: flow(function* update() {
+                    yield Promise.resolve()
+                    applySnapshot(self, {
+                        selected: "100",
+                        items: [{ id: "1" }]
+                    })
+                })
+            }))
+
+        const store = Store.create({
+            selected: "1",
+            items: [{ id: "1" }]
+        })
+        await store.update()
+
+        expect(events).toEqual([["invalidSnapshotReference", "100"]])
+        expect(store.selected).toBeUndefined()
+    })
+
+    test("invalid references applied in an aborted middleware action should be removed before action returns", () => {
+        const events: Array<[string, string | number]> = []
+        const Item = types.model({
+            id: types.identifier
+        })
+        const SafeRef = types.safeReference(Item, {
+            onInvalidated(ev) {
+                events.push([ev.cause, ev.invalidId])
+            }
+        })
+        const Store = types
+            .model({
+                selected: SafeRef,
+                items: types.array(Item)
+            })
+            .actions(() => ({
+                first() {},
+                second() {}
+            }))
+
+        const store = Store.create({
+            selected: "1",
+            items: [{ id: "1" }]
+        })
+
+        const dispose = addMiddleware(store, (call, next, abort) => {
+            if (call.name === "first") {
+                applySnapshot(store, {
+                    selected: "100",
+                    items: [{ id: "1" }]
+                })
+                abort(undefined)
+                return
+            }
+            return next(call)
+        })
+
+        store.first()
+
+        expect(events).toEqual([["invalidSnapshotReference", "100"]])
+        expect(store.selected).toBeUndefined()
+
+        dispose()
     })
 
     test("setting it to an invalid id and then accessing it should still result in an error", () => {

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -104,9 +104,10 @@ export function runWithActionContext(context: IMiddlewareEvent, fn: Function) {
     const baseIsRunningAction = node._isRunningAction
     node._isRunningAction = true
     const previousContext = currentActionContext
+    const isRootActionContext = !previousContext
     currentActionContext = context
     try {
-        return runMiddleWares(node, context, fn)
+        return runMiddleWares(node, context, fn, isRootActionContext)
     } finally {
         currentActionContext = previousContext
         node._isRunningAction = baseIsRunningAction
@@ -259,7 +260,8 @@ class CollectedMiddlewares {
 function runMiddleWares(
     node: AnyObjectNode,
     baseCall: IMiddlewareEvent,
-    originalFn: Function
+    originalFn: Function,
+    isRootActionContext: boolean
 ): any {
     function runInActionScope(call: IMiddlewareEvent, fn: Function): any {
         const execute = () => {
@@ -272,7 +274,7 @@ function runMiddleWares(
                 error = e
             }
 
-            if (!call.parentActionEvent) {
+            if (isRootActionContext || !call.parentActionEvent) {
                 try {
                     node.root.flushEndOfActionCallbacks()
                 } catch (flushError) {
@@ -345,6 +347,9 @@ function runMiddleWares(
                     `The next() and abort() callback within the middleware ${handler.name} for the action: "${call.name}" on the node: ${node2.type.name} were invoked.`
                 )
             }
+        }
+        if (abortInvoked && (isRootActionContext || !call.parentActionEvent)) {
+            return runInActionScope(call, () => result)
         }
         return result
     }

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -261,9 +261,40 @@ function runMiddleWares(
     baseCall: IMiddlewareEvent,
     originalFn: Function
 ): any {
+    function runInActionScope(call: IMiddlewareEvent, fn: Function): any {
+        const execute = () => {
+            let result: any
+            let error: any
+
+            try {
+                result = fn.apply(null, call.args)
+            } catch (e) {
+                error = e
+            }
+
+            if (!call.parentActionEvent) {
+                try {
+                    node.root.flushEndOfActionCallbacks()
+                } catch (flushError) {
+                    if (!error) {
+                        error = flushError
+                    }
+                }
+            }
+
+            if (error) {
+                throw error
+            }
+
+            return result
+        }
+
+        return call.name ? mobxAction(call.name, execute)() : mobxAction(execute)()
+    }
+
     const middlewares = new CollectedMiddlewares(node, originalFn)
     // Short circuit
-    if (middlewares.isEmpty) return mobxAction(originalFn).apply(null, baseCall.args)
+    if (middlewares.isEmpty) return runInActionScope(baseCall, originalFn)
 
     let result: any = null
 
@@ -272,7 +303,7 @@ function runMiddleWares(
         const handler = middleware && middleware.handler
 
         if (!handler) {
-            return mobxAction(originalFn).apply(null, call.args)
+            return runInActionScope(call, originalFn)
         }
 
         // skip hooks if asked to

--- a/src/core/node/object-node.ts
+++ b/src/core/node/object-node.ts
@@ -111,6 +111,7 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
     private _autoUnbox = true // unboxing is disabled when reading child nodes
     _isRunningAction = false // only relevant for root
     private _hasSnapshotReaction = false
+    private _endOfActionCallbacks?: Array<() => void>
 
     private _observableInstanceState = ObservableInstanceLifecycle.UNINITIALIZED
     private _childNodes: IChildNodesMap
@@ -259,6 +260,26 @@ export class ObjectNode<C, S, T> extends BaseNode<C, S, T> {
     get root(): AnyObjectNode {
         const parent = this.parent
         return parent ? parent.root : this
+    }
+
+    enqueueEndOfAction(callback: () => void): void {
+        const root = this.root
+        if (!root._endOfActionCallbacks) {
+            root._endOfActionCallbacks = []
+        }
+        root._endOfActionCallbacks.push(callback)
+    }
+
+    flushEndOfActionCallbacks(): void {
+        const root = this.root
+        while (root._endOfActionCallbacks && root._endOfActionCallbacks.length > 0) {
+            const callbacks = root._endOfActionCallbacks
+            root._endOfActionCallbacks = undefined
+
+            callbacks.forEach(callback => {
+                callback()
+            })
+        }
     }
 
     clearParent(): void {

--- a/src/types/utility-types/reference.ts
+++ b/src/types/utility-types/reference.ts
@@ -30,7 +30,9 @@ import {
     IStateTreeNode,
     devMode,
     isType,
-    type IAnyModelType
+    type IAnyModelType,
+    getCurrentActionContext,
+    setImmediateWithFallback
 } from "../../internal"
 
 export type OnReferenceInvalidatedEvent<STN extends IAnyStateTreeNode> = {
@@ -270,6 +272,24 @@ export abstract class BaseReferenceType<IT extends IAnyComplexType> extends Simp
             }
         })
 
+        const scheduleRetryAfterReconciliation = () => {
+            const retry = () => {
+                if (!storedRefNode.isAlive) {
+                    return
+                }
+                if (this.getSnapshot(storedRefNode) !== identifier) {
+                    return
+                }
+                startWatching(false)
+            }
+
+            if (getCurrentActionContext()) {
+                storedRefNode.root.enqueueEndOfAction(retry)
+            } else {
+                setImmediateWithFallback(retry)
+            }
+        }
+
         const startWatching = (sync: boolean) => {
             // re-create hook in case the stored ref gets reattached
             if (onRefTargetDestroyedHookDisposer) {
@@ -291,12 +311,12 @@ export abstract class BaseReferenceType<IT extends IAnyComplexType> extends Simp
                 }
 
                 if (!refTargetNodeExists) {
-                    // we cannot change the reference in sync mode
-                    // since we are in the middle of a reconciliation/instantiation and the change would be overwritten
-                    // for those cases just let the wrong reference be assigned and fail upon usage
-                    // (like current references do)
-                    // this means that effectively this code will only run when it is created from a snapshot
-                    if (!sync) {
+                    // if the tree is already attached we may still be in the middle of a reconcile/applySnapshot,
+                    // so wait until the current MST action finishes before deciding whether to invalidate or
+                    // attach a watcher to a target that appeared later in the same action.
+                    if (sync) {
+                        scheduleRetryAfterReconciliation()
+                    } else {
                         this.fireInvalidated(
                             "invalidSnapshotReference",
                             storedRefNode,


### PR DESCRIPTION
## What does this PR do and why?

If this pull request is approved, it will make `safeReference` invalidate bad snapshot identifiers that arrive through `applySnapshot` / reconciliation on an already-attached tree, instead of leaving broken references in place until they throw on access.

Today this already works during initial creation, but not when an invalid reference is introduced into an existing tree. In that case MST skips invalidation while reconciliation is still in progress, so `onInvalidated` never fires and `safeReference` can still crash the app when read.

This change keeps the existing API and delays that invalidation check until the current MST action finishes. That gives reconciliation time to complete, including cases where the target node appears later in the same snapshot, and then MST can either:

- attach the normal invalidation watcher when the target exists
- fire `onInvalidated` with `cause: "invalidSnapshotReference"` and let `safeReference` clean itself up

This PR also adds regression coverage for:

- applying invalid safe references to an existing tree
- snapshots where a reference appears before its target later in the same apply

Closes #2212.

## Steps to validate locally

- `bun run typecheck`
- `bun run build`
- `bun run test:all`

Focused checks:
- `bun test __tests__/core/reference-onInvalidated.test.ts`
- `bun test __tests__/core/reference.test.ts`
- `bun test __tests__/core/action.test.ts`
- `bun test __tests__/core/async.test.ts`
- `bun test __tests__/core/actionTrackingMiddleware2.test.ts`

Additional app-level verification:
- Ran a minimal Expo repro on the iOS simulator against this local MST branch  
<img width="1206" height="2622" alt="issue-2212-ios-pass" src="https://github.com/user-attachments/assets/4331349c-e98d-414f-991c-1c8ec5ebfe1a" />

- Confirmed invalid snapshot references in `safeReference` model / array / map values trigger `onInvalidated`
- Confirmed invalid refs are removed instead of throwing on first access
- Confirmed references still resolve correctly when the target appears later in the same snapshot

Note:
- The original external repro repository linked in the issue currently returns 404, so I recreated the failing scenario in a minimal Expo app for runtime verification.
