### PR TITLE
docs: fix mst-operations.ts link in API header

### DIFF
--- a/docs/API_header.md
+++ b/docs/API_header.md
@@ -1,3 +1,3 @@
 # Mobx-State-Tree API reference guide
 
-_This reference guide lists all methods exposed by MST. Contributions like linguistic improvements, adding more details to the descriptions or additional examples are highly appreciated! Please note that the docs are generated from source. Most methods are declared in the [mst-operations.ts](https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mobx-state-tree/src/core/mst-operations.ts) file._
+_This reference guide lists all methods exposed by MST. Contributions like linguistic improvements, adding more details to the descriptions or additional examples are highly appreciated! Please note that the docs are generated from source. Most methods are declared in the [mst-operations.ts](https://github.com/mobxjs/mobx-state-tree/blob/master/src/core/mst-operations.ts) file._


### PR DESCRIPTION
`docs/API_header.md` tells contributors that "Most methods are declared in the [mst-operations.ts](...) file", linking to `packages/mobx-state-tree/src/core/mst-operations.ts`. That 404s — the repo is no longer laid out as a monorepo and the file is at [`src/core/mst-operations.ts`](https://github.com/mobxjs/mobx-state-tree/blob/master/src/core/mst-operations.ts) (200).

That header is prepended to the generated API reference, so it's the first thing a would-be docs contributor clicks.

Scope note: `changelog.md` has several more `blob/master/` links that 404 for the same reason (`docs/middleware.md`, `docs/async-actions.md`, `docs/API/README.md`, `packages/mst-middlewares/README.md`), but it's a historical record so I left it alone. The other live-doc link I checked, in `docs/concepts/references.md`, still resolves fine.