### PR TITLE
Chore/version 7.3.0

### DIFF
--- a/docs/API/index.md
+++ b/docs/API/index.md
@@ -1,16 +1,17 @@
 ---
 id: "index"
-title: "mobx-state-tree - v7.2.0"
+title: "mobx-state-tree - v7.3.0"
 sidebar_label: "Globals"
 ---
 
-[mobx-state-tree - v7.2.0](index.md)
+[mobx-state-tree - v7.3.0](index.md)
 
 ## Index
 
 ### Interfaces
 
 * [CustomTypeOptions](interfaces/customtypeoptions.md)
+* [ErrorFormattingOptions](interfaces/errorformattingoptions.md)
 * [FunctionWithFlag](interfaces/functionwithflag.md)
 * [IActionContext](interfaces/iactioncontext.md)
 * [IActionRecorder](interfaces/iactionrecorder.md)
@@ -288,7 +289,7 @@ ___
 
 Ƭ **IValidationContext**: *[IValidationContextEntry](interfaces/ivalidationcontextentry.md)[]*
 
-*Defined in [src/core/type/type-checker.ts:23](https://github.com/mobxjs/mobx-state-tree/blob/6c2cad97/src/core/type/type-checker.ts#L23)*
+*Defined in [src/core/type/type-checker.ts:26](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/type-checker.ts#L26)*
 
 Array of validation context entries
 
@@ -298,7 +299,7 @@ ___
 
 Ƭ **IValidationResult**: *[IValidationError](interfaces/ivalidationerror.md)[]*
 
-*Defined in [src/core/type/type-checker.ts:36](https://github.com/mobxjs/mobx-state-tree/blob/6c2cad97/src/core/type/type-checker.ts#L36)*
+*Defined in [src/core/type/type-checker.ts:39](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/type-checker.ts#L39)*
 
 Type validation result, which is an array of type validation errors
 
@@ -2765,15 +2766,17 @@ ___
 
 ###  getErrorFormatting
 
-▸ **getErrorFormatting**(): *ErrorFormattingOptions*
+▸ **getErrorFormatting**(): *[ErrorFormattingOptions](interfaces/errorformattingoptions.md)*
 
-*Defined in [src/core/type/errorFormatting.ts:80](https://github.com/mobxjs/mobx-state-tree/blob/master/src/core/type/errorFormatting.ts#L80)*
+*Defined in [src/core/type/errorFormatting.ts:75](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/errorFormatting.ts#L75)*
 
-Returns a copy of the current error formatting options (see [setErrorFormatting](index.md#seterrorformatting)). Useful for temporarily overriding and then restoring the configuration.
+Returns a copy of the current error formatting options (see
+[setErrorFormatting](index.md#seterrorformatting)). Useful for temporarily overriding and then
+restoring the configuration.
 
-**Returns:** *ErrorFormattingOptions*
+**Returns:** *[ErrorFormattingOptions](interfaces/errorformattingoptions.md)*
 
-The current `ErrorFormattingOptions`.
+The current [ErrorFormattingOptions](interfaces/errorformattingoptions.md).
 
 ___
 
@@ -4334,19 +4337,35 @@ ___
 
 ###  setErrorFormatting
 
-▸ **setErrorFormatting**(`options`: Partial‹ErrorFormattingOptions›): *void*
+▸ **setErrorFormatting**(`options`: Partial‹[ErrorFormattingOptions](interfaces/errorformattingoptions.md)›): *void*
 
-*Defined in [src/core/type/errorFormatting.ts:67](https://github.com/mobxjs/mobx-state-tree/blob/master/src/core/type/errorFormatting.ts#L67)*
+*Defined in [src/core/type/errorFormatting.ts:64](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/errorFormatting.ts#L64)*
 
-Configures how snapshots/values and type shapes are formatted inside type-checking error messages. This is **opt-in**: by default MST keeps its original single-line error formatting, so enabling this does not change behavior for anyone who doesn't call it.
+Configures how snapshots/values and type shapes are formatted inside
+type-checking error messages. This is **opt-in**: by default MST keeps its
+original single-line error formatting, so enabling this does not change
+behavior for anyone who doesn't call it.
 
-The given options are merged over the current ones, so you can set only the fields you care about.
+The given options are merged over the current ones, so you can set only the
+fields you care about.
+
+**`example`** 
+// pretty-print large snapshots across multiple lines and truncate them
+setErrorFormatting({ enabled: true })
+
+**`example`** 
+// only bound the message size, without reflowing it onto multiple lines
+setErrorFormatting({ enabled: true, indent: 0 })
+
+**`example`** 
+// tweak the truncation limits
+setErrorFormatting({ enabled: true, maxArrayLength: 3, maxStringLength: 40 })
 
 **Parameters:**
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`options` | Partial‹ErrorFormattingOptions› | A partial set of `ErrorFormattingOptions` to apply.  |
+`options` | Partial‹[ErrorFormattingOptions](interfaces/errorformattingoptions.md)› | A partial set of [ErrorFormattingOptions](interfaces/errorformattingoptions.md) to apply.  |
 
 **Returns:** *void*
 
@@ -4586,7 +4605,7 @@ ___
 
 ▸ **typecheck**<**IT**>(`type`: IT, `value`: ExtractCSTWithSTN‹IT›): *void*
 
-*Defined in [src/core/type/type-checker.ts:164](https://github.com/mobxjs/mobx-state-tree/blob/6c2cad97/src/core/type/type-checker.ts#L164)*
+*Defined in [src/core/type/type-checker.ts:306](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/type-checker.ts#L306)*
 
 Run's the typechecker for the given type on the given value, which can be a snapshot or an instance.
 Throws if the given value is not according the provided type specification.

--- a/docs/API/interfaces/customtypeoptions.md
+++ b/docs/API/interfaces/customtypeoptions.md
@@ -4,7 +4,7 @@ title: "CustomTypeOptions"
 sidebar_label: "CustomTypeOptions"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [CustomTypeOptions](customtypeoptions.md)
+[mobx-state-tree - v7.3.0](../index.md) › [CustomTypeOptions](customtypeoptions.md)
 
 ## Type parameters
 

--- a/docs/API/interfaces/errorformattingoptions.md
+++ b/docs/API/interfaces/errorformattingoptions.md
@@ -1,0 +1,91 @@
+---
+id: "errorformattingoptions"
+title: "ErrorFormattingOptions"
+sidebar_label: "ErrorFormattingOptions"
+---
+
+[mobx-state-tree - v7.3.0](../index.md) › [ErrorFormattingOptions](errorformattingoptions.md)
+
+Options that control how snapshots/values and type shapes are rendered inside
+type-checking error messages (see [setErrorFormatting](../index.md#seterrorformatting)).
+
+## Hierarchy
+
+* **ErrorFormattingOptions**
+
+## Index
+
+### Properties
+
+* [enabled](errorformattingoptions.md#enabled)
+* [indent](errorformattingoptions.md#indent)
+* [maxArrayLength](errorformattingoptions.md#maxarraylength)
+* [maxDepth](errorformattingoptions.md#maxdepth)
+* [maxPropertyCount](errorformattingoptions.md#maxpropertycount)
+* [maxStringLength](errorformattingoptions.md#maxstringlength)
+
+## Properties
+
+###  enabled
+
+• **enabled**: *boolean*
+
+*Defined in [src/core/type/errorFormatting.ts:13](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/errorFormatting.ts#L13)*
+
+When `false` (the default), error messages are rendered exactly as they
+always have been: the offending value is serialized to a single
+`JSON.stringify` line and the message is capped in length. When `true`,
+the value is truncated (using the limits below) and, when `indent > 0`,
+pretty-printed across multiple lines.
+
+___
+
+###  indent
+
+• **indent**: *number*
+
+*Defined in [src/core/type/errorFormatting.ts:19](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/errorFormatting.ts#L19)*
+
+Number of spaces to indent each nesting level by when pretty-printing.
+Use `0` to keep everything on a single line while still truncating
+(handy when you only want to bound the message size, not reflow it).
+
+___
+
+###  maxArrayLength
+
+• **maxArrayLength**: *number*
+
+*Defined in [src/core/type/errorFormatting.ts:23](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/errorFormatting.ts#L23)*
+
+Arrays with more than this many items are clipped, with a note of how many items were omitted.
+
+___
+
+###  maxDepth
+
+• **maxDepth**: *number*
+
+*Defined in [src/core/type/errorFormatting.ts:27](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/errorFormatting.ts#L27)*
+
+Values nested deeper than this are summarized as `{…}` / `[…]`.
+
+___
+
+###  maxPropertyCount
+
+• **maxPropertyCount**: *number*
+
+*Defined in [src/core/type/errorFormatting.ts:25](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/errorFormatting.ts#L25)*
+
+Objects with more than this many keys are clipped, with a note of how many keys were omitted.
+
+___
+
+###  maxStringLength
+
+• **maxStringLength**: *number*
+
+*Defined in [src/core/type/errorFormatting.ts:21](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/errorFormatting.ts#L21)*
+
+Strings longer than this are clipped, with a note of how many characters were omitted.

--- a/docs/API/interfaces/functionwithflag.md
+++ b/docs/API/interfaces/functionwithflag.md
@@ -4,7 +4,7 @@ title: "FunctionWithFlag"
 sidebar_label: "FunctionWithFlag"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [FunctionWithFlag](functionwithflag.md)
+[mobx-state-tree - v7.3.0](../index.md) › [FunctionWithFlag](functionwithflag.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/iactioncontext.md
+++ b/docs/API/interfaces/iactioncontext.md
@@ -4,7 +4,7 @@ title: "IActionContext"
 sidebar_label: "IActionContext"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IActionContext](iactioncontext.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IActionContext](iactioncontext.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/iactionrecorder.md
+++ b/docs/API/interfaces/iactionrecorder.md
@@ -4,7 +4,7 @@ title: "IActionRecorder"
 sidebar_label: "IActionRecorder"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IActionRecorder](iactionrecorder.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IActionRecorder](iactionrecorder.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/iactiontrackingmiddleware2call.md
+++ b/docs/API/interfaces/iactiontrackingmiddleware2call.md
@@ -4,7 +4,7 @@ title: "IActionTrackingMiddleware2Call"
 sidebar_label: "IActionTrackingMiddleware2Call"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IActionTrackingMiddleware2Call](iactiontrackingmiddleware2call.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IActionTrackingMiddleware2Call](iactiontrackingmiddleware2call.md)
 
 ## Type parameters
 

--- a/docs/API/interfaces/iactiontrackingmiddleware2hooks.md
+++ b/docs/API/interfaces/iactiontrackingmiddleware2hooks.md
@@ -4,7 +4,7 @@ title: "IActionTrackingMiddleware2Hooks"
 sidebar_label: "IActionTrackingMiddleware2Hooks"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IActionTrackingMiddleware2Hooks](iactiontrackingmiddleware2hooks.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IActionTrackingMiddleware2Hooks](iactiontrackingmiddleware2hooks.md)
 
 ## Type parameters
 

--- a/docs/API/interfaces/iactiontrackingmiddlewarehooks.md
+++ b/docs/API/interfaces/iactiontrackingmiddlewarehooks.md
@@ -4,7 +4,7 @@ title: "IActionTrackingMiddlewareHooks"
 sidebar_label: "IActionTrackingMiddlewareHooks"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IActionTrackingMiddlewareHooks](iactiontrackingmiddlewarehooks.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IActionTrackingMiddlewareHooks](iactiontrackingmiddlewarehooks.md)
 
 ## Type parameters
 

--- a/docs/API/interfaces/ianycomplextype.md
+++ b/docs/API/interfaces/ianycomplextype.md
@@ -4,7 +4,7 @@ title: "IAnyComplexType"
 sidebar_label: "IAnyComplexType"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IAnyComplexType](ianycomplextype.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IAnyComplexType](ianycomplextype.md)
 
 Any kind of complex type.
 

--- a/docs/API/interfaces/ianymodeltype.md
+++ b/docs/API/interfaces/ianymodeltype.md
@@ -4,7 +4,7 @@ title: "IAnyModelType"
 sidebar_label: "IAnyModelType"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IAnyModelType](ianymodeltype.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IAnyModelType](ianymodeltype.md)
 
 Any model type.
 

--- a/docs/API/interfaces/ianytype.md
+++ b/docs/API/interfaces/ianytype.md
@@ -4,7 +4,7 @@ title: "IAnyType"
 sidebar_label: "IAnyType"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IAnyType](ianytype.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IAnyType](ianytype.md)
 
 Any kind of type.
 

--- a/docs/API/interfaces/ihooks.md
+++ b/docs/API/interfaces/ihooks.md
@@ -4,7 +4,7 @@ title: "IHooks"
 sidebar_label: "IHooks"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IHooks](ihooks.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IHooks](ihooks.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/ijsonpatch.md
+++ b/docs/API/interfaces/ijsonpatch.md
@@ -4,7 +4,7 @@ title: "IJsonPatch"
 sidebar_label: "IJsonPatch"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IJsonPatch](ijsonpatch.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IJsonPatch](ijsonpatch.md)
 
 https://tools.ietf.org/html/rfc6902
 http://jsonpatch.com/

--- a/docs/API/interfaces/imiddlewareevent.md
+++ b/docs/API/interfaces/imiddlewareevent.md
@@ -4,7 +4,7 @@ title: "IMiddlewareEvent"
 sidebar_label: "IMiddlewareEvent"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IMiddlewareEvent](imiddlewareevent.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IMiddlewareEvent](imiddlewareevent.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/imodelreflectiondata.md
+++ b/docs/API/interfaces/imodelreflectiondata.md
@@ -4,7 +4,7 @@ title: "IModelReflectionData"
 sidebar_label: "IModelReflectionData"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IModelReflectionData](imodelreflectiondata.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IModelReflectionData](imodelreflectiondata.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/imodelreflectionpropertiesdata.md
+++ b/docs/API/interfaces/imodelreflectionpropertiesdata.md
@@ -4,7 +4,7 @@ title: "IModelReflectionPropertiesData"
 sidebar_label: "IModelReflectionPropertiesData"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IModelReflectionPropertiesData](imodelreflectionpropertiesdata.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IModelReflectionPropertiesData](imodelreflectionpropertiesdata.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/imodeltype.md
+++ b/docs/API/interfaces/imodeltype.md
@@ -4,7 +4,7 @@ title: "IModelType"
 sidebar_label: "IModelType"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IModelType](imodeltype.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IModelType](imodeltype.md)
 
 ## Type parameters
 

--- a/docs/API/interfaces/ipatchrecorder.md
+++ b/docs/API/interfaces/ipatchrecorder.md
@@ -4,7 +4,7 @@ title: "IPatchRecorder"
 sidebar_label: "IPatchRecorder"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IPatchRecorder](ipatchrecorder.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IPatchRecorder](ipatchrecorder.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/ireversiblejsonpatch.md
+++ b/docs/API/interfaces/ireversiblejsonpatch.md
@@ -4,7 +4,7 @@ title: "IReversibleJsonPatch"
 sidebar_label: "IReversibleJsonPatch"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IReversibleJsonPatch](ireversiblejsonpatch.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IReversibleJsonPatch](ireversiblejsonpatch.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/iserializedactioncall.md
+++ b/docs/API/interfaces/iserializedactioncall.md
@@ -4,7 +4,7 @@ title: "ISerializedActionCall"
 sidebar_label: "ISerializedActionCall"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [ISerializedActionCall](iserializedactioncall.md)
+[mobx-state-tree - v7.3.0](../index.md) › [ISerializedActionCall](iserializedactioncall.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/isimpletype.md
+++ b/docs/API/interfaces/isimpletype.md
@@ -4,7 +4,7 @@ title: "ISimpleType"
 sidebar_label: "ISimpleType"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [ISimpleType](isimpletype.md)
+[mobx-state-tree - v7.3.0](../index.md) › [ISimpleType](isimpletype.md)
 
 A simple type, this is, a type where the instance and the snapshot representation are the same.
 

--- a/docs/API/interfaces/isnapshotprocessor.md
+++ b/docs/API/interfaces/isnapshotprocessor.md
@@ -4,7 +4,7 @@ title: "ISnapshotProcessor"
 sidebar_label: "ISnapshotProcessor"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [ISnapshotProcessor](isnapshotprocessor.md)
+[mobx-state-tree - v7.3.0](../index.md) › [ISnapshotProcessor](isnapshotprocessor.md)
 
 A type that has its snapshots processed.
 

--- a/docs/API/interfaces/isnapshotprocessors.md
+++ b/docs/API/interfaces/isnapshotprocessors.md
@@ -4,7 +4,7 @@ title: "ISnapshotProcessors"
 sidebar_label: "ISnapshotProcessors"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [ISnapshotProcessors](isnapshotprocessors.md)
+[mobx-state-tree - v7.3.0](../index.md) › [ISnapshotProcessors](isnapshotprocessors.md)
 
 Snapshot processors.
 

--- a/docs/API/interfaces/itype.md
+++ b/docs/API/interfaces/itype.md
@@ -4,7 +4,7 @@ title: "IType"
 sidebar_label: "IType"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IType](itype.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IType](itype.md)
 
 A type, either complex or simple.
 

--- a/docs/API/interfaces/ivalidationcontextentry.md
+++ b/docs/API/interfaces/ivalidationcontextentry.md
@@ -4,7 +4,7 @@ title: "IValidationContextEntry"
 sidebar_label: "IValidationContextEntry"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IValidationContextEntry](ivalidationcontextentry.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IValidationContextEntry](ivalidationcontextentry.md)
 
 Validation context entry, this is, where the validation should run against which type
 
@@ -25,7 +25,7 @@ Validation context entry, this is, where the validation should run against which
 
 • **path**: *string*
 
-*Defined in [src/core/type/type-checker.ts:17](https://github.com/mobxjs/mobx-state-tree/blob/6c2cad97/src/core/type/type-checker.ts#L17)*
+*Defined in [src/core/type/type-checker.ts:20](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/type-checker.ts#L20)*
 
 Subpath where the validation should be run, or an empty string to validate it all
 
@@ -35,6 +35,6 @@ ___
 
 • **type**: *[IAnyType](ianytype.md)*
 
-*Defined in [src/core/type/type-checker.ts:19](https://github.com/mobxjs/mobx-state-tree/blob/6c2cad97/src/core/type/type-checker.ts#L19)*
+*Defined in [src/core/type/type-checker.ts:22](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/type-checker.ts#L22)*
 
 Type to validate the subpath against

--- a/docs/API/interfaces/ivalidationerror.md
+++ b/docs/API/interfaces/ivalidationerror.md
@@ -4,7 +4,7 @@ title: "IValidationError"
 sidebar_label: "IValidationError"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [IValidationError](ivalidationerror.md)
+[mobx-state-tree - v7.3.0](../index.md) › [IValidationError](ivalidationerror.md)
 
 Type validation error
 
@@ -26,7 +26,7 @@ Type validation error
 
 • **context**: *[IValidationContext](../index.md#ivalidationcontext)*
 
-*Defined in [src/core/type/type-checker.ts:28](https://github.com/mobxjs/mobx-state-tree/blob/6c2cad97/src/core/type/type-checker.ts#L28)*
+*Defined in [src/core/type/type-checker.ts:31](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/type-checker.ts#L31)*
 
 Validation context
 
@@ -36,7 +36,7 @@ ___
 
 • **message**? : *undefined | string*
 
-*Defined in [src/core/type/type-checker.ts:32](https://github.com/mobxjs/mobx-state-tree/blob/6c2cad97/src/core/type/type-checker.ts#L32)*
+*Defined in [src/core/type/type-checker.ts:35](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/type-checker.ts#L35)*
 
 Error message
 
@@ -46,6 +46,6 @@ ___
 
 • **value**: *any*
 
-*Defined in [src/core/type/type-checker.ts:30](https://github.com/mobxjs/mobx-state-tree/blob/6c2cad97/src/core/type/type-checker.ts#L30)*
+*Defined in [src/core/type/type-checker.ts:33](https://github.com/mobxjs/mobx-state-tree/blob/65595e81/src/core/type/type-checker.ts#L33)*
 
 Value that was being validated, either a snapshot or an instance

--- a/docs/API/interfaces/referenceoptionsgetset.md
+++ b/docs/API/interfaces/referenceoptionsgetset.md
@@ -4,7 +4,7 @@ title: "ReferenceOptionsGetSet"
 sidebar_label: "ReferenceOptionsGetSet"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [ReferenceOptionsGetSet](referenceoptionsgetset.md)
+[mobx-state-tree - v7.3.0](../index.md) › [ReferenceOptionsGetSet](referenceoptionsgetset.md)
 
 ## Type parameters
 

--- a/docs/API/interfaces/referenceoptionsoninvalidated.md
+++ b/docs/API/interfaces/referenceoptionsoninvalidated.md
@@ -4,7 +4,7 @@ title: "ReferenceOptionsOnInvalidated"
 sidebar_label: "ReferenceOptionsOnInvalidated"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [ReferenceOptionsOnInvalidated](referenceoptionsoninvalidated.md)
+[mobx-state-tree - v7.3.0](../index.md) › [ReferenceOptionsOnInvalidated](referenceoptionsoninvalidated.md)
 
 ## Type parameters
 

--- a/docs/API/interfaces/unionoptions.md
+++ b/docs/API/interfaces/unionoptions.md
@@ -4,7 +4,7 @@ title: "UnionOptions"
 sidebar_label: "UnionOptions"
 ---
 
-[mobx-state-tree - v7.2.0](../index.md) › [UnionOptions](unionoptions.md)
+[mobx-state-tree - v7.3.0](../index.md) › [UnionOptions](unionoptions.md)
 
 ## Type parameters
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mobx-state-tree",
-    "version": "7.2.0",
+    "version": "7.3.0",
     "description": "Opinionated, transactional, MobX powered state container",
     "main": "dist/mobx-state-tree.js",
     "umd:main": "dist/mobx-state-tree.umd.js",

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -9,12 +9,16 @@
         "title": "API_header"
       },
       "API/index": {
-        "title": "mobx-state-tree - v7.2.0",
+        "title": "mobx-state-tree - v7.3.0",
         "sidebar_label": "Globals"
       },
       "API/interfaces/customtypeoptions": {
         "title": "CustomTypeOptions",
         "sidebar_label": "CustomTypeOptions"
+      },
+      "API/interfaces/errorformattingoptions": {
+        "title": "ErrorFormattingOptions",
+        "sidebar_label": "ErrorFormattingOptions"
       },
       "API/interfaces/functionwithflag": {
         "title": "FunctionWithFlag",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -54,6 +54,7 @@
     ],
     "Interfaces": [
       "API/interfaces/customtypeoptions",
+      "API/interfaces/errorformattingoptions",
       "API/interfaces/functionwithflag",
       "API/interfaces/iactioncontext",
       "API/interfaces/iactionrecorder",


### PR DESCRIPTION
## What does this PR do and why?

version bump and docs chores for version 7.3.0 which includes a new error formatter.
