### PR TITLE
Fix/map ref enhancer

### DIFF
--- a/docs/API/index.md
+++ b/docs/API/index.md
@@ -1,10 +1,10 @@
 ---
 id: "index"
-title: "mobx-state-tree - v7.3.0"
+title: "mobx-state-tree - v7.3.1"
 sidebar_label: "Globals"
 ---
 
-[mobx-state-tree - v7.3.0](index.md)
+[mobx-state-tree - v7.3.1](index.md)
 
 ## Index
 
@@ -3278,7 +3278,7 @@ ___
 
 ▸ **isMapType**(`type`: unknown): *type is IMapType<IAnyType>*
 
-*Defined in [src/types/complex-types/map.ts:537](https://github.com/mobxjs/mobx-state-tree/blob/b5b44ed6/src/types/complex-types/map.ts#L537)*
+*Defined in [src/types/complex-types/map.ts:536](https://github.com/mobxjs/mobx-state-tree/blob/f97eeea7/src/types/complex-types/map.ts#L536)*
 
 Returns if a given value represents a map type.
 
@@ -3657,7 +3657,7 @@ ___
 
 ▸ **map**<**IT**>(`subtype`: IT): *IMapType‹IT›*
 
-*Defined in [src/types/complex-types/map.ts:527](https://github.com/mobxjs/mobx-state-tree/blob/b5b44ed6/src/types/complex-types/map.ts#L527)*
+*Defined in [src/types/complex-types/map.ts:526](https://github.com/mobxjs/mobx-state-tree/blob/f97eeea7/src/types/complex-types/map.ts#L526)*
 
 `types.map` - Creates a key based collection type who's children are all of a uniform declared type.
 If the type stored in a map has an identifier, it is mandatory to store the child under that identifier in the map.

--- a/docs/API/interfaces/customtypeoptions.md
+++ b/docs/API/interfaces/customtypeoptions.md
@@ -4,7 +4,7 @@ title: "CustomTypeOptions"
 sidebar_label: "CustomTypeOptions"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [CustomTypeOptions](customtypeoptions.md)
+[mobx-state-tree - v7.3.1](../index.md) › [CustomTypeOptions](customtypeoptions.md)
 
 ## Type parameters
 

--- a/docs/API/interfaces/errorformattingoptions.md
+++ b/docs/API/interfaces/errorformattingoptions.md
@@ -4,7 +4,7 @@ title: "ErrorFormattingOptions"
 sidebar_label: "ErrorFormattingOptions"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [ErrorFormattingOptions](errorformattingoptions.md)
+[mobx-state-tree - v7.3.1](../index.md) › [ErrorFormattingOptions](errorformattingoptions.md)
 
 Options that control how snapshots/values and type shapes are rendered inside
 type-checking error messages (see [setErrorFormatting](../index.md#seterrorformatting)).

--- a/docs/API/interfaces/functionwithflag.md
+++ b/docs/API/interfaces/functionwithflag.md
@@ -4,7 +4,7 @@ title: "FunctionWithFlag"
 sidebar_label: "FunctionWithFlag"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [FunctionWithFlag](functionwithflag.md)
+[mobx-state-tree - v7.3.1](../index.md) › [FunctionWithFlag](functionwithflag.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/iactioncontext.md
+++ b/docs/API/interfaces/iactioncontext.md
@@ -4,7 +4,7 @@ title: "IActionContext"
 sidebar_label: "IActionContext"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IActionContext](iactioncontext.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IActionContext](iactioncontext.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/iactionrecorder.md
+++ b/docs/API/interfaces/iactionrecorder.md
@@ -4,7 +4,7 @@ title: "IActionRecorder"
 sidebar_label: "IActionRecorder"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IActionRecorder](iactionrecorder.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IActionRecorder](iactionrecorder.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/iactiontrackingmiddleware2call.md
+++ b/docs/API/interfaces/iactiontrackingmiddleware2call.md
@@ -4,7 +4,7 @@ title: "IActionTrackingMiddleware2Call"
 sidebar_label: "IActionTrackingMiddleware2Call"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IActionTrackingMiddleware2Call](iactiontrackingmiddleware2call.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IActionTrackingMiddleware2Call](iactiontrackingmiddleware2call.md)
 
 ## Type parameters
 

--- a/docs/API/interfaces/iactiontrackingmiddleware2hooks.md
+++ b/docs/API/interfaces/iactiontrackingmiddleware2hooks.md
@@ -4,7 +4,7 @@ title: "IActionTrackingMiddleware2Hooks"
 sidebar_label: "IActionTrackingMiddleware2Hooks"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IActionTrackingMiddleware2Hooks](iactiontrackingmiddleware2hooks.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IActionTrackingMiddleware2Hooks](iactiontrackingmiddleware2hooks.md)
 
 ## Type parameters
 

--- a/docs/API/interfaces/iactiontrackingmiddlewarehooks.md
+++ b/docs/API/interfaces/iactiontrackingmiddlewarehooks.md
@@ -4,7 +4,7 @@ title: "IActionTrackingMiddlewareHooks"
 sidebar_label: "IActionTrackingMiddlewareHooks"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IActionTrackingMiddlewareHooks](iactiontrackingmiddlewarehooks.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IActionTrackingMiddlewareHooks](iactiontrackingmiddlewarehooks.md)
 
 ## Type parameters
 

--- a/docs/API/interfaces/ianycomplextype.md
+++ b/docs/API/interfaces/ianycomplextype.md
@@ -4,7 +4,7 @@ title: "IAnyComplexType"
 sidebar_label: "IAnyComplexType"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IAnyComplexType](ianycomplextype.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IAnyComplexType](ianycomplextype.md)
 
 Any kind of complex type.
 

--- a/docs/API/interfaces/ianymodeltype.md
+++ b/docs/API/interfaces/ianymodeltype.md
@@ -4,7 +4,7 @@ title: "IAnyModelType"
 sidebar_label: "IAnyModelType"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IAnyModelType](ianymodeltype.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IAnyModelType](ianymodeltype.md)
 
 Any model type.
 

--- a/docs/API/interfaces/ianytype.md
+++ b/docs/API/interfaces/ianytype.md
@@ -4,7 +4,7 @@ title: "IAnyType"
 sidebar_label: "IAnyType"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IAnyType](ianytype.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IAnyType](ianytype.md)
 
 Any kind of type.
 

--- a/docs/API/interfaces/ihooks.md
+++ b/docs/API/interfaces/ihooks.md
@@ -4,7 +4,7 @@ title: "IHooks"
 sidebar_label: "IHooks"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IHooks](ihooks.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IHooks](ihooks.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/ijsonpatch.md
+++ b/docs/API/interfaces/ijsonpatch.md
@@ -4,7 +4,7 @@ title: "IJsonPatch"
 sidebar_label: "IJsonPatch"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IJsonPatch](ijsonpatch.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IJsonPatch](ijsonpatch.md)
 
 https://tools.ietf.org/html/rfc6902
 http://jsonpatch.com/

--- a/docs/API/interfaces/imiddlewareevent.md
+++ b/docs/API/interfaces/imiddlewareevent.md
@@ -4,7 +4,7 @@ title: "IMiddlewareEvent"
 sidebar_label: "IMiddlewareEvent"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IMiddlewareEvent](imiddlewareevent.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IMiddlewareEvent](imiddlewareevent.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/imodelreflectiondata.md
+++ b/docs/API/interfaces/imodelreflectiondata.md
@@ -4,7 +4,7 @@ title: "IModelReflectionData"
 sidebar_label: "IModelReflectionData"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IModelReflectionData](imodelreflectiondata.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IModelReflectionData](imodelreflectiondata.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/imodelreflectionpropertiesdata.md
+++ b/docs/API/interfaces/imodelreflectionpropertiesdata.md
@@ -4,7 +4,7 @@ title: "IModelReflectionPropertiesData"
 sidebar_label: "IModelReflectionPropertiesData"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IModelReflectionPropertiesData](imodelreflectionpropertiesdata.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IModelReflectionPropertiesData](imodelreflectionpropertiesdata.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/imodeltype.md
+++ b/docs/API/interfaces/imodeltype.md
@@ -4,7 +4,7 @@ title: "IModelType"
 sidebar_label: "IModelType"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IModelType](imodeltype.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IModelType](imodeltype.md)
 
 ## Type parameters
 

--- a/docs/API/interfaces/ipatchrecorder.md
+++ b/docs/API/interfaces/ipatchrecorder.md
@@ -4,7 +4,7 @@ title: "IPatchRecorder"
 sidebar_label: "IPatchRecorder"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IPatchRecorder](ipatchrecorder.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IPatchRecorder](ipatchrecorder.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/ireversiblejsonpatch.md
+++ b/docs/API/interfaces/ireversiblejsonpatch.md
@@ -4,7 +4,7 @@ title: "IReversibleJsonPatch"
 sidebar_label: "IReversibleJsonPatch"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IReversibleJsonPatch](ireversiblejsonpatch.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IReversibleJsonPatch](ireversiblejsonpatch.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/iserializedactioncall.md
+++ b/docs/API/interfaces/iserializedactioncall.md
@@ -4,7 +4,7 @@ title: "ISerializedActionCall"
 sidebar_label: "ISerializedActionCall"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [ISerializedActionCall](iserializedactioncall.md)
+[mobx-state-tree - v7.3.1](../index.md) › [ISerializedActionCall](iserializedactioncall.md)
 
 ## Hierarchy
 

--- a/docs/API/interfaces/isimpletype.md
+++ b/docs/API/interfaces/isimpletype.md
@@ -4,7 +4,7 @@ title: "ISimpleType"
 sidebar_label: "ISimpleType"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [ISimpleType](isimpletype.md)
+[mobx-state-tree - v7.3.1](../index.md) › [ISimpleType](isimpletype.md)
 
 A simple type, this is, a type where the instance and the snapshot representation are the same.
 

--- a/docs/API/interfaces/isnapshotprocessor.md
+++ b/docs/API/interfaces/isnapshotprocessor.md
@@ -4,7 +4,7 @@ title: "ISnapshotProcessor"
 sidebar_label: "ISnapshotProcessor"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [ISnapshotProcessor](isnapshotprocessor.md)
+[mobx-state-tree - v7.3.1](../index.md) › [ISnapshotProcessor](isnapshotprocessor.md)
 
 A type that has its snapshots processed.
 

--- a/docs/API/interfaces/isnapshotprocessors.md
+++ b/docs/API/interfaces/isnapshotprocessors.md
@@ -4,7 +4,7 @@ title: "ISnapshotProcessors"
 sidebar_label: "ISnapshotProcessors"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [ISnapshotProcessors](isnapshotprocessors.md)
+[mobx-state-tree - v7.3.1](../index.md) › [ISnapshotProcessors](isnapshotprocessors.md)
 
 Snapshot processors.
 

--- a/docs/API/interfaces/itype.md
+++ b/docs/API/interfaces/itype.md
@@ -4,7 +4,7 @@ title: "IType"
 sidebar_label: "IType"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IType](itype.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IType](itype.md)
 
 A type, either complex or simple.
 

--- a/docs/API/interfaces/ivalidationcontextentry.md
+++ b/docs/API/interfaces/ivalidationcontextentry.md
@@ -4,7 +4,7 @@ title: "IValidationContextEntry"
 sidebar_label: "IValidationContextEntry"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IValidationContextEntry](ivalidationcontextentry.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IValidationContextEntry](ivalidationcontextentry.md)
 
 Validation context entry, this is, where the validation should run against which type
 

--- a/docs/API/interfaces/ivalidationerror.md
+++ b/docs/API/interfaces/ivalidationerror.md
@@ -4,7 +4,7 @@ title: "IValidationError"
 sidebar_label: "IValidationError"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [IValidationError](ivalidationerror.md)
+[mobx-state-tree - v7.3.1](../index.md) › [IValidationError](ivalidationerror.md)
 
 Type validation error
 

--- a/docs/API/interfaces/referenceoptionsgetset.md
+++ b/docs/API/interfaces/referenceoptionsgetset.md
@@ -4,7 +4,7 @@ title: "ReferenceOptionsGetSet"
 sidebar_label: "ReferenceOptionsGetSet"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [ReferenceOptionsGetSet](referenceoptionsgetset.md)
+[mobx-state-tree - v7.3.1](../index.md) › [ReferenceOptionsGetSet](referenceoptionsgetset.md)
 
 ## Type parameters
 

--- a/docs/API/interfaces/referenceoptionsoninvalidated.md
+++ b/docs/API/interfaces/referenceoptionsoninvalidated.md
@@ -4,7 +4,7 @@ title: "ReferenceOptionsOnInvalidated"
 sidebar_label: "ReferenceOptionsOnInvalidated"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [ReferenceOptionsOnInvalidated](referenceoptionsoninvalidated.md)
+[mobx-state-tree - v7.3.1](../index.md) › [ReferenceOptionsOnInvalidated](referenceoptionsoninvalidated.md)
 
 ## Type parameters
 

--- a/docs/API/interfaces/unionoptions.md
+++ b/docs/API/interfaces/unionoptions.md
@@ -4,7 +4,7 @@ title: "UnionOptions"
 sidebar_label: "UnionOptions"
 ---
 
-[mobx-state-tree - v7.3.0](../index.md) › [UnionOptions](unionoptions.md)
+[mobx-state-tree - v7.3.1](../index.md) › [UnionOptions](unionoptions.md)
 
 ## Type parameters
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mobx-state-tree",
-    "version": "7.3.0",
+    "version": "7.3.1",
     "description": "Opinionated, transactional, MobX powered state container",
     "main": "dist/mobx-state-tree.js",
     "umd:main": "dist/mobx-state-tree.umd.js",

--- a/src/types/complex-types/map.ts
+++ b/src/types/complex-types/map.ts
@@ -7,7 +7,6 @@ import {
     IMapWillChange,
     intercept,
     Lambda,
-    observable,
     ObservableMap,
     observe,
     values,
@@ -146,7 +145,7 @@ export enum MapIdentifierMode {
 
 class MSTMap<IT extends IAnyType> extends ObservableMap<string, any> {
     constructor(initialData?: IObservableMapInitialValues<string, any> | undefined, name?: string) {
-        super(initialData, (observable.ref as any).enhancer, name)
+        super(initialData, v => v, name)
     }
 
     get(key: string): IT["Type"] | undefined {

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -9,7 +9,7 @@
         "title": "API_header"
       },
       "API/index": {
-        "title": "mobx-state-tree - v7.3.0",
+        "title": "mobx-state-tree - v7.3.1",
         "sidebar_label": "Globals"
       },
       "API/interfaces/customtypeoptions": {


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/mobxjs/mobx-state-tree/issues/2292. This was failing silently - the default `deepEnhancer` behavior was converting MST values to be observable (but they already are), so there's no real difference, other than we can now avoid unnecessary work.

## Steps to validate locally

Tests will still pass - the only way to really test this is to test implementation details, but I am personally satisfied with a passing test suite.
