### PR TITLE
fix(array): run afterCreate when applySnapshot replaces array children

### DIFF
--- a/__tests__/core/2295.test.ts
+++ b/__tests__/core/2295.test.ts
@@ -1,0 +1,78 @@
+// https://github.com/mobxjs/mobx-state-tree/issues/2295
+import { describe, expect, test } from "bun:test"
+import { applySnapshot, types } from "../../src/index"
+
+describe("2295 - afterCreate runs for recreated array children", () => {
+    test("applySnapshot recreates identifier-less children and runs afterCreate", () => {
+        const calls: string[] = []
+
+        const Child = types.model("Child", { email: types.string }).actions(self => ({
+            afterCreate() {
+                calls.push(self.email)
+            }
+        }))
+
+        const Store = types.model("Store", { children: types.array(Child) })
+
+        const store = Store.create({ children: [{ email: "one@example.com" }] })
+        // MST instantiates nodes lazily, so read the child to materialize it.
+        expect(store.children.map(child => child.email)).toEqual(["one@example.com"])
+        expect(calls).toEqual(["one@example.com"])
+
+        applySnapshot(store, { children: [{ email: "two@example.com" }] })
+        expect(store.children.map(child => child.email)).toEqual(["two@example.com"])
+
+        // Without an identifier MST cannot know the two snapshots describe the same
+        // entity, so the child is replaced rather than updated in place, which means
+        // afterCreate has to run for the newly created child.
+        expect(calls).toEqual(["one@example.com", "two@example.com"])
+    })
+
+    test("identified children are still reconciled in place without re-running afterCreate", () => {
+        const calls: string[] = []
+
+        const Child = types
+            .model("Child", { id: types.identifier, email: types.string })
+            .actions(self => ({
+                afterCreate() {
+                    calls.push(self.id)
+                }
+            }))
+
+        const Store = types.model("Store", { children: types.array(Child) })
+
+        const store = Store.create({ children: [{ id: "a", email: "one@example.com" }] })
+        expect(store.children.map(child => child.email)).toEqual(["one@example.com"])
+        expect(calls).toEqual(["a"])
+
+        applySnapshot(store, { children: [{ id: "a", email: "two@example.com" }] })
+
+        // Same identifier means the same entity, so the node is reused and the hook
+        // must not fire again.
+        expect(store.children.map(child => child.email)).toEqual(["two@example.com"])
+        expect(calls).toEqual(["a"])
+    })
+
+    test("entries spread across the array keep their own values", () => {
+        const Child = types.model("Child", { value: types.number })
+        const Store = types.model("Store", { children: types.array(Child) })
+
+        const size = 20
+        const store = Store.create({
+            children: Array.from({ length: size }, (_, i) => ({ value: i }))
+        })
+        expect(store.children.map(child => child.value)).toEqual(
+            Array.from({ length: size }, (_, i) => i)
+        )
+
+        // Change the first, a middle and the last entry, so the changes are not adjacent.
+        const next = Array.from({ length: size }, (_, i) => ({ value: i }))
+        next[0] = { value: 100 }
+        next[7] = { value: 107 }
+        next[size - 1] = { value: 200 }
+
+        applySnapshot(store, { children: next })
+
+        expect(store.children.map(child => child.value)).toEqual(next.map(child => child.value))
+    })
+})

--- a/src/types/complex-types/array.ts
+++ b/src/types/complex-types/array.ts
@@ -324,30 +324,23 @@ export class ArrayType<IT extends IAnyType> extends ComplexType<
             return
         }
 
-        let oldEnd = oldLength - 1
-        let newEnd = newLength - 1
-        while (
-            oldEnd >= firstChangedIndex &&
-            newEnd >= firstChangedIndex &&
-            childNodes[oldEnd].snapshot === snapshot[newEnd]
-        ) {
-            oldEnd--
-            newEnd--
+        // The lengths match, so only the differing entries have to change. Collect them
+        // before touching the array, because assigning to one entry invalidates the
+        // snapshots of the others and their identity can no longer be compared.
+        const changedIndexes: number[] = []
+        for (let i = firstChangedIndex; i < oldLength; i++) {
+            if (childNodes[i].snapshot !== snapshot[i]) {
+                changedIndexes.push(i)
+            }
         }
 
-        // Trim the unchanged suffix too, so we only replace the minimal changed window.
-        const replacedCount = oldEnd >= firstChangedIndex ? oldEnd - firstChangedIndex + 1 : 0
-        const replacementSnapshots =
-            newEnd >= firstChangedIndex
-                ? snapshot.slice(firstChangedIndex, newEnd + 1)
-                : EMPTY_ARRAY
-
-        if (replacedCount === 1 && replacementSnapshots.length === 1) {
-            target[firstChangedIndex] = replacementSnapshots[0]
-            return
+        // Assign the changed entries individually rather than splicing across the
+        // untouched entries between them: a single assignment reconciles exactly one
+        // child, which keeps the cost proportional to the number of changes instead of
+        // the distance between the first and the last of them.
+        for (const index of changedIndexes) {
+            target[index] = snapshot[index]
         }
-
-        target.splice(firstChangedIndex, replacedCount, ...replacementSnapshots)
     }
 
     getChildType(): IAnyType {
@@ -420,8 +413,16 @@ function canApplyDirectSnapshotsInRange(
     startIndex: number
 ) {
     for (let i = startIndex; i < childNodes.length; i++) {
-        if (childNodes[i].snapshot === snapshot[i]) continue
-        if (!canApplyDirectSnapshot(childType, childNodes[i], snapshot[i])) {
+        const childNode = childNodes[i]
+        if (childNode.snapshot === snapshot[i]) continue
+        if (!canApplyDirectSnapshot(childType, childNode, snapshot[i])) {
+            return false
+        }
+        // Array reconciliation only treats two snapshots as the same child when they carry
+        // a matching identifier (see `areSame`). Identifier-less children are replaced
+        // rather than updated in place, so they must not take the direct-apply path or
+        // lifecycle hooks such as afterCreate would never run for the new child.
+        if (!childNode.identifierAttribute || childNode.identifier === null) {
             return false
         }
     }


### PR DESCRIPTION
## What does this PR do and why?

If this pull request is approved, it will restore the `afterCreate` hook for array children that `applySnapshot` replaces, which regressed in 7.1.0.

Fixes #2295.

### Problem

Given an array of models **without an identifier**, applying a snapshot used to replace each changed child, so the new child's `afterCreate` ran. Since 7.1.0 the child is reused instead and the hook never fires:

```ts
const Child = types.model("Child", { email: types.string }).actions((self) => ({
    afterCreate() { console.log("afterCreate", self.email) }
}))
const Store = types.model("Store", { children: types.array(Child) })

const store = Store.create({ children: [{ email: "one@example.com" }] })
store.children[0].email                                        // afterCreate one@example.com
applySnapshot(store, { children: [{ email: "two@example.com" }] })
store.children[0].email                                        // 7.0.2: afterCreate two@example.com
                                                               // 7.1.0+: nothing
```

I bisected this to #2285: the tests below pass on its parent (`24037f14`) and fail on `master`.

### Root cause

#2285 added a direct-apply fast path that reuses an existing child node instead of replacing it. It gates on `isMatchingSnapshotId()`:

```ts
isMatchingSnapshotId(current, snapshot) {
    return (
        !current.identifierAttribute ||
        current.identifier === normalizeIdentifier(snapshot[current.identifierAttribute])
    )
}
```

That returns `true` for **any** snapshot when the child has no identifier, so an identifier-less child is always reused.

Array reconciliation has never treated those children as the same entity. `areSame()` — used by `reconcileArrayChildren`, the path arrays took before #2285 — requires an identifier before reusing a node:

```ts
return (
    oldNode.identifier !== null &&
    oldNode.identifierAttribute &&
    ...
)
```

So the two identity predicates disagree, and the fast path reuses nodes that array reconciliation would have replaced.

This is specific to arrays. `map` and `model` previously reached the same child via `target.set(key, value)` / `storedValue[name] = value`, which go through `tryToReconcileNode()` and *also* use `isMatchingSnapshotId` — reusing identifier-less children there is long-standing behavior. I confirmed both are unchanged before and after #2285, so this PR leaves them alone.

### Change

Two changes in `src/types/complex-types/array.ts`:

1. `canApplyDirectSnapshotsInRange()` now also requires the child to carry an identifier, matching `areSame`. Identifier-less children fall back to replacement, so `afterCreate` runs again.

2. The fallback no longer trims a range and splices it. Because that branch is only reached when the lengths are equal, each differing entry is assigned individually. Without this, restoring correctness would have been very costly: the benchmark from #2128 spreads its changes evenly, so the spliced range covered nearly the whole array (10k items / 10 changed went from 18ms to ~1470ms). Assigning per index keeps the cost proportional to the number of changes rather than the distance between the first and last one.

The changed indexes are collected before the array is touched, because assigning one entry invalidates the snapshots of the others and their identity can no longer be compared.

### Performance

The perf work in #2285 is preserved. Median of 3 runs on the #2128 benchmark shapes (Windows 11, Node 24.18.0, bun 1.3.14):

| scenario | before #2285 | `master` | this PR | assertion |
| --- | --- | --- | --- | --- |
| 10k items, 1 changed | 1338.9 ms | 14.8 ms | 16.2 ms | < 100 ms |
| 10k items, 10 changed | 1346.8 ms | 18.1 ms | 22.6 ms | < 100 ms |
| 10k items, 100 changed | 1524.9 ms | 24.4 ms | 88.8 ms | < 200 ms |
| 1k items, all changed | 126.0 ms | 77.7 ms | 114.6 ms | none |

The 100-changed case is the honest cost of this fix: those children are recreated rather than reused, which is the behavior being restored. It stays well inside the existing assertion and far below the pre-#2285 baseline.

## Steps to validate locally

```
bun install
bun test __tests__/core/2295.test.ts
```

`__tests__/core/2295.test.ts` adds three tests:

- **`applySnapshot recreates identifier-less children and runs afterCreate`** — the regression. Fails on `master`, passes here.
- **`identified children are still reconciled in place without re-running afterCreate`** — guards the other direction, so the fix cannot be "replace everything". Passes on both.
- **`entries spread across the array keep their own values`** — covers the rewritten assignment path with non-adjacent changes. Passes on both.

To see the regression, check out this branch and revert only the source file:

```
git checkout origin/master -- src/types/complex-types/array.ts
bun test __tests__/core/2295.test.ts   # first test fails
```

### What I ran

| command | result |
| --- | --- |
| `bun run typecheck` | clean |
| `NODE_ENV=development bun test` | 1154 pass, 1 skip, 0 fail |
| `MST_TESTING=1 NODE_ENV=production bun test` | 1019 pass, 1 skip, 0 fail |
| `bun run prettier:check` | clean |
| `bun run lint` | 4 errors, identical on `master` (pre-existing, untouched) |

### What I did not run

- Only Windows 11 was used; no Linux or macOS run.
- `bun run build` and the size-limit check were not run, so `bun run test:all` was not run end to end.
- The `__tests__/perf/*.skip.ts` benchmarks were not run as-is; I measured the same scenarios from `apply-snapshot.skip.ts` directly against `src` to produce the table above.
- No hosted CI run before submitting.

### Compatibility

- No public API change; this restores 7.0.x behavior for identifier-less array children.
- No dependency, lockfile, or generated-file changes.
- No changeset — the repository does not use them.
- No TypeScript signature changes.
